### PR TITLE
Fix tool UX defects

### DIFF
--- a/core/src/main/java/com/vzome/core/editor/AxialStretchTool.java
+++ b/core/src/main/java/com/vzome/core/editor/AxialStretchTool.java
@@ -4,8 +4,11 @@
 package com.vzome.core.editor;
 
 
+import java.util.EnumSet;
+
 import org.w3c.dom.Element;
 
+import com.vzome.api.Tool.InputBehaviors;
 import com.vzome.core.algebra.AlgebraicMatrix;
 import com.vzome.core.algebra.AlgebraicNumber;
 import com.vzome.core.algebra.AlgebraicVector;
@@ -220,6 +223,12 @@ public class AxialStretchTool extends TransformationTool
 		this .first = first;
 		this .category = category;
     }
+
+	@Override
+	public EnumSet<InputBehaviors> defaultInputBehaviors()
+	{
+		return EnumSet.of( InputBehaviors.DELETE );
+	}
 
     protected String checkSelection( boolean prepareTool )
     {

--- a/core/src/main/java/com/vzome/core/editor/LinearMapTool.java
+++ b/core/src/main/java/com/vzome/core/editor/LinearMapTool.java
@@ -4,6 +4,9 @@
 package com.vzome.core.editor;
 
 
+import java.util.EnumSet;
+
+import com.vzome.api.Tool.InputBehaviors;
 import com.vzome.core.construction.ChangeOfBasis;
 import com.vzome.core.construction.Point;
 import com.vzome.core.construction.Segment;
@@ -73,6 +76,12 @@ public class LinearMapTool extends TransformationTool
         super( name, tools );
         this.originalScaling = originalScaling;
     }
+
+	@Override
+	public EnumSet<InputBehaviors> defaultInputBehaviors()
+	{
+		return EnumSet.of( InputBehaviors.DELETE );
+	}
 
     protected String checkSelection( boolean prepareTool )
     {

--- a/core/src/main/java/com/vzome/core/editor/RotationTool.java
+++ b/core/src/main/java/com/vzome/core/editor/RotationTool.java
@@ -4,8 +4,11 @@
 package com.vzome.core.editor;
 
 
+import java.util.EnumSet;
+
 import org.w3c.dom.Element;
 
+import com.vzome.api.Tool.InputBehaviors;
 import com.vzome.core.algebra.AlgebraicField;
 import com.vzome.core.algebra.AlgebraicNumber;
 import com.vzome.core.algebra.AlgebraicVector;
@@ -115,7 +118,10 @@ public class RotationTool extends SymmetryTool
     @Override
     public String getCategory()
     {
-        return ID;
+		if ( this .fullRotation )
+	        return "axial symmetry";
+		else
+	        return ID;
     }
 
     public RotationTool( String id, Symmetry symmetry, ToolsModel editor )
@@ -130,6 +136,15 @@ public class RotationTool extends SymmetryTool
         this .fullRotation = full;
         this .corrected = true;
     }
+
+	@Override
+	public EnumSet<InputBehaviors> defaultInputBehaviors()
+	{
+		if ( this .fullRotation )
+			return EnumSet.of( InputBehaviors.SELECT );
+		else
+			return EnumSet.of( InputBehaviors.DELETE );
+	}
 
     @Override
     protected String checkSelection( boolean prepareTool )

--- a/core/src/main/java/com/vzome/core/editor/ScalingTool.java
+++ b/core/src/main/java/com/vzome/core/editor/ScalingTool.java
@@ -4,8 +4,11 @@
 package com.vzome.core.editor;
 
 
+import java.util.EnumSet;
+
 import org.w3c.dom.Element;
 
+import com.vzome.api.Tool.InputBehaviors;
 import com.vzome.core.algebra.AlgebraicField;
 import com.vzome.core.algebra.AlgebraicMatrix;
 import com.vzome.core.algebra.AlgebraicNumber;
@@ -129,6 +132,12 @@ public class ScalingTool extends SymmetryTool
     {
 		this.scaleFactor = scaleFactor;
     }
+
+	@Override
+	public EnumSet<InputBehaviors> defaultInputBehaviors()
+	{
+		return EnumSet.of( InputBehaviors.DELETE );
+	}
 
     @Override
     protected String checkSelection( boolean prepareTool )

--- a/core/src/main/java/com/vzome/core/editor/TranslationTool.java
+++ b/core/src/main/java/com/vzome/core/editor/TranslationTool.java
@@ -4,6 +4,9 @@
 package com.vzome.core.editor;
 
 
+import java.util.EnumSet;
+
+import com.vzome.api.Tool.InputBehaviors;
 import com.vzome.core.algebra.AlgebraicField;
 import com.vzome.core.algebra.AlgebraicNumber;
 import com.vzome.core.algebra.AlgebraicVector;
@@ -59,6 +62,12 @@ public class TranslationTool extends TransformationTool
 		{
 			return true;
 		}
+	}
+
+	@Override
+	public EnumSet<InputBehaviors> defaultInputBehaviors()
+	{
+		return EnumSet.of( InputBehaviors.DELETE );
 	}
 
     @Override


### PR DESCRIPTION
Non-symmetry tools should use DELETE as their default input behavior.

The icon for axial symmetry is now fixed, also.