### PR TITLE
Added execCommandLine action

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
@@ -381,6 +381,23 @@ public class DocumentFrame extends JFrame implements PropertyChangeListener, Con
                         system = cmd .substring( "setSymmetry.".length() );
                         mController .actionPerformed( e ); // TODO getExclusiveAction
                     }
+                    else if ( cmd .startsWith( "execCommandLine/" ) )
+                    {
+                        if ( mFile == null ) {
+                            JOptionPane .showMessageDialog( DocumentFrame.this, "You must save your model before you can run a shell command.",
+                                    "Command Failure", JOptionPane .ERROR_MESSAGE );
+                            return;
+                        }
+                        String cmdLine = cmd .substring( "execCommandLine/" .length() );
+                        cmdLine = cmdLine .replace( "{}", mFile .getName() );
+                        logger.log( Level.INFO, "executing command line: " + cmdLine );
+                        try {
+                            Runtime .getRuntime() .exec( cmdLine, null, mFile .getParentFile() );
+                        } catch ( IOException ioe ) {
+                            System .err .println( "Runtime.exec() failed on " + cmdLine );
+                            ioe .printStackTrace();
+                        }
+                    }
                     else if ( cmd .startsWith( "showProperties-" ) )
                     {
             			String key = cmd .substring( "showProperties-" .length() );
@@ -773,6 +790,9 @@ public class DocumentFrame extends JFrame implements PropertyChangeListener, Con
         			actionListener = controller;
         		}
         		else if ( command .startsWith( "setSymmetry." ) ) {
+        			actionListener = this .localActions;
+        		}
+        		else if ( command .startsWith( "execCommandLine/" ) ) {
         			actionListener = this .localActions;
         		}
         		else if ( command .startsWith( "showProperties-" ) ) {

--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentMenuBar.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentMenuBar.java
@@ -605,6 +605,8 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
                         String actionName = key.toString();
                         String menuText = customMenuItems.getProperty(actionName).trim();
                         if(!menuText.isEmpty()) {
+                            Logger.getLogger( getClass().getName() ) .log( Level.INFO, "custom menu item: " + menuText );
+                            Logger.getLogger( getClass().getName() ) .log( Level.INFO, "          action:   " + actionName );
                             // also note that we're swapping keys for elements
                             // as we move from the Properties collection to the sortedMenuCommands
                             sortedMenuCommands.put(menuText, actionName);


### PR DESCRIPTION
Can be used in vZomeCustomMenu.properties.  Format there is:

  execCommandLine/<shell-command-line> = Your Menu String

Whitespace, ':', and '=' characters in <shell-command-line> must be escaped: '\:',
since the vZomeCustomMenu.properties file uses java.util.Properties.load() syntax.

The command line will be executed with the current working directory as the
directory containing the vZome save file.  The vZome save file name can be
substituted into the command line by using "{}" in <shell-command-line>.