### PR TITLE
Correct document count after failing to load a document

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
@@ -672,6 +672,9 @@ public class DocumentFrame extends JFrame implements PropertyChangeListener, Con
                 JOptionPane .showMessageDialog( DocumentFrame.this,
                         e .getLocalizedMessage(),
                         "Error Loading Document", JOptionPane.ERROR_MESSAGE );
+                // setting "visible" to FALSE will remove this document from the application controller's 
+                // document collection so its document count is correct and it cleans up correctly 
+                mController .setProperty( "visible", Boolean.FALSE );
                 DocumentFrame.this .dispose();
             }
             


### PR DESCRIPTION
When an exception occurred during document load, the application controller's document count was no longer correct, so closing the last document window did not call system.exit and the JVM was not terminated. This PR fixes that problem.