### PR TITLE
Fixed red/yellow stretch/squash tools

### DIFF
--- a/core/src/main/java/com/vzome/core/editor/AxialStretchTool.java
+++ b/core/src/main/java/com/vzome/core/editor/AxialStretchTool.java
@@ -181,7 +181,7 @@ public class AxialStretchTool extends TransformationTool
 		@Override
 		public Tool createToolInternal( String id )
 		{
-			String category = id .substring( 0, id .indexOf( "." ) );
+			String category = getCategory( red, stretch, first );
 			return new AxialStretchTool( id, (IcosahedralSymmetry) getSymmetry(), getToolsModel(), stretch, red, first, category );
 		}
 


### PR DESCRIPTION
This defect was left over from the FieldApplication refactoring.  The createToolInternal()
implementation was still expecting to parse the category out of the ID.  Since the factory
already knows the category, we should not need to parse the ID at all.