### PR TITLE
Replace two NPEs with more informative IllegalStateExceptions

### DIFF
--- a/core/src/main/java/com/vzome/core/algebra/AlgebraicField.java
+++ b/core/src/main/java/com/vzome/core/algebra/AlgebraicField.java
@@ -102,10 +102,6 @@ public abstract class AlgebraicField
      * but PolygonField(6) does not equal SqrtField(3) though they share 
      * the same irrational coefficient, but they are of different order.
      * 
-     * For now, I an not including defaultStrutScaling in the equality test
-     * or the hashCode, but I am using test cases to be sure that equal fields
-     * have equal defaultStrutScaling for backward compatibility
-     *  
      * @param obj
      * @return 
      */

--- a/core/src/main/java/com/vzome/core/commands/CommandCentroid.java
+++ b/core/src/main/java/com/vzome/core/commands/CommandCentroid.java
@@ -38,7 +38,7 @@ public class CommandCentroid extends AbstractCommand
     {
         ConstructionList result = new ConstructionList();
         if ( parameters == null || parameters .size() == 0 )
-            throw new Failure( "Select at least two balls to compute the centroid." );
+            throw new Failure( "Select two or more balls to compute their centroid." );
         final Construction[] params = parameters .getConstructions();
         
         List<Point> verticesList = new ArrayList<>();
@@ -47,9 +47,12 @@ public class CommandCentroid extends AbstractCommand
                 verticesList.add((Point) param);
             }
         }
-        // this test causes old files to fail to load
-//        if ( verticesList .size() < 2 )
-//            throw new Failure( "Select at least two balls to compute the centroid." );
+        // Checking if verticesList .size() < 2 causes old files to fail to load
+        // but failing to check if verticesList .isEmpty() throws ArrayIndexOutOfBoundsException.
+        // Allowing a single ball to be its own centroid will let older files load,
+        // but will generate an appropriate warning if any struts or panels are selected, but no balls.
+        if ( verticesList .isEmpty() )
+            throw new Failure( "Select two or more balls to compute their centroid." );
         Point[] points = new Point[0];
         CentroidPoint centroid = new CentroidPoint( verticesList .toArray( points ) );
         effects .constructionAdded( centroid );

--- a/core/src/main/java/com/vzome/core/commands/XmlSaveFormat.java
+++ b/core/src/main/java/com/vzome/core/commands/XmlSaveFormat.java
@@ -32,6 +32,7 @@ import com.vzome.core.construction.Segment;
 import com.vzome.core.construction.SegmentJoiningPoints;
 import com.vzome.core.math.DomUtils;
 import com.vzome.core.math.symmetry.Axis;
+import com.vzome.core.math.symmetry.Direction;
 import com.vzome.core.math.symmetry.OrbitSet;
 import com.vzome.core.math.symmetry.QuaternionicSymmetry;
 import com.vzome.core.math.symmetry.Symmetry;
@@ -593,10 +594,9 @@ public class XmlSaveFormat
         else if ( aname .equals( "spring" ) )
         	aname = "apple";
         String iname = xml .getAttribute( indexAttr );
-        sname = xml .getAttribute( senseAttr );
         int index = Integer .parseInt( iname );
         int sense = Symmetry .PLUS;
-        if ( "minus" .equals( sname )) { // NOTE: used to say "index < 0"
+        if ( "minus" .equals( xml .getAttribute( senseAttr ) )) { // NOTE: used to say "index < 0"
             sense = Symmetry .MINUS;
 //            index *= -1;
         }
@@ -604,7 +604,13 @@ public class XmlSaveFormat
         String outs = xml .getAttribute( "outbound" );
         if ( outs != null && outs .equals( "false" ) )
         	outbound = false;
-        return group .getDirection( aname ) .getAxis( sense, index, outbound );
+        Direction dir = group .getDirection( aname );
+        if(dir == null) {
+            String msg = "Unsupported direction '" + aname + "' in " + sname + " symmetry";
+            logger .severe( msg );
+            throw new IllegalStateException( msg );
+        }
+        return dir .getAxis( sense, index, outbound );
     }
 
     public AlgebraicNumber parseNumber( Element xml, String attrName )

--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
@@ -625,6 +625,11 @@ public class DocumentController extends DefaultController implements J3dComponen
     {
         String name =  symmetrySystem .getName();
         symmetryController = getSymmetryController( name );
+        if(symmetryController == null) {
+            String msg = "Unsupported symmetry: " + name;
+            mErrors.reportError(msg, new Object[] {} );
+            throw new IllegalStateException( msg );
+        }
 
         String modelResourcePath = this .symmetryController .getProperty( "modelResourcePath" );
         mControlBallModel = this .mApp .getSymmetryModel( modelResourcePath, symmetrySystem .getSymmetry() );


### PR DESCRIPTION
Unsupported Symmetries and Directions in vZome files threw NPEs. This simply replaces the NPEs with IllegalStateExceptions which provide more helpful debugging information. 

This was occurring on some sqrtPhi models that were developed with pre-released code having features (like icosahedral symmetry) that is not yet implemented in the current released version.