### PR TITLE
Fix one of the color mapping commands so opposite directions are the same color.

### DIFF
--- a/core/src/main/java/com/vzome/core/algebra/AlgebraicVectors.java
+++ b/core/src/main/java/com/vzome/core/algebra/AlgebraicVectors.java
@@ -39,6 +39,18 @@ public class AlgebraicVectors {
     }
 
     /**
+     * @param vector
+     * @return the greater of {@code vector} and its inverse. 
+     * The comparison is based on a canonical (not mathematical) comparison as implemented in {@code AlgebraicVector.compareTo()}. 
+     * There is no reasonable mathematical sense of ordering vectors, 
+     * but this provides a way to map a vector and its inverse to a common vector for such purposes as sorting and color mapping.    
+     */
+    public static AlgebraicVector getCanonicalOrientation( AlgebraicVector vector ) {
+        AlgebraicVector negate = vector.negate();
+        return vector.compareTo(negate) > 0 ? vector : negate;
+    }
+
+    /**
      * getMostDistantFromOrigin() is is used by a few ColorMapper classes, but I think it can eventually be useful elsewhere as well, for example, a zoom-to-fit command or in deriving a convex hull. I've made it a static method of the AlgebraicVector class to encourage such reuse.
      *
      * @param vectors A collection of vectors to be evaluated.

--- a/core/src/main/java/com/vzome/core/editor/ManifestationColorMappers.java
+++ b/core/src/main/java/com/vzome/core/editor/ManifestationColorMappers.java
@@ -1,5 +1,15 @@
 package com.vzome.core.editor;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.w3c.dom.Element;
+
 import com.vzome.core.algebra.AlgebraicNumber;
 import com.vzome.core.algebra.AlgebraicVector;
 import com.vzome.core.algebra.AlgebraicVectors;
@@ -16,14 +26,6 @@ import com.vzome.core.model.Panel;
 import com.vzome.core.model.Strut;
 import com.vzome.core.render.Color;
 import com.vzome.core.render.RenderedManifestation;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-import org.w3c.dom.Element;
 
 /**
  * @author David Hall
@@ -436,21 +438,27 @@ public class ManifestationColorMappers {
         }
     }
 
+    /**
+     * Polarity info is intentionally removed by this mapping 
+     * so that parallel struts and the panels normal to them will be the same color.
+     */
     public static class RadialStandardBasisColorMap extends ManifestationSubclassColorMapper {
 
         @Override
         protected Color applyTo(Connector ball, int alpha) {
             return applyTo(ball.getLocation(), alpha);
         }
-
+        
         @Override
         protected Color applyTo(Strut strut, int alpha) {
-            return applyTo(strut.getOffset(), alpha);
+            // map to the same color for either direction
+            return applyTo( AlgebraicVectors.getCanonicalOrientation( strut.getOffset() ), alpha);
         }
 
         @Override
         protected Color applyTo(Panel panel, int alpha) {
-            return applyTo(panel.getNormal(), alpha);
+            // map to the same color for either direction
+            return applyTo( AlgebraicVectors.getCanonicalOrientation( panel.getNormal() ), alpha);
         }
 
         protected Color applyTo(AlgebraicVector vector, int alpha) {

--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentMenuBar.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentMenuBar.java
@@ -273,8 +273,8 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
             }
             {
                 JMenu submenu2 = new JMenu("Map Colors...");
-                submenu2 .add( enableIf( isEditor, createMenuItem( "Radial by Centroid", mapToColor + "RadialCentroidColorMap" ) ) );
-                submenu2 .add( enableIf( isEditor, createMenuItem( "Radial by Standard Basis", mapToColor + "RadialStandardBasisColorMap" ) ) );
+                submenu2 .add( enableIf( isEditor, createMenuItem( "To Centroid", mapToColor + "RadialCentroidColorMap" ) ) );
+                submenu2 .add( enableIf( isEditor, createMenuItem( "To Direction", mapToColor + "RadialStandardBasisColorMap" ) ) );
                 submenu2 .add( enableIf( isEditor, createMenuItem( "To Octant", mapToColor + "CentroidByOctantAndDirectionColorMap" ) ) );
                 submenu2 .add( enableIf( isEditor, createMenuItem( "To Coordinate Plane", mapToColor + "CoordinatePlaneColorMap" ) ) );
                 submenu2 .add( enableIf( isEditor, createMenuItem( "System Colors", mapToColor + "SystemColorMap" ) ) );


### PR DESCRIPTION
I fixed this command so that it can now be used to color all parallel struts and the panels normal to them as unique colors, or at least unique within the range of discreet RGB colors. It formerly mapped opposite directions to inverted colors, which was not my original intention. This mapping of unique directions (not orbits) to unique colors, is particularly useful on the zonohedra models.