### PR TITLE
Add two new color mapping commands

### DIFF
--- a/core/src/main/java/com/vzome/core/algebra/AlgebraicVectors.java
+++ b/core/src/main/java/com/vzome/core/algebra/AlgebraicVectors.java
@@ -39,6 +39,18 @@ public class AlgebraicVectors {
     }
 
     /**
+     * @param vector
+     * @return the greater of {@code vector} and its inverse. 
+     * The comparison is based on a canonical (not mathematical) comparison as implemented in {@code AlgebraicVector.compareTo()}. 
+     * There is no reasonable mathematical sense of ordering vectors, 
+     * but this provides a way to map a vector and its inverse to a common vector for such purposes as sorting and color mapping.    
+     */
+    public static AlgebraicVector getCanonicalOrientation( AlgebraicVector vector ) {
+        AlgebraicVector negate = vector.negate();
+        return vector.compareTo(negate) > 0 ? vector : negate;
+    }
+
+    /**
      * getMostDistantFromOrigin() is is used by a few ColorMapper classes, but I think it can eventually be useful elsewhere as well, for example, a zoom-to-fit command or in deriving a convex hull. I've made it a static method of the AlgebraicVector class to encourage such reuse.
      *
      * @param vectors A collection of vectors to be evaluated.

--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentMenuBar.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentMenuBar.java
@@ -273,8 +273,10 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
             }
             {
                 JMenu submenu2 = new JMenu("Map Colors...");
-                submenu2 .add( enableIf( isEditor, createMenuItem( "Radial by Centroid", mapToColor + "RadialCentroidColorMap" ) ) );
-                submenu2 .add( enableIf( isEditor, createMenuItem( "Radial by Standard Basis", mapToColor + "RadialStandardBasisColorMap" ) ) );
+                submenu2 .add( enableIf( isEditor, createMenuItem( "To Centroid", mapToColor + "RadialCentroidColorMap" ) ) );
+                submenu2 .add( enableIf( isEditor, createMenuItem( "To Direction", mapToColor + "RadialStandardBasisColorMap" ) ) );
+                submenu2 .add( enableIf( isEditor, createMenuItem( "To Canonical Orientation", mapToColor + "CanonicalOrientationColorMap" ) ) );
+                submenu2 .add( enableIf( isEditor, createMenuItem( "To Normal Polarity", mapToColor + "NormalPolarityColorMap" ) ) );
                 submenu2 .add( enableIf( isEditor, createMenuItem( "To Octant", mapToColor + "CentroidByOctantAndDirectionColorMap" ) ) );
                 submenu2 .add( enableIf( isEditor, createMenuItem( "To Coordinate Plane", mapToColor + "CoordinatePlaneColorMap" ) ) );
                 submenu2 .add( enableIf( isEditor, createMenuItem( "System Colors", mapToColor + "SystemColorMap" ) ) );


### PR DESCRIPTION
Both of these new color mappings are helpful in determining strut and panel orientations. (e.g. when a meta-model panel might be flipped and need to be inverted or to see whether parallel strut vectors point the same direction or in opposite directions.