### PR TITLE
Extracted UndoRedoController

### DIFF
--- a/core/src/main/java/com/vzome/core/editor/DocumentModel.java
+++ b/core/src/main/java/com/vzome/core/editor/DocumentModel.java
@@ -249,6 +249,12 @@ public class DocumentModel implements Snapshot .Recorder, UndoableEdit .Context
 				String str = editNumber + ": " + DomUtils .toString( xml );
 				DocumentModel.this .firePropertyChange( "current.edit.xml", null, str );
 			}
+
+            @Override
+            public void publishChanges()
+            {
+                mEditorModel .notifyListeners();
+            }
 		});
 
         lesson .addPropertyChangeListener( new PropertyChangeListener()
@@ -1272,62 +1278,9 @@ public class DocumentModel implements Snapshot .Recorder, UndoableEdit .Context
         return man.getClass().getSimpleName();
     }
 
-	public void undo( boolean useBlocks )
-	{
-		mHistory .undo( useBlocks );
-        this .mEditorModel .notifyListeners();
-	}
-
-	public void redo( boolean useBlocks ) throws Command.Failure
-	{
-		mHistory .redo( useBlocks );
-        this .mEditorModel .notifyListeners();
-	}
-
-	public void undo()
-	{
-		mHistory .undo();
-        this .mEditorModel .notifyListeners();
-	}
-
-	public void redo() throws Command.Failure
-	{
-		mHistory .redo();
-        this .mEditorModel .notifyListeners();
-	}
-
-	public void undoToBreakpoint()
-	{
-		mHistory .undoToBreakpoint();
-        this .mEditorModel .notifyListeners();
-	}
-
 	public void undoToManifestation( Manifestation man )
 	{
 		mHistory .undoToManifestation( man );
-        this .mEditorModel .notifyListeners();
-	}
-
-	public void redoToBreakpoint() throws Command.Failure
-	{
-		mHistory .redoToBreakpoint();
-        this .mEditorModel .notifyListeners();
-	}
-
-	public void setBreakpoint()
-	{
-		mHistory .setBreakpoint();
-	}
-
-	public void undoAll()
-	{
-		mHistory .undoAll();
-        this .mEditorModel .notifyListeners();
-	}
-
-	public void redoAll( int i ) throws Command .Failure
-	{
-		mHistory .redoAll( i );
         this .mEditorModel .notifyListeners();
 	}
 
@@ -1500,4 +1453,9 @@ public class DocumentModel implements Snapshot .Recorder, UndoableEdit .Context
 	{
 		return this .bookmarkFactory;
 	}
+
+    public EditHistory getHistoryModel()
+    {
+        return this .mHistory;
+    }
 }

--- a/desktop/src/main/java/org/vorthmann/ui/Controller.java
+++ b/desktop/src/main/java/org/vorthmann/ui/Controller.java
@@ -85,4 +85,6 @@ public interface Controller extends ActionListener
     Controller getSubController( String string );
     
     MouseTool getMouseTool();
+
+    void addSubController( String name, Controller sub );
 }

--- a/desktop/src/main/java/org/vorthmann/ui/DefaultController.java
+++ b/desktop/src/main/java/org/vorthmann/ui/DefaultController.java
@@ -12,6 +12,8 @@ import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.vorthmann.j3d.MouseTool;
 
@@ -22,6 +24,8 @@ public class DefaultController implements Controller
     protected ErrorChannel mErrors;
     
     protected Controller mNextController;
+    
+    private final Map<String,Controller> subcontrollers = new HashMap<String, Controller>();
     
     protected PropertyChangeSupport properties()
     {
@@ -116,12 +120,22 @@ public class DefaultController implements Controller
     {
         return "true" .equals( getProperty( propName ) );
     }
+    
+    @Override
+    public void addSubController( String name, Controller sub )
+    {
+        this .subcontrollers .put( name, sub );
+        sub .setNextController( this );
+    }
 
     @Override
-    public Controller getSubController( String string )
+    public Controller getSubController( String name )
     {
+        Controller subc = this .subcontrollers .get( name );
+        if ( subc != null )
+            return subc;
         if ( mNextController != null )
-            return mNextController .getSubController( string );
+            return mNextController .getSubController( name );
         return null;
     }
 

--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/ApplicationController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/ApplicationController.java
@@ -486,9 +486,9 @@ public class ApplicationController extends DefaultController
     private void newDocumentController( final String name, final DocumentModel document, final Properties props )
     {
         DocumentController newest = new DocumentController( document, this, props );
-    	this .registerDocumentController( name, newest );
+        this .registerDocumentController( name, newest );
         // trigger window creation in the UI
-		this .properties() .firePropertyChange( "newDocument", null, newest );
+        this .properties() .firePropertyChange( "newDocument", null, newest );
     }
 
     private void registerDocumentController( final String name, final DocumentController newest )

--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/UndoRedoController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/UndoRedoController.java
@@ -1,0 +1,78 @@
+package org.vorthmann.zome.app.impl;
+
+import java.awt.event.ActionEvent;
+
+import org.vorthmann.ui.Controller;
+import org.vorthmann.ui.DefaultController;
+
+import com.vzome.core.editor.EditHistory;
+
+public class UndoRedoController extends DefaultController implements Controller
+{
+    private final EditHistory model;
+
+    public UndoRedoController( EditHistory model )
+    {
+        super();
+        this.model = model;
+    }
+
+    @Override
+    public void doAction( String action, ActionEvent e ) throws Exception
+    {
+        switch ( action ) {
+
+        case "undo":
+            this .model .undo( ! this .userHasEntitlement( "developer.extras" ) );
+            break;
+
+        case "redo":
+            this .model .redo( ! this .userHasEntitlement( "developer.extras" ) );
+            break;
+
+        case "undoToBreakpoint":
+            this .model .undoToBreakpoint();
+            break;
+
+        case "redoToBreakpoint":
+            this .model .redoToBreakpoint();
+            break;
+
+        case "setBreakpoint":
+            this .model .setBreakpoint();
+            break;
+
+        case "undoAll":
+            this .model .undoAll();
+            break;
+
+        case "redoAll":
+            this .model .redoAll( - 1 );
+            break;
+
+        default:
+            if ( action.startsWith( "redoUntilEdit." ) ) {
+                String editNum = action .substring( "redoUntilEdit.".length() ) .trim();
+                // editNum will be "null" if user canceled the numeric input dialog
+                // We'll also treat an empty string the same as canceling
+                if(! (editNum.equals("null") || editNum.equals("") ) ) {
+                    int eNum = -1;
+                    try {
+                        eNum = Integer.parseInt( editNum );
+                    } catch (Exception ex) {
+                        mErrors.reportError( "'" + editNum + "' is not a valid integer. Edit number must be a positive integer.", new Object[] {} );
+                    }
+                    if(eNum <= 0) {
+                        mErrors.reportError( "Edit number must be a positive integer.", new Object[] {} );
+                    } else {
+                        this .model .redoAll( eNum );
+                    }
+                }
+            }
+            else
+                super .doAction( action, e );
+            break;
+        }
+    }
+
+}

--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentMenuBar.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentMenuBar.java
@@ -27,39 +27,39 @@ import org.vorthmann.ui.Controller;
 
 public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
 {
-	private static final int COMMAND = Platform.getKeyModifierMask();
-	
-	private static final int COMMAND_OPTION = COMMAND | InputEvent.ALT_DOWN_MASK;
+    private static final int COMMAND = Platform.getKeyModifierMask();
 
-	private static final int COMMAND_SHIFT = COMMAND | InputEvent.SHIFT_DOWN_MASK;
+    private static final int COMMAND_OPTION = COMMAND | InputEvent.ALT_DOWN_MASK;
 
-	private static final int CONTROL = InputEvent.CTRL_DOWN_MASK;
-	
-	private static final int CONTROL_OPTION = InputEvent.CTRL_DOWN_MASK | InputEvent.ALT_DOWN_MASK;
+    private static final int COMMAND_SHIFT = COMMAND | InputEvent.SHIFT_DOWN_MASK;
+
+    private static final int CONTROL = InputEvent.CTRL_DOWN_MASK;
+
+    private static final int CONTROL_OPTION = InputEvent.CTRL_DOWN_MASK | InputEvent.ALT_DOWN_MASK;
 
     private static final long serialVersionUID = 1L;
-	
+
     private final JMenuItem setColorMenuItem, showToolsMenuItem, zomicMenuItem, pythonMenuItem, importVEFItem;
 
-	private final ControlActions actions;
-	
-	private final boolean fullPower;
+    private final ControlActions actions;
 
-	private final Controller controller;
+    private final boolean fullPower;
 
-	public DocumentMenuBar( final Controller controller, ControlActions actions )
-	{
-		this .controller = controller;
-		this .actions = actions;
+    private final Controller controller;
 
-		controller .addPropertyListener( this );
+    public DocumentMenuBar( final Controller controller, ControlActions actions )
+    {
+        this .controller = controller;
+        this .actions = actions;
+
+        controller .addPropertyListener( this );
 
         String initSystem = controller .getProperty( "symmetry" );
 
         String fieldName = controller .getProperty( "field.name" );
 
         // TODO: compute these booleans once in DocumentFrame, and don't recompute here
-        
+
         boolean readerPreview = controller .propertyIsTrue( "reader.preview" );
 
         boolean isEditor = controller .userHasEntitlement( "model.edit" ) && ! readerPreview;
@@ -71,11 +71,11 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
         boolean enable4d = developerExtras || ( fullPower && controller .userHasEntitlement( "4d.symmetries" ) );
 
         boolean metaModels = developerExtras || ( fullPower && controller .userHasEntitlement( "meta.models" ) );
-        
+
         boolean canSave = controller .userHasEntitlement( "save.files" );
 
         boolean isGolden = "golden" .equals( fieldName );
-        
+
         boolean isHeptagon = "heptagon" .equals( fieldName );
 
         boolean isSqrtPhi = "sqrtPhi" .equals( fieldName );
@@ -83,11 +83,11 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
         boolean isRootTwo = "rootTwo" .equals( fieldName );
 
         boolean isRootThree = "rootThree" .equals( fieldName );
-        
+
         boolean oldTools = controller .propertyIsTrue( "original.tools" );
-        
+
         List<String> symmetries = Arrays .asList( controller .getCommandList( "symmetryPerspectives" ) );
-        
+
         boolean hasIcosahedral = symmetries .contains( "icosahedral" );
 
         // ----------------------------------------- File menu
@@ -98,14 +98,14 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
         {
             JMenu submenu = new JMenu( "New Model..." );
             submenu.add( enableIf( isEditor || readerPreview, createMenuItem( "Zome (Golden) Field", "new-golden", KeyEvent.VK_N, COMMAND ) ) );
-            
+
             String[] fieldNames = controller .getCommandList( "fields" );
             for ( String fName : fieldNames ) {
-				if ( controller .propertyIsTrue( "enable." + fName + ".field" ) ) {
-					String label = controller .getProperty( "field.label." + fName );
-		            submenu .add( createMenuItem( label + " Field", "new-" + fName ) );
-				}
-			}
+                if ( controller .propertyIsTrue( "enable." + fName + ".field" ) ) {
+                    String label = controller .getProperty( "field.label." + fName );
+                    submenu .add( createMenuItem( label + " Field", "new-" + fName ) );
+                }
+            }
             menu.add( submenu );
         }
         else
@@ -169,13 +169,13 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
 
         menu.addSeparator();
 
-//        if ( controller .userHasEntitlement( "export.zomespace" ) )
-//        {
-//            submenu = new JMenu( "Export Article..." );
-//            submenu .add( createMenuItem( "Zomespace", "export.zomespace" ) );
-//            menu.add( submenu );
-//            submenu .setEnabled( fullPower && canSave );
-//        }
+        //        if ( controller .userHasEntitlement( "export.zomespace" ) )
+        //        {
+        //            submenu = new JMenu( "Export Article..." );
+        //            submenu .add( createMenuItem( "Zomespace", "export.zomespace" ) );
+        //            menu.add( submenu );
+        //            submenu .setEnabled( fullPower && canSave );
+        //        }
 
         submenu = new JMenu( "Capture Image..." );
         submenu .add( createMenuItem( "JPEG", "capture.jpg" ) );
@@ -196,17 +196,17 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
         // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Edit menu
 
         menu = new JMenu( "Edit" );
-        menu.add( enableIf( isEditor, createMenuItem( "Undo", "undo", KeyEvent.VK_Z, COMMAND ) ) );
-        menu.add( enableIf( isEditor, createMenuItem( "Redo", ( "redo" ), KeyEvent.VK_Y, COMMAND ) ) );
-        menu.add( enableIf( isEditor, createMenuItem( "Undo All", ( "undoAll" ), KeyEvent.VK_Z, COMMAND_OPTION ) ) );
-        menu.add( enableIf( isEditor, createMenuItem( "Redo All", ( "redoAll" ), KeyEvent.VK_Y, COMMAND_OPTION ) ) );
+        menu .add( withAccelerator( KeyEvent.VK_Z, COMMAND, withAction( "undoRedo", "undo",  new JMenuItem( "Undo" ) ) ) );
+        menu .add( withAccelerator( KeyEvent.VK_Y, COMMAND, withAction( "undoRedo", "redo",  new JMenuItem( "Redo" ) ) ) );
+        menu .add( withAccelerator( KeyEvent.VK_Z, COMMAND_OPTION, withAction( "undoRedo", "undoAll",  new JMenuItem( "Undo All" ) ) ) );
+        menu .add( withAccelerator( KeyEvent.VK_Y, COMMAND_OPTION, withAction( "undoRedo", "redoAll",  new JMenuItem( "Redo All" ) ) ) );
         if ( developerExtras )
         {
             menu .addSeparator(); // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-            menu .add( createMenuItem( "Undo To Breakpoint", ( "undoToBreakpoint" ), KeyEvent.VK_B, COMMAND_SHIFT ) );
-            menu .add( createMenuItem( "Redo To Breakpoint", ( "redoToBreakpoint" ), KeyEvent.VK_B, COMMAND_OPTION ) );
-            menu .add( createMenuItem( "Set Breakpoint", ( "setBreakpoint" ), KeyEvent.VK_B, COMMAND ) );
-            menu .add( createMenuItem( "Redo to Edit Number...", "redoUntilEdit" ) );
+            menu .add( withAccelerator( KeyEvent.VK_B, COMMAND_SHIFT, withAction( "undoRedo", "undoToBreakpoint", new JMenuItem( "Undo To Breakpoint" ) ) ) );
+            menu .add( withAccelerator( KeyEvent.VK_B, COMMAND_OPTION, withAction( "undoRedo", "redoToBreakpoint", new JMenuItem( "Redo To Breakpoint" ) ) ) );
+            menu .add( withAccelerator( KeyEvent.VK_B, COMMAND, withAction( "undoRedo", "setBreakpoint", new JMenuItem( "Set Breakpoint" ) ) ) );
+            menu .add( withAction( "undoRedo", "redoUntilEdit", new JMenuItem( "Redo to Edit Number..." ) ) );
         }
         menu .addSeparator(); // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
         menu .add( enableIf( isEditor, createMenuItem( "Cut", ( "cut" ), KeyEvent.VK_X, COMMAND ) ) );
@@ -218,22 +218,22 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
         menu .add( enableIf( isEditor, createMenuItem( "Select All", ( "selectAll" ), KeyEvent.VK_A, COMMAND ) ) );
         menu .add( enableIf( isEditor, createMenuItem( "Select Neighbors", ( "selectNeighbors" ), KeyEvent.VK_A, COMMAND_OPTION ) ) );
         menu.add( enableIf( isEditor, createMenuItem( "Invert Selection", ( "invertSelection" ) ) ) );
-		
-		submenu = new JMenu("Select...");
+
+        submenu = new JMenu("Select...");
         submenu.add( enableIf( isEditor, createMenuItem( "Balls", ( "selectBalls" ) ) ) );
         submenu.add( enableIf( isEditor, createMenuItem( "Struts", ( "selectStruts" ) ) ) );
         submenu.add( enableIf( isEditor, createMenuItem( "Panels", ( "selectPanels" ) ) ) );
-		submenu.add( enableIf( isEditor, createMenuItem( "Automatic Struts", ( "SelectAutomaticStruts" ) ) ) );
-//		submenu.add( enableIf( isEditor, createMenuItem( "All Collinear", ( "SelectCollinear" ) ) ) );
-//      submenu.add( enableIf( isEditor, createMenuItem( "Parallel Struts", ( "SelectParallelStruts" ) ) ) );
-		menu.add(submenu);
+        submenu.add( enableIf( isEditor, createMenuItem( "Automatic Struts", ( "SelectAutomaticStruts" ) ) ) );
+        //		submenu.add( enableIf( isEditor, createMenuItem( "All Collinear", ( "SelectCollinear" ) ) ) );
+        //      submenu.add( enableIf( isEditor, createMenuItem( "Parallel Struts", ( "SelectParallelStruts" ) ) ) );
+        menu.add(submenu);
 
-		submenu = new JMenu("Deselect...");
+        submenu = new JMenu("Deselect...");
         submenu.add( enableIf( isEditor, createMenuItem( "Balls", ( "deselectBalls" ) ) ) );
         submenu.add( enableIf( isEditor, createMenuItem( "Struts", ( "deselectStruts" ) ) ) );
         submenu.add( enableIf( isEditor, createMenuItem( "Panels", ( "deselectPanels" ) ) ) );
         submenu.add( enableIf( isEditor, createMenuItem( "All", ( "unselectAll" ) ) ) );
-		menu.add(submenu);
+        menu.add(submenu);
 
         menu .addSeparator(); // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
         menu .add( enableIf( isEditor, createMenuItem( "Group", ( "group" ), KeyEvent.VK_G, COMMAND ) ) );
@@ -316,13 +316,13 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
         menu .addSeparator(); // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
         menu.add( enableIf( isEditor, createMenuItem( "Ball At Origin", ( "ballAtOrigin" ) ) ) );
         if ( controller .propertyIsTrue( "original.tools" ) )
-        	menu.add( enableIf( isEditor, createMenuItem( "Ball At Symmetry Center", ( "ballAtSymmCenter" ) ) ) );
+            menu.add( enableIf( isEditor, createMenuItem( "Ball At Symmetry Center", ( "ballAtSymmCenter" ) ) ) );
 
         menu .addSeparator(); // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-//        menu.add( enableIf( isEditor, createMenuItem( "Affine Transform All", getExclusiveAction( "affineTransformAll" ) ) );
-//        menuItem = enableIf( isEditor, createMenuItem( "Conjugate", getExclusiveAction( "conjugate" ) );
+        //        menu.add( enableIf( isEditor, createMenuItem( "Affine Transform All", getExclusiveAction( "affineTransformAll" ) ) );
+        //        menuItem = enableIf( isEditor, createMenuItem( "Conjugate", getExclusiveAction( "conjugate" ) );
         if ( metaModels ) {
-        	menu .add(  createMenuItem( "Meta-model", ( "realizeMetaParts" ) ) );
+            menu .add(  createMenuItem( "Meta-model", ( "realizeMetaParts" ) ) );
         }
         menu.add( enableIf( isEditor, createMenuItem( "Parallelepiped", "parallelepiped", KeyEvent.VK_P, COMMAND_SHIFT ) ) );
         if ( isGolden ) {
@@ -338,7 +338,7 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
 
             menu.add( enableIf( isEditor, createMenuItem( "Assert Selection", ( "assertSelection" ) ) ) );
 
-//            menu.add( enableIf( isEditor, createMenuItem( "6-Lattice", getExclusiveAction( "sixLattice" ) ) );
+            //            menu.add( enableIf( isEditor, createMenuItem( "6-Lattice", getExclusiveAction( "sixLattice" ) ) );
         }
 
         super .add( menu );
@@ -347,19 +347,19 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
         // ----------------------------------------- Tools menu
 
         menu = new JMenu( "Tools" );
-        
+
         if ( oldTools ) {
             menu.add( enableIf( isEditor, createMenuItem( "Set Center", "setSymmetryCenter" ) ) ); 
             menu.add( enableIf( isEditor, createMenuItem( "Set Axis", "setSymmetryAxis" ) ) ); 
             menu.addSeparator(); 
-            
+
             showToolsMenuItem = enableIf( isEditor, createMenuItem( "Show Tools Panel", "showToolsPanel" ) );
             showToolsMenuItem .setEnabled( fullPower );
             menu .add( showToolsMenuItem );
             menu .addSeparator();
         }
         else
-        	this .showToolsMenuItem = null;
+            this .showToolsMenuItem = null;
 
         Controller symmetryController = controller .getSubController( "symmetry" );
         // TODO: replace legacy commands with default tools
@@ -373,11 +373,11 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
         menu.add( enableIf( isEditor, createMenuItem( "Tetrahedral Symmetry", "tetrasymm", symmetryController, KeyEvent.VK_T, COMMAND_OPTION ) ) );
         if ( oldTools ) {
             menu.add( enableIf( isEditor, createMenuItem( "Axial Symmetry", "axialsymm", symmetryController, KeyEvent.VK_R, COMMAND ) ) );
-        	    menu.add( enableIf( isEditor, createMenuItem( "Mirror Reflection", "mirrorsymm" , symmetryController, KeyEvent.VK_M, COMMAND ) ) );
+            menu.add( enableIf( isEditor, createMenuItem( "Mirror Reflection", "mirrorsymm" , symmetryController, KeyEvent.VK_M, COMMAND ) ) );
             menu.add( enableIf( isEditor, createMenuItem( "Translate", "translate", symmetryController, KeyEvent.VK_T, COMMAND ) ) );
         }
         menu.add( enableIf( isEditor, createMenuItem( "Point Reflection", "pointsymm" ) ) );
-        
+
         menu .addSeparator();
         menu .add( enableIf( isEditor, createMenuItem( "Generate Polytope...", "showPolytopesDialog", KeyEvent.VK_P, COMMAND_OPTION ) ) );
         if ( enable4d ) {
@@ -424,7 +424,7 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
             // DISABLED until the symmetry group has been properly implemented
             // menu.add( rbMenuItem );
         }
-        
+
         rbMenuItem = actions .setMenuAction( "setSymmetry.octahedral", controller, new JRadioButtonMenuItem( "Octahedral System" ) );
         rbMenuItem .setSelected( "octahedral".equals( initSystem ) );
         rbMenuItem .setEnabled( fullPower );
@@ -449,7 +449,7 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
         }
 
         menu.addSeparator();
-        
+
         if ( developerExtras )
         {
             JMenuItem wfMenuItem = actions .setMenuAction( "toggleWireframe", controller, new JCheckBoxMenuItem( "Wireframe" ) );
@@ -472,7 +472,7 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
         showStrutScalesItem .setSelected( setting );
         showStrutScalesItem .setEnabled( fullPower );
         controller .addPropertyListener( new PropertyChangeListener(){
-			@Override
+            @Override
             public void propertyChange( PropertyChangeEvent chg )
             {
                 if ( "showStrutScales" .equals( chg .getPropertyName() ) )
@@ -480,10 +480,10 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
             }} );
         menu .add( showStrutScalesItem );
 
-//        cbMenuItem = enabler .enableMenuAction( "toggleOneSidedPanels", new JCheckBoxMenuItem( "Show Panels One-sided" ) );
-//        setting = "true".equals( controller.getProperty( "oneSidedPanels" ) );
-//        cbMenuItem.setSelected( setting );
-//        menu.add( cbMenuItem );
+        //        cbMenuItem = enabler .enableMenuAction( "toggleOneSidedPanels", new JCheckBoxMenuItem( "Show Panels One-sided" ) );
+        //        setting = "true".equals( controller.getProperty( "oneSidedPanels" ) );
+        //        cbMenuItem.setSelected( setting );
+        //        menu.add( cbMenuItem );
 
         cbMenuItem = actions .setMenuAction( "toggleFrameLabels", controller, new JCheckBoxMenuItem( "Show Frame Labels" ) );
         setting = "true".equals( controller .getProperty( "showFrameLabels" ) );
@@ -514,7 +514,7 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
         // ----------------------------------------- Custom menu
         menu = getCustomMenu();
         if(menu != null) {
-        	super .add( menu );
+            super .add( menu );
         }
 
 
@@ -526,11 +526,11 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
         menu .addSeparator(); 
         menu .add( createMenuItem( "About vZome...", "showAbout" ) );
         super .add( menu );
-	}
+    }
 
-	@Override
-	public void propertyChange( PropertyChangeEvent e )
-	{
+    @Override
+    public void propertyChange( PropertyChangeEvent e )
+    {
         if ( "editor.mode" .equals( e .getPropertyName() ) )
         {
             String mode = (String) e .getNewValue();
@@ -538,7 +538,7 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
             {
                 setColorMenuItem .setEnabled( false );
                 if ( showToolsMenuItem != null )
-                	showToolsMenuItem .setEnabled( false );
+                    showToolsMenuItem .setEnabled( false );
                 pythonMenuItem .setEnabled( false );
                 zomicMenuItem .setEnabled( false );
                 importVEFItem .setEnabled( false );
@@ -547,38 +547,59 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
             {                   
                 setColorMenuItem .setEnabled( true );
                 if ( showToolsMenuItem != null )
-                	showToolsMenuItem .setEnabled( fullPower );
+                    showToolsMenuItem .setEnabled( fullPower );
                 pythonMenuItem .setEnabled( fullPower );
                 zomicMenuItem .setEnabled( fullPower );
                 importVEFItem .setEnabled( fullPower );
             }
         }
-	}
+    }
 
-	private JMenuItem enableIf( boolean enable, JMenuItem control )
-	{
-    	control .setEnabled( enable );
-    	return control;
-	}
-	
+    private JMenuItem enableIf( boolean enable, JMenuItem control )
+    {
+        control .setEnabled( enable );
+        return control;
+    }
+
+    private JMenuItem withAction( String controllerName, String action, JMenuItem menuItem )
+    {
+        menuItem .setActionCommand( action );
+        Controller subc = this .controller;
+        if ( controllerName != null )
+            subc = subc .getSubController( controllerName );
+        if ( subc != null ) {
+            menuItem .setEnabled( true );
+            menuItem .addActionListener( subc );
+        }
+        else
+            menuItem .setEnabled( false );
+        return menuItem;
+    }
+
+    private JMenuItem withAccelerator( int key, int modifiers, JMenuItem menuItem )
+    {
+        menuItem .setAccelerator( KeyStroke.getKeyStroke( key, modifiers ) );
+        return menuItem;
+    }
+
     private JMenuItem createMenuItem( String label, String command )
     {
-    	return createMenuItem( label, command, KeyEvent .CHAR_UNDEFINED, 0 );
-	}
+        return createMenuItem( label, command, KeyEvent .CHAR_UNDEFINED, 0 );
+    }
 
     private JMenuItem createMenuItem( String label, String command, int key, int modifiers )
     {
-    	return this .createMenuItem( label, command, this .controller, key, modifiers );
-	}
+        return this .createMenuItem( label, command, this .controller, key, modifiers );
+    }
 
     private JMenuItem createMenuItem( String label, String command, Controller controller, int key, int modifiers )
     {
-    	JMenuItem menuItem = actions .setMenuAction( command, controller, new JMenuItem( label ) );
-    	menuItem .setEnabled( true );
+        JMenuItem menuItem = actions .setMenuAction( command, controller, new JMenuItem( label ) );
+        menuItem .setEnabled( true );
         if ( key != KeyEvent .CHAR_UNDEFINED )
             menuItem .setAccelerator( KeyStroke.getKeyStroke( key, modifiers ) );
-		return menuItem;
-	}
+        return menuItem;
+    }
 
     /**
      * @return JMenu with custom menu items added or null if no custom menu items are defined.


### PR DESCRIPTION
This refactoring establishes a pattern for further cleanup of DocumentController.
It eliminates one layer of “dispatch” code in DocumentModel, and moves
another layer from DocumentController to UndoRedoController.  Finally,
the latter can use a specific model, EditHistory.

I added EditHistory.Listener.publishChanges() to further clean up a little,
but I’m not sure if this is the right pattern for doing SelectionChanges
notifyListeners().