### PR TITLE
Fix compile error in GenerateLinearMaps

### DIFF
--- a/core/src/regression/java/com/vzome/experiments/GenerateLinearMaps.java
+++ b/core/src/regression/java/com/vzome/experiments/GenerateLinearMaps.java
@@ -129,7 +129,7 @@ public class GenerateLinearMaps
 				return false; // short-circuit because a1 and a2 guarantee white struts, regardless of a3
 			}
 
-			doc .undo();
+			doc. getHistoryModel() .undo();
 			deselect();
 
 			AlgebraicNumber blueShort = blue .getUnitLength() .times( field .createPower( 2 ) );


### PR DESCRIPTION
Allow the entire project to compile by replacing doc. undo() with doc. getHistoryModel() .undo() since doc.undo() method has been removed.