### PR TITLE
Specify UTF-8 encoding for Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ subprojects {
 	// set them to 1.8 for Java 8
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
+    options.encoding = 'UTF-8'
   }
 
   repositories {

--- a/core/src/regression/java/com/vzome/experiments/GenerateLinearMaps.java
+++ b/core/src/regression/java/com/vzome/experiments/GenerateLinearMaps.java
@@ -129,7 +129,7 @@ public class GenerateLinearMaps
 				return false; // short-circuit because a1 and a2 guarantee white struts, regardless of a3
 			}
 
-			doc .undo();
+			doc. getHistoryModel() .undo();
 			deselect();
 
 			AlgebraicNumber blueShort = blue .getUnitLength() .times( field .createPower( 2 ) );

--- a/core/src/test/java/logging.properties
+++ b/core/src/test/java/logging.properties
@@ -58,9 +58,9 @@ java.util.logging.FileHandler.pattern = %h/vZomeLogs/vZomeCustomLog%u.%g.log
 java.util.logging.FileHandler.limit = 500000
 java.util.logging.FileHandler.count = 10
 
-# Windows defaults to UTF8 encoding, so specify UTF16
+# Windows defaults to windows-1252 encoding, so specify UTF8
 # if extended characters (like phi as "\u03c6") need to be read from log files.
-# java.util.logging.FileHandler.encoding = UTF16
+java.util.logging.FileHandler.encoding = UTF8
 
 # Use either SimpleFormatter or XMLFormatter for the FileHandler...
 # java.util.logging.FileHandler.formatter = java.util.logging.XMLFormatter
@@ -120,7 +120,7 @@ java.util.logging.SimpleFormatter.format=%4$s: %5$s%n
 #org.vorthmann.vzome.level = FINE
 #org.vorthmann.zome.controller.level = CONFIG
 #org.vorthmann.zome.ui.level = FINEST
-# To see JVM args and verify that extended characters like phi are properly encoded in the log file. (Set FileHandler.encoding = UTF16 above)
+# To see JVM args and verify that extended characters like phi are properly encoded in the log file. (Set FileHandler.encoding = UTF8 above)
 #org.vorthmann.zome.ui.ApplicationUI.level = FINE
 
 # for manifestation adds and removes

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -36,7 +36,7 @@ ext.vzomeArgs = [  // a list, not a map
 mainClassName = 'org.vorthmann.zome.ui.ApplicationUI'
 // used by the 'application' Gradle plugin
 run.args( vzomeArgs )
-applicationDefaultJvmArgs = [ '-Xmx3048M' ]   // this variable is for 'application' plugin
+applicationDefaultJvmArgs = [ '-Xmx3048M', '-Dfile.encoding=UTF8' ]
 jvmArgs.each { entry ->
     applicationDefaultJvmArgs << "-D$entry.key=$entry.value"
 }


### PR DESCRIPTION
UTF-8 encoding is standard for Mac. It must be explicitly specified for Windows to properly show extended characters to stdout, stderr, log files and exported text files. Note that this PR also includes the undo-fix PR.