### PR TITLE
Show coordinates of strut end in properties dialog

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
@@ -1624,6 +1624,9 @@ public class DocumentController extends DefaultController implements J3dComponen
                     Strut strut = Strut.class.cast(man);
                     strut.getLocation().getVectorExpression(buf, AlgebraicField.DEFAULT_FORMAT);
                     
+                    buf.append("\n\nend: ");
+                    strut.getEnd().getVectorExpression(buf, AlgebraicField.DEFAULT_FORMAT);
+                    
                     buf.append("\n\noffset: ");
                     AlgebraicVector offset = strut.getOffset();
                     if (offset.isOrigin()) {


### PR DESCRIPTION
Don't know how this little detail went un-noticed until now.