### PR TITLE
Remove unused references to VefParser.usesActualScale()

### DIFF
--- a/core/src/main/java/com/vzome/core/commands/CommandImportVEFData.java
+++ b/core/src/main/java/com/vzome/core/commands/CommandImportVEFData.java
@@ -153,7 +153,7 @@ public class CommandImportVEFData extends AbstractCommand
         @Override
         protected void addVertex( int index, AlgebraicVector location )
         {
-            if ( scale != null && ! usesActualScale() ) {
+            if ( scale != null ) {
                 location = location .scale( scale );
             }
             if ( mProjection != null )

--- a/core/src/main/java/com/vzome/core/construction/VefToModel.java
+++ b/core/src/main/java/com/vzome/core/construction/VefToModel.java
@@ -63,7 +63,7 @@ public class VefToModel extends VefParser
     protected void addVertex( int index, AlgebraicVector location )
     {
         logger .finest( "addVertex location = " + location .getVectorExpression( AlgebraicField .VEF_FORMAT ) );
-        if ( scale != null && ! usesActualScale())
+        if ( scale != null )
         {
             location = location .scale( scale );
             logger .finest( "scaled = " + location .getVectorExpression( AlgebraicField .VEF_FORMAT ) );

--- a/core/src/main/java/com/vzome/core/math/VefParser.java
+++ b/core/src/main/java/com/vzome/core/math/VefParser.java
@@ -79,21 +79,6 @@ public abstract class VefParser
         return isRational;
     }
 
-    /**
-     * True if this VEF file should be interpreted without additional
-     *  scaling in VefToModel.
-     * This is somewhat misplaced and confusing.  It does not govern the interpretation
-     * of vertex data within the parser.  It only governs additional scaling within
-     * addVertex in subclasses, and in fact only within one subclass, VefToModel.
-     * 
-     * This is no longer relevant, since VEF import now gives the user control over any scale factor.
-     * @return
-     */
-    public boolean usesActualScale()
-    {
-        return false;
-    }
-
     protected boolean wFirst()
     {
         return mVersion >= VERSION_W_FIRST;


### PR DESCRIPTION
No functional change, just a little code cleanup.