### PR TITLE
Improved defaults for 2d export

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
@@ -585,7 +585,7 @@ public class DocumentController extends DefaultController implements Controller3
 
             else if ( action.equals( "refresh.2d" ) )
             {
-                this .java2dController .setScene( cameraController.getView(), this.sceneLighting, this.currentSnapshot );
+                this .java2dController .setScene( cameraController.getView(), this.sceneLighting, this.currentSnapshot, this.drawOutlines );
             }
 
             else if ( action.startsWith( "setStyle." ) )
@@ -878,7 +878,7 @@ public class DocumentController extends DefaultController implements Controller3
                 Dimension size = this .modelCanvas .getSize();              
                 String format = command .substring( "export2d." .length() ) .toLowerCase();
                 Java2dSnapshot snapshot = documentModel .capture2d( currentSnapshot, size.height, size.width, cameraController .getView(), sceneLighting, false, true );
-                documentModel .export2d( snapshot, format, file, true, false );
+                documentModel .export2d( snapshot, format, file, this .drawOutlines, false );
                 this .openApplication( file );
                 return;
             }
@@ -1246,7 +1246,8 @@ public class DocumentController extends DefaultController implements Controller3
         
         case "snapshot.2d": {
             if ( java2dController == null ) {
-                java2dController = new Java2dSnapshotController( this .documentModel, cameraController.getView(), this.sceneLighting, this.currentSnapshot );
+                java2dController = new Java2dSnapshotController( this .documentModel, cameraController.getView(), this.sceneLighting,
+                						this.currentSnapshot, this.drawOutlines );
                 java2dController .setNextController( this );
             }
             return java2dController;

--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/Java2dSnapshotController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/Java2dSnapshotController.java
@@ -29,7 +29,7 @@ public class Java2dSnapshotController extends DefaultController
 {    
     private boolean current = false;
  
-    private boolean showBackground = false, monochrome = true, lineDrawing = false, doLighting = true, outlinePanels = true;
+    private boolean showBackground = true, monochrome = true, lineDrawing = false, doLighting = true, outlinePanels = true;
 
     private transient Java2dSnapshot snapshot;
 
@@ -42,12 +42,13 @@ public class Java2dSnapshotController extends DefaultController
     private RenderedModel model;
 
     
-    public Java2dSnapshotController( DocumentModel document, Camera camera, Lights lights, RenderedModel model )
+    public Java2dSnapshotController( DocumentModel document, Camera camera, Lights lights, RenderedModel model, boolean outlinePanels )
     {
         this .document = document;
         this .camera = camera;
         this .lights = lights;
         this .model = model;
+        this .outlinePanels = outlinePanels;
     }
 
     private final static String[] DRAW_STYLES = new String[]{ "outlined shapes", "shaded shapes", "shaded, outlined shapes", "colored lines", "black lines" };
@@ -214,12 +215,13 @@ public class Java2dSnapshotController extends DefaultController
     }
 
 
-    public void setScene( Camera camera, Lights lights, RenderedModel model )
+    public void setScene( Camera camera, Lights lights, RenderedModel model, boolean outlinePanels )
     {
         this .camera = camera;
         this .lights = lights;
         this .model = model;
         this .current = false;
+        this .outlinePanels = outlinePanels;
     }
 }
 


### PR DESCRIPTION
Background is on by default, and panel outlines are shown only
if they are on in the main view, so that the 2d export / rendering
is more WYSIWIG.