### PR TITLE
Remove logging of null core-version at startup

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/ui/ApplicationUI.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/ApplicationUI.java
@@ -396,7 +396,6 @@ public final class ApplicationUI implements ActionListener, PropertyChangeListen
 				"version",
 				"buildNumber",
 				"gitCommit",
-				"coreVersion"
 			});
         // Use an anonymousLogger to ensure that this is always written to the log file 
         // regardless of the settings in the logging.properties file


### PR DESCRIPTION
Build 45 logs a null coreVersion at startup. Since desktop and core should have the same version, it is no longer necessary to log both. Commit 1b6e7ffebc17b490bff65b99d5782e48acf1b467 removed the initialization of the coreVersion property. This commit simply removes it from the log as well.