### PR TITLE
Fix GaussJordanReduction to work with non-square matrices

### DIFF
--- a/core/src/main/java/com/vzome/core/algebra/BigRational.java
+++ b/core/src/main/java/com/vzome/core/algebra/BigRational.java
@@ -175,6 +175,22 @@ public class BigRational implements Comparable<BigRational>, Fields.BigRationalE
         this(BigInteger.valueOf(numerator), denominator);
     }
 
+    public static BigRational[][] newMatrix(int [][] numerators) {
+        BigRational[][] matrix = new BigRational[numerators.length][];
+        for (int row = 0; row < numerators.length; row++) {
+            matrix[row] = newArray(numerators[row]);
+        }
+        return matrix;
+    }
+    
+    public static BigRational[] newArray(int [] numerators) {
+        BigRational[] array = new BigRational[numerators.length];
+        for (int col = 0; col < numerators.length; col++) {
+            array[col] = new BigRational(numerators[col]);
+        }
+        return array;
+    }
+    
     /**
      * 
      * @param numerator

--- a/core/src/main/java/com/vzome/core/algebra/Fields.java
+++ b/core/src/main/java/com/vzome/core/algebra/Fields.java
@@ -5,32 +5,29 @@ package com.vzome.core.algebra;
 
 import java.util.Arrays;
 
-public class Fields
-{
-    public interface BigRationalElement<R, T> extends RationalElement<R, T>
-    {
+public class Fields {
+    public interface BigRationalElement<R, T> extends RationalElement<R, T> {
         boolean isBig();
+
         boolean notBig();
     }
-    
-    public interface RationalElement<R, T> extends Element<T>
-    {
+
+    public interface RationalElement<R, T> extends Element<T> {
         R getNumerator();
 
         R getDenominator();
 
-        T dividedBy( T that );
+        T dividedBy(T that);
 
         double evaluate();
     }
 
-    public interface Element<T>
-    {
-        T times( T that );
+    public interface Element<T> {
+        T times(T that);
 
-        T plus( T that );
+        T plus(T that);
 
-        T minus( T that );
+        T minus(T that);
 
         T reciprocal();
 
@@ -41,122 +38,140 @@ public class Fields
         boolean isOne();
     }
 
-    
-    public static final int rows( Element<?>[][] matrix )
-    {
-    	return matrix.length;
+    public static final int rows(Object[][] matrix) {
+        return matrix.length;
     }
-    
-    public static final int columns( Element<?>[][] matrix )
-    {
-    	return matrix[ 0 ] .length;
+
+    public static final int columns(Object[][] matrix) {
+        return matrix[0].length;
     }
-    
-    public static <T extends Element<T>> void matrixMultiplication( T[][] left, T[][] right, T[][] product )
-    {
-    	if ( rows( right ) != columns( left ) )
-    		throw new IllegalArgumentException( "matrices cannot be multiplied" );
-    	if ( rows( product ) != rows( left ) )
-    		throw new IllegalArgumentException( "product matrix has wrong number of rows" );
-    	if ( columns( right ) != columns( product ) )
-    		throw new IllegalArgumentException( "product matrix has wrong number of columns" );
-    	
-    	for (int i = 0; i < rows( product ); i++) {
-			for (int j = 0; j < columns( product ); j++) {
-				T sum = null;
-				for (int j2 = 0; j2 < columns( left ); j2++) {
-					T prod = left[ i ][ j2 ] .times( right[ j2 ][ j ] );
-					if ( sum == null )
-						sum = prod;
-					else
-						sum = sum .plus( prod );
-				}
-				product[ i ][ j ] = sum;
-			}
-		}
-    }
-    
-    @SuppressWarnings("unchecked")
-    public static <T extends Element<T>> int gaussJordanReduction( T[][] m, T[][] adjoined )
-    {
-        // Array "m" is copied to a local array named matrix so that m remains unchanged.
-        // The adjoined array is modified in place and will be accessible to the caller.
-        final Object[][] matrix = new Object[ m.length ][];
-        for (int i = 0; i < m.length; i++) {
-        	matrix[i] = Arrays.copyOf( m[i], m[i].length );
-        }
-        
-        // now the real work...
-        for ( int upleft = 0; upleft < matrix.length; upleft++ ) {
-            int pivot = -1;
-            // find pivot: skip columns all zero, find highest non-zero row
-            for ( int j = upleft; j < matrix[0].length; j++ ) {
-                for ( int i = upleft; i < matrix.length; i++ ) {
-                    if ( ! ((T)matrix[ i ][ j ]) .isZero() ) {
-                        pivot = i;
-                        break;
-                    }
+
+    public static <T extends Element<T>> void matrixMultiplication(T[][] left, T[][] right, T[][] product) {
+        if (rows(right) != columns(left))
+            throw new IllegalArgumentException("matrices cannot be multiplied");
+        if (rows(product) != rows(left))
+            throw new IllegalArgumentException("product matrix has wrong number of rows");
+        if (columns(right) != columns(product))
+            throw new IllegalArgumentException("product matrix has wrong number of columns");
+
+        for (int i = 0; i < rows(product); i++) {
+            for (int j = 0; j < columns(product); j++) {
+                T sum = null;
+                for (int j2 = 0; j2 < columns(left); j2++) {
+                    T prod = left[i][j2].times(right[j2][j]);
+                    if (sum == null)
+                        sum = prod;
+                    else
+                        sum = sum.plus(prod);
                 }
-                if ( pivot >= 0 ) {
+                product[i][j] = sum;
+            }
+        }
+    }
+
+    public static <T extends Element<T>> int gaussJordanReduction(T[][] matrix) {
+        // Here, the matrix is modified in place so it will be accessible to the caller.
+        return gaussJordanReduction(matrix, matrix);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T extends Element<T>> int gaussJordanReduction(T[][] immutableMatrix, T[][] adjoined) {
+        // matrices "immutableMatrix" and "adjoined" must have the same number of rows,
+        // but do necessarily have the same number of columns and are not necessarily square.
+        final int nRows = rows(immutableMatrix);
+
+        // All of the work is done on a copy of immutableMatrix simply named matrix
+        // so that immutableMatrix actually remains unchanged.
+        // The "adjoined" array is modified in place and will be accessible to the caller.
+        final Object[][] matrix = copyOf(immutableMatrix);
+
+        int rank = 0;
+        // find successive pivot columns, skipping columns that contain only zeroes
+        for (int col = 0; col < columns(matrix); col++) {
+            int pivotRow = -1;
+            for (int row = rank; row < nRows; row++) {
+                T element = (T) matrix[row][col];
+                if (!element.isZero()) {
+                    pivotRow = row;
                     break;
                 }
             }
-            if ( pivot < 0 ) {
-                break; // all done, matrix is now in Reduced Row Echelon Form (ReREF)
-            }
+            if (pivotRow >= 0) {
+                // swap pivot row and current rank row if necessary
+                if (pivotRow != rank) {
+                    swap(matrix, rank, pivotRow);
+                    swap(adjoined, rank, pivotRow);
+                    pivotRow = rank;
+                }
+                
+                // scale the pivot row if necessary
+                T scalar = (T) matrix[pivotRow][col];
+                if (!scalar.isOne()) {
+                    scalar = scalar.reciprocal();
+                    scale((T[]) matrix[pivotRow], scalar);
+                    scale(adjoined[pivotRow], scalar);
+                }
 
-            // exchange pivot and top rows
-            if ( pivot != upleft ) {
-                for ( int j = upleft; j < matrix[0].length; j++ ) {
-                    T temp = (T) matrix[ upleft ][ j ];
-                    matrix[ upleft ][ j ] = matrix[ pivot ][ j ];
-                    matrix[ pivot ][ j ] = temp;
-                }
-                for ( int j = 0; j < adjoined[0].length; j++ ) {
-                	T temp = adjoined[ upleft ][ j ];
-                	adjoined[ upleft ][ j ] = adjoined[ pivot ][ j ];
-                	adjoined[ pivot ][ j ] = temp;
-                }
-            }
-
-            // normalize the top row
-            if ( ! ((T) matrix[ upleft ][ upleft ]) .isOne() ) {
-                T divisor = ((T) matrix[ upleft ][ upleft ]) .reciprocal();
-                for ( int j = upleft; j < matrix[0].length; j++ ) {
-                    matrix[ upleft ][ j ] = ((T) matrix[ upleft ][ j ]) .times( divisor );
-                }
-                for ( int j = 0; j < adjoined[0].length; j++ ) {
-                	adjoined[ upleft ][ j ] = adjoined[ upleft ][ j ] .times( divisor );
-                }
-            }
-
-            // zero out all other entries in the upleft column, 
-            // by subtracting matrix[i,upleft] * matrix[upleft,j] from matrix[i,j]
-            for ( int i = 0; i < matrix.length; i++ ) {
-                if ( i != upleft && ! ((T) matrix[ i ][ upleft ]) .isZero() ) {
-                    T factor = (T) matrix[ i ][ upleft ];
-                    matrix[ i ][ upleft ] = factor .plus( factor .negate() ); // zero it out
-                    for ( int j = upleft+1; j < matrix[0].length; j++ ) {
-                        T temp = ((T) matrix[ upleft ][ j ]) .times( factor );
-                        matrix[ i ][ j ] = ((T) matrix[ i ][ j ]) .plus( temp .negate() );
-                    }
-                    for ( int j = 0; j < adjoined[0].length; j++ ) {
-                    	T temp = adjoined[ upleft ][ j ] .times( factor );
-                    	adjoined[ i ][ j ] = adjoined[ i ][ j ] .plus( temp .negate() );
+                // use pivot operation to zero out all entries in the current column 
+                // except for the pivot row
+                for (int row = 0; row < nRows; row++) {
+                    if (row != pivotRow) {
+                        scalar = ((T) matrix[row][col]);
+                        if (!scalar.isZero()) {
+                            scalar = scalar.negate();
+                            pivot(matrix, row, scalar, pivotRow);
+                            pivot(adjoined, row, scalar, pivotRow);
+                        }
                     }
                 }
+                rank++;
             }
         }
-        // since the caller won't have access to the matrix in reduced row echelon form,
-        // we'll return its rank so the caller can determine if it is invertable
-        int rank = 0;
-        for ( int i = 0; i < matrix.length; i++ ) {
-            if(i < matrix[i].length ) {
-                if(((T) matrix[i][i]) .isOne()) {
-                    rank++;
-                }
-            }
+        // After being reduced to Row Echelon Form (ReREF),
+        // rank is the number of matrix rows having a one in one of their elements
+        return rank;   
+    }
+
+    // Elementary matrix operations used in Gauss Jordan Reduction are implemented as individual functions
+    
+    private static <T extends Element<T>> Object[][] copyOf(T[][] matrix) {
+        final int nRows = rows(matrix);
+        final int nCols = columns(matrix);
+        final Object[][] copy = new Object[nRows][];
+        for (int i = 0; i < nRows; i++) {
+            copy[i] = Arrays.copyOf(matrix[i], nCols);
         }
-        return rank;
+        return copy;
+    }
+
+    /**
+     * 
+     * @param array of elements to be swapped 
+     * @param r index of the first element to be swapped
+     * @param s index of the second element to be swapped
+     * <br/>
+     * Note that since Java implements a multi-dimensional array as an array of arrays,
+     * the {@code array} parameter can be an {@code Object[][]} in which case
+     * entire rows are swapped rather than an element at a time. 
+     * Besides being more efficient at run time, this also means 
+     * that rows of multi-dimensional arrays do not necessarily have to be the same length.
+     */
+    private static void swap(Object[] array, int r, int s) {
+        Object temp = array[r];
+        array[r] = array[s];
+        array[s] = temp;
+    }
+
+    private static <T extends Element<T>> void scale(T[] array, T scalar) {
+        for (int col = 0; col < array.length; col++) {
+            array[col] = scalar.times(array[col]);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Element<T>> void pivot(Object[][] matrix, int row, T scalar, int rank) {
+        for (int col = 0; col < columns(matrix); col++) {
+            matrix[row][col] = ((T) matrix[row][col]).plus(((T) matrix[rank][col]).times(scalar));
+        }
     }
 }

--- a/core/src/test/java/com/vzome/core/algebra/AlgebraicFieldTest.java
+++ b/core/src/test/java/com/vzome/core/algebra/AlgebraicFieldTest.java
@@ -1,5 +1,6 @@
 package com.vzome.core.algebra;
 
+import static com.vzome.core.generic.Utilities.getSourceCodeLine;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
@@ -47,16 +48,333 @@ public class AlgebraicFieldTest {
         assertEquals(fields.size(), pass);
 	}    
 
-    	@Test
-    	public void testReciprocal()
-    	{
-    		for( AlgebraicField field : fields ) {
-    			try {
-    				field .zero() .reciprocal() .evaluate();
-    				fail( "Zero divide should throw an exception" );
-    			} catch ( RuntimeException re ) {
-    				assertEquals( "Denominator is zero", re .getMessage() );
-    			}
-    		}
-    	}
+	@Test
+	public void testReciprocal()
+	{
+		for( AlgebraicField field : fields ) {
+			try {
+				field .zero() .reciprocal() .evaluate();
+				fail( "Zero divide should throw an exception" );
+			} catch ( RuntimeException re ) {
+				assertEquals( "Denominator is zero", re .getMessage() );
+			}
+		}
+	}
+
+    @Test
+    public void testGaussJordanReduction()
+    {
+        int[][] matrix = {
+            // first column is not a pivot column.
+            // rows == columns
+            // rank == 1
+            //  both rows are identical 
+            //  so result should have row 0 unchanged 
+            // and all 0's in row 1
+            {  0,  1 },
+            {  0,  1 },
+        };
+        int[][] expected = {
+            {  0,  1, },
+            {  0,  0, },
+        };
+        verifyGaussJordanReduction(matrix, matrix, expected, 1);
+
+        matrix = new int[][] {
+            {  0,  2,  0,  0, },
+            {  0,  0,  0,  2, },
+            {  2,  0,  0,  0, },
+            {  0,  0,  2,  0, },
+            {  1,  2, -2,  1, },
+        };
+        expected = new int[][] {
+            {  1,  0,  0,  0, },
+            {  0,  1,  0,  0, },
+            {  0,  0,  1,  0, },
+            {  0,  0,  0,  1, },
+            {  0,  0,  0,  0, },
+        };
+        verifyGaussJordanReduction(matrix, matrix, expected, 4);
+    
+        matrix = new int[][] {
+            // intermediate column is not a pivot column.
+            // rows < columns
+            // rank == 2
+            {  0,  0,  0,  0,  0,  0, },
+            {  0,  1,  0,  0,  0,  0, },
+            {  0,  0,  0,  0,  0,  0, },
+            {  0,  0,  0,  0,  1,  0, },
+        };
+        expected = new int[][] {
+            {  0,  1,  0,  0,  0,  0, },
+            {  0,  0,  0,  0,  1,  0, },
+            {  0,  0,  0,  0,  0,  0, },
+            {  0,  0,  0,  0,  0,  0, },
+        };
+        verifyGaussJordanReduction(matrix, matrix, expected, 2);
+
+        matrix = new int[][] {
+            // intermediate row is not a pivot row.
+            // rows > columns
+            // rank == 2
+            {  0,  0,  0,  0, },
+            {  0,  0,  1,  0, },
+            {  0,  0,  0,  0, },
+            {  0,  0,  0,  0, },
+            {  0,  1,  0,  0, },
+            {  0,  0,  0,  0, },
+        };
+        expected = new int[][] {
+            {  0,  1,  0,  0, },
+            {  0,  0,  1,  0, },
+            {  0,  0,  0,  0, },
+            {  0,  0,  0,  0, },
+            {  0,  0,  0,  0, },
+            {  0,  0,  0,  0, },
+        };
+        verifyGaussJordanReduction(matrix, matrix, expected, 2);
+
+        matrix = new int[][] {
+            {  1,  4,  6,  7, },
+            { -3, -7, -8, -6, },
+            {  2, 12, 17, 32, },
+        };
+        expected = new int[][] {
+            {  1,  0,  0, -9, },
+            {  0,  1,  0,  7, },
+            {  0,  0,  1, -2, },
+        };
+        verifyGaussJordanReduction(matrix, matrix, expected, 3);
+    }
+    
+    @Test
+    public void testGaussJordanReductionAdjoined()
+    {
+        int[][] matrix = {
+            {  1,  4,  6, },
+            { -3, -7, -8, },
+            {  2, 12, 17, },
+        };
+        int[][] adjoined = {
+            {  7, },
+            { -6, },
+            { 32, },
+        };
+        int[][] expected = {
+            { -9, },
+            {  7, },
+            { -2, },
+        };
+        verifyGaussJordanReduction(matrix, adjoined, expected, matrix[0].length);
+    
+        matrix = new int[][] {
+            // n   m   l   k   j   i   h     // 30 = 5 * 3 * 2
+            {  1,  0,  0,  0,  0,  0,  0, }, // 10 = 5 * 2
+            {  0,  1,  0,  0,  0,  0,  0, },
+            {  0,  0,  1,  0,  0,  0,  0, },
+            {  0,  0,  0,  1,  0,  0,  0, },
+            {  0,  0,  0,  0,  1,  0, -1, },
+
+            {  1,  0,  0,  0,  0,  0, -2, }, // 6 = 3 * 2
+            {  0,  1,  0,  0,  0, -1,  0, },
+            {  0,  0,  1,  0, -1,  0,  0, }, 
+        };
+        adjoined = new int[][] {
+            // g   f   e   d   c   b   a   1     // 30 = 5 * 3 * 2
+            {  0,  0,  0,  2,  0,  0,  0,  0, }, // 10 = 5 * 2
+            {  0,  0,  1,  0,  1,  0,  0,  0, },
+            {  0,  1,  0,  0,  0,  1,  0,  0, },
+            {  1,  0,  0,  0,  0,  0,  1,  0, },
+            {  0,  0,  0,  0,  0,  0,  0,  1, },
+
+            {  0,  0,  0,  0,  0, -2,  0,  0, }, // 6 = 3 * 2
+            {  1,  0,  0,  0, -1,  0, -1,  0, },
+            {  0,  1,  0, -1,  0,  0,  0, -1, }, 
+        };
+        expected  = new int[][] {
+            // g   f   e   d   c   b   a   1     // 30 = 5 * 3 * 2
+            {  0,  0,  0,  2,  0,  0,  0,  0, },
+            {  0,  0,  1,  0,  1,  0,  0,  0, },
+            {  0,  1,  0,  0,  0,  1,  0,  0, },
+            {  1,  0,  0,  0,  0,  0,  1,  0, },
+            {  0,  0,  0,  1,  0,  1,  0,  1, },
+            { -1,  0,  1,  0,  2,  0,  1,  0, },
+            {  0,  0,  0,  1,  0,  1,  0,  0, },
+            {  0,  0,  0,  0,  0,  0,  0,  0, },
+        };
+        verifyGaussJordanReduction(matrix, adjoined, expected, matrix[0].length);
+ 
+        matrix = new int[][] {
+            // p   o   n   m   l     // 35 = 7 * 5
+            {  1,  0,  0,  0,  0, }, // 7
+            {  0,  1,  0,  0,  0, },
+            {  0,  0,  1,  0, -1, },
+
+            {  1,  0,  0,  0, -1, }, // 5
+            {  0,  1,  0, -1,  0, },
+        };
+        adjoined = new int[][] {
+            // k   j   i   h   g   f   e   d   c   b   a   1     // 35 = 7 * 5
+            {  0,  1,  1,  0,  0,  0,  0,  0, -1, -1,  0,  0, }, // 7
+            {  1,  0,  0,  1,  0,  0,  0, -1,  0,  0, -1,  0, },
+            {  0,  0,  0,  0,  1,  0, -1,  0,  0,  0,  0, -1, },
+
+            {  1,  0,  0,  0, -1, -1,  0,  0,  0,  1,  1,  0, }, // 5
+            {  0,  1,  0, -1,  0,  0, -1,  0,  1,  0,  0,  1, },
+        };
+        expected = new int[][] {
+            // k   j   i   h   g   f   e   d   c   b   a   1     // 35 = 7 * 5
+            {  0,  1,  1,  0,  0,  0,  0,  0, -1, -1,  0,  0, },
+            {  1,  0,  0,  1,  0,  0,  0, -1,  0,  0, -1,  0, },
+            { -1,  1,  1,  0,  2,  1, -1,  0, -1, -2, -1, -1, },
+            {  1, -1,  0,  2,  0,  0,  1, -1, -1,  0, -1, -1, },
+            { -1,  1,  1,  0,  1,  1,  0,  0, -1, -2, -1,  0, },
+        };
+        verifyGaussJordanReduction(matrix, adjoined, expected, matrix[0].length);
+
+        matrix = new int[][] {
+            // C   B   A   z   y   x   w   v   u   t   s   r   q   p     // 60 = 5 * 3 * 2 * 2
+            {  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, }, // 20 = 5 * 2 * 2
+            {  0,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, },
+            {  0,  0,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, },
+            {  0,  0,  0,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, },
+            {  0,  0,  0,  0,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0, },
+            {  0,  0,  0,  0,  0,  1,  0,  0,  0,  0,  0,  0,  0,  0, },
+            {  0,  0,  0,  0,  0,  0,  1,  0,  0,  0,  0,  0,  0,  0, },
+            {  0,  0,  0,  0,  0,  0,  0,  1,  0,  0,  0,  0,  0, -1, },
+            {  0,  0,  0,  0,  0,  0,  0,  0,  1,  0,  0,  0, -1,  0, },
+            {  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  0, -1,  0,  0, },
+            
+            {  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, -2,  0, }, // 12 = 3 * 2 * 2
+            {  0,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0, -1,  0, -1, },
+            {  0,  0,  1,  0,  0,  0,  0,  0,  0,  0, -1,  0,  0,  0, },
+            {  0,  0,  0,  1,  0,  0,  0,  0,  0, -1,  0,  0,  0,  0, },
+            {  0,  0,  0,  0,  1,  0,  0,  0, -1,  0,  0,  0,  0,  0, },
+            {  0,  0,  0,  0,  0,  1,  0, -1,  0,  0,  0,  0,  0,  0, },
+        };
+        adjoined = new int[][] {
+            // o   n   m   l   k   j   i   h   g   f   e   d   c   b   a   1     // 60 = 5 * 3 * 2 * 2
+            {  0,  0,  0,  0,  0,  0,  2,  0,  0,  0,  0,  0,  0,  0,  0,  0, }, // 20 = 5 * 2 * 2
+            {  0,  0,  0,  0,  0,  1,  0,  1,  0,  0,  0,  0,  0,  0,  0,  0, },
+            {  0,  0,  0,  0,  1,  0,  0,  0,  1,  0,  0,  0,  0,  0,  0,  0, },
+            {  0,  0,  0,  1,  0,  0,  0,  0,  0,  1,  0,  0,  0,  0,  0,  0, },
+            {  0,  0,  1,  0,  0,  0,  0,  0,  0,  0,  1,  0,  0,  0,  0,  0, },
+            {  0,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  0,  0,  0,  0, },
+            {  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  0,  0,  0, },
+            {  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  0,  0, },
+            {  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  0, },
+            {  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1, },
+
+            {  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, -2,  0,  0,  0,  0,  0, }, // 12 = 3 * 2 * 2
+            {  0,  0,  0,  0,  0,  0,  0,  0,  0, -1,  0, -1,  0,  0,  0,  0, },
+            {  1,  0,  0,  0,  0,  0,  0,  0, -1,  0,  0,  0, -1,  0,  0,  0, },
+            {  0,  1,  0,  0,  0,  0,  0, -1,  0,  0,  0,  0,  0, -1,  0,  0, },
+            {  0,  0,  1,  0,  0,  0, -1,  0,  0,  0,  0,  0,  0,  0, -1,  0, },
+            {  0,  0,  0,  1,  0, -1,  0,  0,  0,  0,  0,  0,  0,  0,  0, -1, },
+        };
+        expected = new int[][] {
+            // o   n   m   l   k   j   i   h   g   f   e   d   c   b   a   1     // 60 = 5 * 3 * 2 * 2
+            {  0,  0,  0,  0,  0,  0,  2,  0,  0,  0,  0,  0,  0,  0,  0,  0, },
+            {  0,  0,  0,  0,  0,  1,  0,  1,  0,  0,  0,  0,  0,  0,  0,  0, },
+            {  0,  0,  0,  0,  1,  0,  0,  0,  1,  0,  0,  0,  0,  0,  0,  0, },
+            {  0,  0,  0,  1,  0,  0,  0,  0,  0,  1,  0,  0,  0,  0,  0,  0, },
+            {  0,  0,  1,  0,  0,  0,  0,  0,  0,  0,  1,  0,  0,  0,  0,  0, },
+            {  0,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  0,  0,  0,  0, },
+            {  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  0,  0,  0, },
+            {  0,  1,  0, -1,  0,  1,  0,  0,  0,  0,  0,  1,  0,  0,  0,  1, },
+            {  0,  0,  0,  0,  0,  0,  1,  0,  0,  0,  1,  0,  0,  0,  1,  0, },
+            {  0, -1,  0,  1,  0,  0,  0,  1,  0,  1,  0,  0,  0,  1,  0,  0, },
+            { -1,  0,  0,  0,  1,  0,  0,  0,  2,  0,  0,  0,  1,  0,  0,  0, },
+            {  0, -1,  0,  1,  0,  0,  0,  1,  0,  1,  0,  0,  0,  1,  0, -1, },
+            {  0,  0,  0,  0,  0,  0,  1,  0,  0,  0,  1,  0,  0,  0,  0,  0, },
+            {  0,  1,  0, -1,  0,  1,  0,  0,  0,  0,  0,  1,  0, -1,  0,  1, },
+            {  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, },
+            {  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, },
+        };
+        verifyGaussJordanReduction(matrix, adjoined, expected, matrix[0].length);
+    }
+    
+    private static void verifyGaussJordanReduction(int[][] intMatrix, int[][] intAdjoined, int[][] intExpected, int expectedRank) {
+        final BigRational[][] matrix = BigRational.newMatrix(intMatrix);
+        final BigRational[][] adjoined = BigRational.newMatrix(intAdjoined);
+        final BigRational[][] expected = BigRational.newMatrix(intExpected);
+                
+        System.out.println("-----------------------------------------------------");
+        System.out.println(getSourceCodeLine(2));
+        System.out.println("Initial Augmented Matrices:");
+        showMatrices(matrix, adjoined);
+        int rank = Fields.gaussJordanReduction(matrix, adjoined);
+        System.out.println("Rank = " + rank);
+        System.out.println("Adjoined matrix reduced:");
+        showMatrix(adjoined);
+        
+        assertEquals(expectedRank, rank);
+        assertEquals(expected.length, matrix.length);
+        assertEquals(expected.length, adjoined.length);
+        
+        for(int r = 0; r < adjoined.length; r++ ) {
+            String msg = "adjoined[" + r + "].length";
+            assertEquals(msg, expected[r].length, adjoined[r].length);
+        }
+        for(int r = 0; r < adjoined.length; r++ ) {
+            for(int c = 0; c < adjoined[0].length; c++ ) {
+                String msg = "adjoined[" + r + "][" + c + "]";
+                assertEquals(msg, expected[r][c], adjoined[r][c]);
+            }
+        }
+
+        if(rank < expected.length) {
+            for(int r = rank; r < adjoined.length; r++ ) {
+                for(int c = 0; c < adjoined[0].length; c++ ) {
+                    String msg = "adjoined[" + r + "][" + c + "]";
+                    assertTrue(msg, adjoined[r][c].isZero());
+                }
+            }
+        }
+    }
+    
+    private static void showMatrix(BigRational[][] matrix) {
+        StringBuffer buf = new StringBuffer();
+        buf.append("{\n");
+        for(int r = 0; r < matrix.length; r++) {
+            buf.append("    { ");
+            for(int c = 0; c < matrix[r].length; c++) {
+                buf.append(paddedString(matrix[r][c]));
+                buf.append(", ");
+            }
+            buf.append("},\n");
+        }
+        buf.append("}");
+        System.out.println(buf.toString());
+    }
+
+    private static void showMatrices(BigRational[][] matrix, BigRational[][] adjoined) {
+        StringBuffer buf = new StringBuffer();
+        final String delim = "  ";
+        for(int r = 0; r < matrix.length; r++) {
+            buf.append(" ");
+            for(int c = 0; c < matrix[r].length; c++) {
+                buf.append(nzPaddedString(matrix[r][c]));
+                buf.append(delim);
+            }
+            buf.deleteCharAt(buf.length()-1);
+            buf.append("|");
+            for(int c = 0; c < adjoined[r].length; c++) {
+                buf.append(nzPaddedString(adjoined[r][c]));
+                buf.append(delim);
+            }
+          buf.append("\n");
+        }
+        System.out.println(buf.toString());
+    }
+    
+    private static String paddedString(BigRational b) {
+        return (b.isNegative() ? "" : " ") + b.toString();
+    }
+
+    private static String nzPaddedString(BigRational b) {
+     // replace zero values with underscores to make non-zero values stand out
+        return b.isZero() ? " _" : paddedString(b); 
+    }
+
 }


### PR DESCRIPTION
The original GaussJordanReduction method only worked with square matrices. This was OK since it was only ever called by invert() which only uses square matrices. However, I found that I need to use GausJordanReduction on non-square matrices in my parameterizedField branch, so I an introducing these changes and test cases as a stand-alone commit to be merged into master ASAP.