### PR TITLE
Fixed the bug with the "outlines" checkbox

### DIFF
--- a/desktop/src/main/java/com/vzome/desktop/controller/CameraController.java
+++ b/desktop/src/main/java/com/vzome/desktop/controller/CameraController.java
@@ -452,6 +452,9 @@ public class CameraController extends DefaultController implements Controller3d
         case "drawOutlines": // for the trackball rendering
             return "false";
 
+        case "docDrawOutlines": // for the checkbox
+            return super .getProperty( "drawOutlines" );
+
         case "showIcosahedralLabels":
             // TODO refactor to fix this
             if ( super .propertyIsTrue( "isIcosahedralSymmetry" ) )

--- a/desktop/src/main/java/org/vorthmann/zome/ui/CameraControlPanel.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/CameraControlPanel.java
@@ -134,7 +134,7 @@ public class CameraControlPanel extends JPanel {
         //   checkbox .setHorizontalAlignment( SwingConstants.LEFT );
         outlinesCheckbox .addActionListener( controller );
         outlinesCheckbox .setActionCommand( "toggleOutlines" );
-        outlinesCheckbox .setSelected( "true" .equals( controller .getProperty( "drawOutlines" ) ) );
+        outlinesCheckbox .setSelected( "true" .equals( controller .getProperty( "docDrawOutlines" ) ) );
         checkboxesPanel .add( outlinesCheckbox );
         
         this .addMouseWheelListener( new MouseWheelListener()


### PR DESCRIPTION
Initial state of the checkbox was out of sync.

The problem was that the CameraController needs a permanent "false"
value for the drawOutlines property, for rendering the trackball, but
needs to use the parent property to drive the checkbox.