### PR TITLE
Remove the undo/redo behavior change for developers

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/UndoRedoController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/UndoRedoController.java
@@ -23,11 +23,11 @@ public class UndoRedoController extends DefaultController implements Controller
         switch ( action ) {
 
         case "undo":
-            this .model .undo( ! this .userHasEntitlement( "developer.extras" ) );
+            this .model .undo( true );
             break;
 
         case "redo":
-            this .model .redo( ! this .userHasEntitlement( "developer.extras" ) );
+            this .model .redo( true );
             break;
 
         case "undoToBreakpoint":


### PR DESCRIPTION
With useBlocks=false, one can undo part of a begin/end block, which
breaks invariants.