### PR TITLE
Command-line file arguments avoid openurl

### DIFF
--- a/core/src/main/java/com/vzome/core/editor/Application.java
+++ b/core/src/main/java/com/vzome/core/editor/Application.java
@@ -83,7 +83,7 @@ public class Application
         properties = loadDefaults();
         if ( overrides != null )
         {
-        	properties .putAll( overrides );
+            properties .putAll( overrides );
         }
         properties .putAll( loadBuildProperties() );
 
@@ -119,7 +119,7 @@ public class Application
         this .exporters .put( "seg", new SegExporter( null, this .mColors, this .mLights, null ) );
         this .exporters .put( "ply", new PlyExporter( this .mColors, this .mLights ) );
         this .exporters .put( "history", new HistoryExporter( null, this .mColors, this .mLights, null ) );
-        
+
         this .exporters2d .put( "pdf", PDFExporter::new );
         this .exporters2d .put( "svg", SVGExporter::new );
         this .exporters2d .put( "ps",  PostScriptExporter::new );
@@ -127,7 +127,7 @@ public class Application
         // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
         this.fieldAppSuppliers.put("golden", GoldenFieldApplication::new);
         this.fieldAppSuppliers.put("rootTwo", RootTwoFieldApplication::new);
-		this.fieldAppSuppliers.put("rootThree", RootThreeFieldApplication::new);
+        this.fieldAppSuppliers.put("rootThree", RootThreeFieldApplication::new);
         this.fieldAppSuppliers.put("dodecagon", RootThreeFieldApplication::new);
         this.fieldAppSuppliers.put("heptagon", HeptagonFieldApplication::new);
         this.fieldAppSuppliers.put("snubDodec", SnubDodecFieldApplication::new);
@@ -140,14 +140,14 @@ public class Application
 
         // parse the bytes as XML
         try {
-        	DocumentBuilderFactory factory = DocumentBuilderFactory .newInstance();
-        	factory .setNamespaceAware( true );
-        	DocumentBuilder builder = factory .newDocumentBuilder();
-        	xml = builder .parse( bytes );
+            DocumentBuilderFactory factory = DocumentBuilderFactory .newInstance();
+            factory .setNamespaceAware( true );
+            DocumentBuilder builder = factory .newDocumentBuilder();
+            xml = builder .parse( bytes );
             bytes.close();
-        } catch ( SAXException e ) {
-//            String errorCode = "XML is bad:  " + e.getMessage() + " at line " + e.getLineNumber() + ", column "
-//                    + e.getColumnNumber();
+        } catch ( SAXException | IOException e ) {
+            //            String errorCode = "XML is bad:  " + e.getMessage() + " at line " + e.getLineNumber() + ", column "
+            //                    + e.getColumnNumber();
             logger .severe( e .getMessage() );
             throw e;
         }
@@ -182,92 +182,92 @@ public class Application
         return new DocumentModel( kind, failures, element, this );
     }
 
-	public DocumentModel createDocument( String fieldName )
-	{
-		FieldApplication kind = this .getDocumentKind( fieldName );
-		return new DocumentModel( kind, failures, null, this );
-	}
+    public DocumentModel createDocument( String fieldName )
+    {
+        FieldApplication kind = this .getDocumentKind( fieldName );
+        return new DocumentModel( kind, failures, null, this );
+    }
 
-	public DocumentModel importDocument( String content, String extension )
-	{
-		String fieldName = "golden";
-		// TODO: use fieldName from VEF input
-		FieldApplication kind = this .getDocumentKind( fieldName );
-		DocumentModel result = new DocumentModel( kind, failures, null, this );
+    public DocumentModel importDocument( String content, String extension )
+    {
+        String fieldName = "golden";
+        // TODO: use fieldName from VEF input
+        FieldApplication kind = this .getDocumentKind( fieldName );
+        DocumentModel result = new DocumentModel( kind, failures, null, this );
         Map<String,Object> props = new HashMap<>();
         props .put( "script", content );
-		result .doEdit( extension, props );
-		return result;
-	}
+        result .doEdit( extension, props );
+        return result;
+    }
 
-	public AlgebraicField getField( String name )
-	{
-		return this .getDocumentKind( name ) .getField();
-	}
+    public AlgebraicField getField( String name )
+    {
+        return this .getDocumentKind( name ) .getField();
+    }
 
-	public FieldApplication getDocumentKind( String name )
-	{
+    public FieldApplication getDocumentKind( String name )
+    {
         Supplier<FieldApplication> supplier = fieldAppSuppliers.get(name);
         if( supplier != null ) {
             return supplier.get();
         }
         throw new IllegalArgumentException("Unknown Application Type " + name);
-	}
+    }
 
-	public Set<String> getFieldNames()
-	{
+    public Set<String> getFieldNames()
+    {
         return fieldAppSuppliers.keySet();
-	}
+    }
 
-	public static Properties loadDefaults()
-	{
+    public static Properties loadDefaults()
+    {
         String defaultRsrc = "com/vzome/core/editor/defaultPrefs.properties";
         Properties defaults = new Properties();
         try {
             ClassLoader cl = Application.class.getClassLoader();
             InputStream in = cl.getResourceAsStream( defaultRsrc );
             if ( in != null )
-            	defaults .load( in );
+                defaults .load( in );
         } catch ( IOException ioe ) {
             System.err.println( "problem reading default preferences: " + defaultRsrc );
         }
         return defaults;
-	}
+    }
 
-	public static Properties loadBuildProperties()
-	{
+    public static Properties loadBuildProperties()
+    {
         String defaultRsrc = "vzome-core-build.properties";
         Properties defaults = new Properties();
         try {
             ClassLoader cl = Application.class.getClassLoader();
             InputStream in = cl.getResourceAsStream( defaultRsrc );
             if ( in != null )
-            	defaults .load( in );
+                defaults .load( in );
         } catch ( IOException ioe ) {
             logger.warning( "problem reading build properties: " + defaultRsrc );
         }
         return defaults;
-	}
+    }
 
-	public Colors getColors()
-	{
-		return this .mColors;
-	}
+    public Colors getColors()
+    {
+        return this .mColors;
+    }
 
     public Exporter3d getExporter( String format )
     {
         return this .exporters .get( format );
     }
 
-	public Lights getLights()
-	{
-		return this .mLights;
-	}
+    public Lights getLights()
+    {
+        return this .mLights;
+    }
 
-	public String getCoreVersion()
-	{
-		return this .properties .getProperty( "version" );
-	}
+    public String getCoreVersion()
+    {
+        return this .properties .getProperty( "version" );
+    }
 
     public SnapshotExporter getSnapshotExporter( String format )
     {

--- a/desktop/platform/mac/src/main/java/com/vzome/platform/mac/Adapter.java
+++ b/desktop/platform/mac/src/main/java/com/vzome/platform/mac/Adapter.java
@@ -31,11 +31,7 @@ public class Adapter
     public static void main( String[] args )
     {
         try {
-            // These four lines duplicate ApplicationUI.main()
-            String prop = System .getProperty( "user.dir" );
-            File workingDir = new File( prop );
-            URL codebase = workingDir .toURI() .toURL();
-            final ApplicationUI ui = ApplicationUI .initialize( args, codebase );
+            final ApplicationUI ui = ApplicationUI .initialize( args );
             
             // Now hook it up to the Finder events
             Application appl = Application .getApplication();

--- a/desktop/src/main/java/org/vorthmann/j3d/Platform.java
+++ b/desktop/src/main/java/org/vorthmann/j3d/Platform.java
@@ -5,6 +5,8 @@ import java.awt.event.ActionEvent;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.AccessControlException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -43,9 +45,9 @@ public class Platform
         return isWindows? "vZomeLogs" : isMac? "Library/Logs/vZome" : "vZomeLogs";
     }
     
-    public static File logsFolder()
+    public static Path logsFolder()
     {
-        return new File( System.getProperty( "user.home" ), logsPath() );
+        return Paths .get( System.getProperty( "user.home" ), logsPath() );
     }
 	
 	public static void openApplication( File file )

--- a/desktop/src/main/java/org/vorthmann/zome/ui/ApplicationUI.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/ApplicationUI.java
@@ -15,6 +15,7 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -227,6 +228,10 @@ public final class ApplicationUI implements ActionListener, PropertyChangeListen
                     } catch ( MalformedURLException | URISyntaxException e ) {
                         // probably just on Mac or Linux
                         normalizedPath = Paths .get( arg );
+                    } catch ( FileSystemNotFoundException e ) {
+                        // Someone passed an HTTP URL, and Paths.get() can't handle it.
+                        logger.warning( "URL command-line arguments are not supported." );
+                        continue; // leave fileArgument as null
                     }
                     fileArgument = normalizedPath .toAbsolutePath() .normalize();
                     logger.info( "Normalized file argument: " + fileArgument );
@@ -332,7 +337,8 @@ public final class ApplicationUI implements ActionListener, PropertyChangeListen
         case "openURL":
             String str = JOptionPane .showInputDialog( null, "Enter the URL for an online .vZome file.", "Open URL",
                     JOptionPane.PLAIN_MESSAGE );
-            mController .actionPerformed( new ActionEvent( this, ActionEvent.ACTION_PERFORMED, "openURL-" + str ) );
+            if ( str != null )
+                mController .actionPerformed( new ActionEvent( this, ActionEvent.ACTION_PERFORMED, "openURL-" + str ) );
             break;
 
         case "quit":


### PR DESCRIPTION
On Windows, drag-n-drop or double-click results in a file URI being
passed as a command-line argument.  To handle this, we were treating all
command-line path arguments as URLs, and the "openurl" action had code
to handle File URIs.

A better way is to treat paths we *know* are files as files, and use the
"open" action.  "openurl" is reserved for the menu command, and file URIs
are NOT supported there.

Unfortunately, the diffs in ApplicationUI are obscured by reformatting.
Note that we deal with Windows immediately on line 223.  Note also that
we no longer use "defaultAction"... instead we have the if stmt on line 286.