### PR TITLE
Add 2 new "Nearest Predefined Orbit" Color Maps

### DIFF
--- a/core/src/main/java/com/vzome/core/edits/ManifestationColorMappers.java
+++ b/core/src/main/java/com/vzome/core/edits/ManifestationColorMappers.java
@@ -14,9 +14,8 @@ import com.vzome.core.algebra.AlgebraicNumber;
 import com.vzome.core.algebra.AlgebraicVector;
 import com.vzome.core.algebra.AlgebraicVectors;
 import com.vzome.core.commands.Command.Failure;
-import com.vzome.core.editor.Manifestations;
-import com.vzome.core.editor.SymmetrySystem;
 import com.vzome.core.editor.Manifestations.ManifestationIterator;
+import com.vzome.core.editor.SymmetrySystem;
 import com.vzome.core.edits.ColorMappers.ColorMapper;
 import com.vzome.core.math.DomUtils;
 import com.vzome.core.math.symmetry.Axis;
@@ -94,6 +93,8 @@ public class ManifestationColorMappers {
             : mapperName.equals("SystemCentroidColorMap") ? new SystemCentroidColorMap(symm)
             : mapperName.equals("NearestSpecialOrbitColorMap") ? new NearestSpecialOrbitColorMap(symm)
             : mapperName.equals("CentroidNearestSpecialOrbitColorMap") ? new CentroidNearestSpecialOrbitColorMap(symm)
+            : mapperName.equals("NearestPredefinedOrbitColorMap") ? new NearestPredefinedOrbitColorMap(symm)
+            : mapperName.equals("CentroidNearestPredefinedOrbitColorMap") ? new CentroidNearestPredefinedOrbitColorMap(symm)
             : ManifestationColorMappers.getColorMapper(mapperName);
 
         if (colorMapper == null) {
@@ -647,7 +648,7 @@ public class ManifestationColorMappers {
      * Gets standard color of the nearest special orbit using the standard color basis
      */
     public static class NearestSpecialOrbitColorMap extends SystemColorMap {
-        protected final Set<Direction> specialOrbits = new LinkedHashSet<>(); // maintains insert order.
+        protected Set<Direction> specialOrbits = new LinkedHashSet<>(); // maintains insert order.
 
         protected NearestSpecialOrbitColorMap(SymmetrySystem symm) {
             super(symm);
@@ -668,7 +669,7 @@ public class ManifestationColorMappers {
 
         @Override
         protected Color applyTo(Panel panel, int alpha) {
-            return applyTo(panel.getNormal());
+            return applyTo(panel.getNormal()).getPastel();
         }
 
         @Override
@@ -703,8 +704,29 @@ public class ManifestationColorMappers {
 
         @Override
         protected Color applyTo(Panel panel, int alpha) {
-            return applyTo(panel.getCentroid());
+            return applyTo(panel.getCentroid()).getPastel();
         }
     }
 
+    /**
+     * Gets standard color of the nearest predefined orbit using the symmetry's standard color scheme
+     */
+    public static class NearestPredefinedOrbitColorMap extends NearestSpecialOrbitColorMap {
+        protected NearestPredefinedOrbitColorMap(SymmetrySystem symm) {
+            super(symm);
+            // setting specialOrbits to null will use the predefined orbits of the symmetery
+            specialOrbits = null;
+        }
+    }
+
+    /**
+     * Gets standard color of the nearest predefined orbit based on the centroid of each manifestation
+     */
+    public static class CentroidNearestPredefinedOrbitColorMap extends CentroidNearestSpecialOrbitColorMap {
+        protected CentroidNearestPredefinedOrbitColorMap(SymmetrySystem symm) {
+            super(symm);
+            // setting specialOrbits to null will use the predefined orbits of the symmetery
+            specialOrbits = null;
+        }
+    }
 }

--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentMenuBar.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentMenuBar.java
@@ -294,6 +294,8 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
                 submenu2 .add( enableIf( isEditor, createMenuItem( "To Coordinate Plane", mapToColor + "CoordinatePlaneColorMap" ) ) );
                 submenu2 .add( enableIf( isEditor, createMenuItem( "System Colors", mapToColor + "SystemColorMap" ) ) );
                 submenu2 .add( enableIf( isEditor, createMenuItem( "System by Centroid", mapToColor + "SystemCentroidColorMap" ) ) );
+                submenu2 .add( enableIf( isEditor, createMenuItem( "Nearest Predefined Orbit", mapToColor + "NearestPredefinedOrbitColorMap" ) ) );
+                submenu2 .add( enableIf( isEditor, createMenuItem( "Nearest Predefined Orbit by Centroid", mapToColor + "CentroidNearestPredefinedOrbitColorMap" ) ) );
                 submenu2 .add( enableIf( isEditor, createMenuItem( "Nearest Special Orbit", mapToColor + "NearestSpecialOrbitColorMap" ) ) );
                 submenu2 .add( enableIf( isEditor, createMenuItem( "Nearest Special Orbit by Centroid", mapToColor + "CentroidNearestSpecialOrbitColorMap" ) ) );
                 submenu.add(submenu2);


### PR DESCRIPTION
These color maps will set the color of automatic struts and panels to the same color as the nearest predefined (non-automatic) direction for the current symmetry. It's a convenient way to show what predefined direction is closest to a given automatic direction.  Earlier versions of vZome will treat unrecognized color maps as no-ops, so they can still open a model that uses this new color mapping.