### PR TITLE
Color now attached to Manifestation

### DIFF
--- a/core/src/main/java/com/vzome/core/model/Manifestation.java
+++ b/core/src/main/java/com/vzome/core/model/Manifestation.java
@@ -11,6 +11,7 @@ import org.w3c.dom.Element;
 
 import com.vzome.core.algebra.AlgebraicVector;
 import com.vzome.core.construction.Construction;
+import com.vzome.core.render.Color;
 import com.vzome.core.render.RenderedManifestation;
 
 /**
@@ -25,6 +26,8 @@ public abstract class Manifestation implements GroupElement
     private boolean hidden = false;
 
     private int mId = NO_ID;
+
+    private Color color;
 
     private static final int NO_ID = -1;
 
@@ -71,6 +74,16 @@ public abstract class Manifestation implements GroupElement
     public boolean isUnnecessary()
     {
         return mManifests .isEmpty();
+    }
+    
+    public Color getColor()
+    {
+        return this.color;
+    }
+
+    public void setColor( Color color )
+    {
+        this.color = color;
     }
 
     public void setRenderedObject( RenderedManifestation obj )

--- a/core/src/main/java/com/vzome/core/model/RealizedModel.java
+++ b/core/src/main/java/com/vzome/core/model/RealizedModel.java
@@ -193,6 +193,7 @@ public class RealizedModel implements Iterable<Manifestation> //implements Const
     
     public void setColor( Manifestation m, Color color )
     {
+        m .setColor( color );
         if ( m .isRendered() ) {
             for (ManifestationChanges next : mListeners) {
                 next .manifestationColored( m, color );

--- a/core/src/main/java/com/vzome/core/render/RenderedManifestation.java
+++ b/core/src/main/java/com/vzome/core/render/RenderedManifestation.java
@@ -26,8 +26,6 @@ public class RenderedManifestation
     private Polyhedron mShape;
     
     private RenderedModel model;
-
-	private String mColorName;
     
     private Color color = null;
     
@@ -258,7 +256,6 @@ public class RenderedManifestation
         RenderedManifestation copy = new RenderedManifestation( null );
         copy .location = this .location;
         copy .fixedLocation = this .fixedLocation;
-        copy .mColorName = this .mColorName;
         copy .color = this .color;
         copy .mGlow = this .mGlow;
         copy .mOrientation = this .mOrientation;

--- a/core/src/main/java/com/vzome/core/render/RenderedModel.java
+++ b/core/src/main/java/com/vzome/core/render/RenderedModel.java
@@ -361,7 +361,6 @@ public class RenderedModel implements ManifestationChanges, Iterable<RenderedMan
 
     private void resetAttributes( RenderedManifestation rm, boolean justShape )
 	{
-        Color oldColor = rm .getColor();
 	    Manifestation m = rm .getManifestation();
         if ( m instanceof Connector ) {
             resetAttributes( rm, justShape, (Connector) m );
@@ -395,7 +394,9 @@ public class RenderedModel implements ManifestationChanges, Iterable<RenderedMan
         		
                 Direction orbit = axis .getDirection();
 
-                Color color = orbitSource .getColor( orbit ) .getPastel();
+                Color color = m .getColor();
+                if ( color == null )
+                    color = orbitSource .getColor( orbit ) .getPastel();
                 rm .setColor( color );
             } catch ( IllegalStateException e ) {
             	if ( logger .isLoggable( Level.WARNING ) )
@@ -404,8 +405,6 @@ public class RenderedModel implements ManifestationChanges, Iterable<RenderedMan
         }
         else
             throw new UnsupportedOperationException( "only strut, ball, and panel shapes currently supported" );
-	    if ( oldColor != null )
-	        rm .setColor( oldColor );
 	}
 
 	protected void resetAttributes( RenderedManifestation rm, boolean justShape, Strut strut )
@@ -464,7 +463,9 @@ public class RenderedModel implements ManifestationChanges, Iterable<RenderedMan
 		if ( justShape )
 		    return;
 		
-		Color color = mPolyhedra .getColor( orbit );
+        Color color = rm .getManifestation() .getColor();
+        if ( color == null )
+            color = mPolyhedra .getColor( orbit );
 		if ( color == null )
 			color = orbitSource .getColor( orbit );
 		rm .setColor( color );
@@ -475,9 +476,11 @@ public class RenderedModel implements ManifestationChanges, Iterable<RenderedMan
 		rm .setShape( mPolyhedra .getConnectorShape() );
 		if ( justShape )
 		    return;
-		Color color = mPolyhedra .getColor( null );
-		if ( color == null )
-			color = orbitSource .getColor( null );
+		Color color = rm .getManifestation() .getColor();
+        if ( color == null )
+            color = mPolyhedra .getColor( null );
+        if ( color == null )
+            color = orbitSource .getColor( null );
 		rm .setColor( color );
 		rm .setOrientation( field .identityMatrix( 3 ) );
 	}


### PR DESCRIPTION
Default Manifestation color is still null.  If null, the current coloring rules apply, first
using the rendering style then the symmetry.  Coloring a Manifestation means that
the specific color will always apply.  Hide/show and delete+undo restore colors,
since the colors are stored in the Manifestations in the history.