### PR TITLE
Set Connector color to WHITE instead of null

### DIFF
--- a/core/src/main/java/com/vzome/core/edits/ManifestationColorMappers.java
+++ b/core/src/main/java/com/vzome/core/edits/ManifestationColorMappers.java
@@ -248,13 +248,14 @@ public class ManifestationColorMappers {
         public void initialize(ManifestationIterator selection)
         throws Failure {
             if(color == null) { // if not already set by XML
+                Manifestation last = null;
                 for(Manifestation man : selection) {
                     if(man != null && man.isRendered()) {
-                        Color c = man.getRenderedObject().getColor();
-                        if(c != null) {
-                            this.color = c;
-                        }
+                        last = man;
                     }
+                }
+                if(last != null) {
+                    this.color = last.getColor();
                 }
             }
             if(color == null) {

--- a/core/src/main/java/com/vzome/core/model/Connector.java
+++ b/core/src/main/java/com/vzome/core/model/Connector.java
@@ -4,6 +4,7 @@ import com.vzome.core.algebra.AlgebraicField;
 import com.vzome.core.algebra.AlgebraicVector;
 import com.vzome.core.construction.Construction;
 import com.vzome.core.construction.FreePoint;
+import com.vzome.core.render.Color;
 
 /**
  * @author Scott Vorthmann
@@ -14,7 +15,7 @@ public class Connector extends Manifestation implements Comparable<Connector>
 	public Connector( AlgebraicVector loc )
 	{
 		super();
-		
+		this.setColor(Color.WHITE);
 		m_center = loc;
 	}
 


### PR DESCRIPTION
Fix bug in CopyLastSelectedColor when last selected manifestation is a ball with a null color.