### PR TITLE
Fix missing log files

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/ui/ApplicationUI.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/ApplicationUI.java
@@ -14,7 +14,6 @@ import java.lang.management.RuntimeMXBean;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -98,7 +97,9 @@ public final class ApplicationUI implements ActionListener, PropertyChangeListen
         if (fh == null) {
             Path logsFolder = Platform.logsFolder();
             try {
-                Files .createDirectory( logsFolder );
+                if(! Files.exists(logsFolder)) {
+                    Files .createDirectory( logsFolder );
+                }
                 // If there is a log file naming conflict and no "%u" field has been specified, 
                 //  an incremental unique number will be added at the end of the filename after a dot.
                 // This behavior interferes with file associations based on the .log file extension.
@@ -110,7 +111,6 @@ public final class ApplicationUI implements ActionListener, PropertyChangeListen
                 // SV: I've reversed the %u and %g, so that sorting by name puts related logs together, in order.  The Finder / Explorer already
                 //   knows how to sort by date, so we don't need to support that.
                 fh = new FileHandler("%h/" + Platform.logsPath() + "/vZome60_%u_%g.log", 500000, 10);
-            } catch (FileAlreadyExistsException e1) {
             } catch (Exception e1) {
                 rootLogger.log(Level.WARNING, "unable to set up vZome file log handler", e1);
                 try {
@@ -124,6 +124,18 @@ public final class ApplicationUI implements ActionListener, PropertyChangeListen
                 rootLogger.addHandler(fh);
             }
         }
+        // The following reflection code generates a warning in Java 11 so I'm omitting it, 
+        // but still leaving it here so it can be uncommented for debugging
+//        if(fh != null) {
+//            try {
+//                Field privateFilesField = fh.getClass().getDeclaredField("files");
+//                privateFilesField.setAccessible(true);
+//                File[] files = (File[]) privateFilesField.get(fh);
+//                System.out.println("Log file " + files[0].getCanonicalPath());
+//            } catch(Exception ex) {
+//                ex.printStackTrace();
+//            }
+//        }
     }
 
     private static ApplicationUI theUI;


### PR DESCRIPTION
Logger's FileHandler was not being initialized if the log folder already existed. This resulted in no log files being generated. This was broke in commit d51257ec0369c74e631fd3c2ff133bbef75adcfc