### PR TITLE
Support for smarter shape changes

### DIFF
--- a/core/src/main/java/com/vzome/core/editor/DocumentModel.java
+++ b/core/src/main/java/com/vzome/core/editor/DocumentModel.java
@@ -211,7 +211,7 @@ public class DocumentModel implements Snapshot .Recorder, UndoableEdit .Context
             symmetrySys .createToolFactories( this .tools );
         }
 
-        this .kind .registerToolFactories( this .toolFactories, this .tools );
+        kind .registerToolFactories( this .toolFactories, this .tools );
 
         this .bookmarkFactory = new BookmarkTool.Factory( tools );
         this .editorModel .addSelectionSummaryListener( this .bookmarkFactory );
@@ -534,7 +534,7 @@ public class DocumentModel implements Snapshot .Recorder, UndoableEdit .Context
                 @Override
                 public QuaternionicSymmetry getQuaternionSet( String name )
                 {
-                    return kind .getQuaternionSymmetry( name);
+                    return kind .getQuaternionSymmetry( name );
                 }
             };
 
@@ -891,12 +891,14 @@ public class DocumentModel implements Snapshot .Recorder, UndoableEdit .Context
 
     public SymmetrySystem getSymmetrySystem( String name )
     {
-        return this .symmetrySystems .get( name );
+        if ( name == null )
+            return this .getSymmetrySystem();
+        else
+            return this .symmetrySystems .get( name );
     }
 
-    public void setSymmetrySystem( String name )
+    public void setSymmetrySystem( SymmetrySystem system )
     {
-        SymmetrySystem system = this .symmetrySystems .get( name );
         this .editorModel .setSymmetrySystem( system );
     }
 

--- a/core/src/main/java/com/vzome/core/render/RenderedModel.java
+++ b/core/src/main/java/com/vzome/core/render/RenderedModel.java
@@ -256,15 +256,6 @@ public class RenderedModel implements ManifestationChanges, Iterable<RenderedMan
 	    return mRendered .iterator();
 	}
 
-    /**
-    * @deprecated Consider using a JDK-5 for-loop if possible. Otherwise use {@link #iterator()} instead.
-    */
-    @Deprecated
-	public Iterator<RenderedManifestation> getRenderedManifestations()
-	{
-	    return mRendered .iterator();
-	}
-
 	public OrbitSource getOrbitSource()
 	{
 	    return this .orbitSource;
@@ -272,46 +263,24 @@ public class RenderedModel implements ManifestationChanges, Iterable<RenderedMan
 
     // TODO add changeScale( int increment )
 
+    public void setShapes( Shapes shapes )
+    {
+        boolean supported = this .mainListener .shapesChanged( shapes );
+        if ( ! supported )
+            // Oddity: this assumes that the orbitSource has already been updated
+            this .setOrbitSource( orbitSource ); // gets the job done, but overkill
+    }
+
 	public void setOrbitSource( OrbitSource orbitSource )
 	{
-        this.orbitSource = orbitSource;
+        this .orbitSource = orbitSource;
         this .enabled = true;
 
-        if ( mPolyhedra == null ) {
-            mPolyhedra = orbitSource .getShapes();
+        mPolyhedra = orbitSource .getShapes();        
+        if ( mPolyhedra == null )
             return;
-        }
-        Symmetry oldSymm = mPolyhedra .getSymmetry();
-        boolean hadShapeColors = mPolyhedra .hasColors();
-        mPolyhedra = orbitSource .getShapes();
-        boolean hasShapeColors = mPolyhedra .hasColors();
-        
-        if ( false && oldSymm == orbitSource .getSymmetry() && !hadShapeColors && !hasShapeColors ) {
-            
-//            boolean didOneBall = false;
-            
-            HashSet<RenderedManifestation> newSet = new HashSet<>();
-            for ( Iterator<RenderedManifestation> polys = mRendered .iterator(); polys .hasNext(); )
-            {
-                RenderedManifestation rendered = polys .next();
-                polys .remove();
-//                if ( rendered .getManifestation() instanceof Connector ) {
-//                    if ( didOneBall )
-//                        continue;
-//                    else
-//                        didOneBall = true;
-//                }
-                resetAttributes( rendered, false );
-                newSet .add( rendered );  // must re-hash, since shape has changed
-                if ( mainListener != null ) {
-                    mainListener .shapeChanged( rendered );
-                }
-                for (RenderingChanges listener : mListeners) {
-                    listener .shapeChanged( rendered );
-                }
-            }
-            mRendered .addAll( newSet );
-        } else {
+
+        {
 //            int yieldFreq = mRendered .size() / 20;
             int yieldCount = 0;
             HashSet<RenderedManifestation> newSet = new HashSet<>();

--- a/core/src/main/java/com/vzome/core/render/RenderingChanges.java
+++ b/core/src/main/java/com/vzome/core/render/RenderingChanges.java
@@ -31,18 +31,9 @@ public interface RenderingChanges {
     void shapeChanged( RenderedManifestation manifestation );
 
     /**
-    * @deprecated As of 7/20/2016: Use controller property "showFrameLabels" instead.
-    */
-    @Deprecated
-    default void enableFrameLabels(){
-        throw new IllegalStateException( "enableFrameLabels is deprecated." );
-    }
-
-    /**
-    * @deprecated As of 7/20/2016: Use controller property "showFrameLabels" instead.
-    */
-    @Deprecated
-    default void disableFrameLabels(){
-        throw new IllegalStateException( "disableFrameLabels is deprecated." );
-    }
+     * Change shapes all at once, if supported.
+     * @param shapes
+     * @return true if the rendering mechanism can support this
+     */
+    boolean shapesChanged( Shapes shapes );
 }

--- a/core/src/main/java/com/vzome/core/render/TransparentRendering.java
+++ b/core/src/main/java/com/vzome/core/render/TransparentRendering.java
@@ -68,4 +68,10 @@ public class TransparentRendering implements RenderingChanges
         throw new IllegalStateException();
     }
 
+    @Override
+    public boolean shapesChanged( Shapes shapes )
+    {
+        return this .mRealOne .shapesChanged( shapes );
+    }
+
 }

--- a/core/src/test/java/com/vzome/core/render/RenderedModelTest.java
+++ b/core/src/test/java/com/vzome/core/render/RenderedModelTest.java
@@ -100,6 +100,13 @@ public class RenderedModelTest
 		{
 			fail( "should not be called" );
 		}
+
+        @Override
+        public boolean shapesChanged( Shapes shapes )
+        {
+            fail( "should not be called" );
+            return false;
+        }
 	}
 
 	@Test

--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/PartsController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/PartsController.java
@@ -17,6 +17,8 @@ import com.vzome.core.render.Color;
 import com.vzome.core.render.RenderedManifestation;
 import com.vzome.core.render.RenderedModel.OrbitSource;
 import com.vzome.core.render.RenderingChanges;
+import com.vzome.core.render.Shapes;
+
 import java.util.StringTokenizer;
 
 public class PartsController extends DefaultController implements RenderingChanges
@@ -199,5 +201,11 @@ public class PartsController extends DefaultController implements RenderingChang
     @Override
     public void shapeChanged( RenderedManifestation manifestation )
     {}
+
+    @Override
+    public boolean shapesChanged( Shapes shapes )
+    {
+        return false;
+    }
 
 }

--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/SymmetryController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/SymmetryController.java
@@ -23,11 +23,11 @@ import com.vzome.core.math.symmetry.Direction;
 import com.vzome.core.math.symmetry.OrbitSet;
 import com.vzome.core.math.symmetry.Symmetry;
 import com.vzome.core.render.Color;
-import com.vzome.core.render.RenderedModel.OrbitSource;
+import com.vzome.core.render.RenderedModel;
 import com.vzome.core.render.Shapes;
 import com.vzome.desktop.controller.CameraController;
 
-public class SymmetryController extends DefaultController// implements RenderedModel.OrbitSource
+public class SymmetryController extends DefaultController
 {
     @Override
     public String getProperty( String string )
@@ -72,6 +72,7 @@ public class SymmetryController extends DefaultController// implements RenderedM
     private final Map<String, Controller> symmetryToolFactories = new LinkedHashMap<>();
     private final Map<String, Controller> transformToolFactories = new LinkedHashMap<>();
     private final Map<String, Controller> linearMapToolFactories = new LinkedHashMap<>();
+    private final RenderedModel renderedModel;
 
     public Symmetry getSymmetry()
     {
@@ -83,9 +84,10 @@ public class SymmetryController extends DefaultController// implements RenderedM
         return snapper;
     }
 
-    public SymmetryController( Controller parent, SymmetrySystem model )
+    public SymmetryController( Controller parent, SymmetrySystem model, RenderedModel mRenderedModel )
     {
-        this.symmetrySystem = model;
+        this .symmetrySystem = model;
+        renderedModel = mRenderedModel;
         Symmetry symmetry = model .getSymmetry();
         availableOrbits = new OrbitSet( symmetry );
         snapOrbits = new OrbitSet( symmetry );
@@ -255,7 +257,7 @@ public class SymmetryController extends DefaultController// implements RenderedM
             {
                 String styleName =  action .substring( "setStyle." .length() );
                 this .symmetrySystem .setStyle( styleName );
-                super .doAction( action, e ); // falling through so that rendering gets adjusted
+                this .renderedModel .setShapes( this .symmetrySystem .getShapes() );
             }
             else {
                 boolean handled = this .symmetrySystem .doAction( action );
@@ -285,7 +287,9 @@ public class SymmetryController extends DefaultController// implements RenderedM
         return this .symmetrySystem .getOrbits();
     }
 
-    public OrbitSource getOrbitSource()
+    // TODO: Can we get rid of this?  It is only needed by PreviewStrut.
+    //   We should be able to accomplish the sync with PropertyChangeListeners
+    public RenderedModel.OrbitSource getOrbitSource()
     {
         return this .symmetrySystem;
     }

--- a/desktop/src/main/java/org/vorthmann/zome/render/java3d/Java3dSceneGraph.java
+++ b/desktop/src/main/java/org/vorthmann/zome/render/java3d/Java3dSceneGraph.java
@@ -52,6 +52,7 @@ import com.vzome.core.render.Color;
 import com.vzome.core.render.Colors;
 import com.vzome.core.render.RenderedManifestation;
 import com.vzome.core.render.RenderingChanges;
+import com.vzome.core.render.Shapes;
 import com.vzome.core.viewing.Lights;
 
 /**
@@ -692,5 +693,11 @@ public class Java3dSceneGraph implements RenderingChanges, PropertyChangeListene
 
     private void hideIcosahedralLabels() {
         mRoot.removeChild(icosahedralLabels);
+    }
+
+    @Override
+    public boolean shapesChanged( Shapes shapes )
+    {
+        return false;  // I have no desire to support this, since I'm switching to JOGL which can do it easily
     }
 }

--- a/desktop/src/test/java/org/vorthmann/zome/app/impl/LengthPanelControllersTest.java
+++ b/desktop/src/test/java/org/vorthmann/zome/app/impl/LengthPanelControllersTest.java
@@ -25,7 +25,7 @@ public class LengthPanelControllersTest
         SymmetrySystem system = new SymmetrySystem( null, perspective, null, new Colors( new Properties() ), true );
 
         Controller strutBuilder = new StrutBuilderController( null, null ) .withShowStrutScales( true );
-        Controller symmController = new SymmetryController( strutBuilder, system );
+        Controller symmController = new SymmetryController( strutBuilder, system, null );
         Controller buildOrbits = getSubController( symmController, "buildOrbits" );
         assertNotNull( buildOrbits );
         


### PR DESCRIPTION
Added RenderingChanges.shapesChanged().  It returns false when unsupported,
and none of the implementations support it yet.

Added RenderedModel.setShapes().  This calls RC.shapesChanged(), and if
it returns false, it falls back to doing setOrbitSource(), as if the
entire symmetry had been changed.  This is obviously overkill, but it has
been the implementation forever.  Now I have laid the groundwork to fix
that.