### PR TITLE
Ignore ConcurrentModificationException in JoglScene.render()

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/ui/ApplicationUI.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/ApplicationUI.java
@@ -110,7 +110,7 @@ public final class ApplicationUI implements ActionListener, PropertyChangeListen
                 // 
                 // SV: I've reversed the %u and %g, so that sorting by name puts related logs together, in order.  The Finder / Explorer already
                 //   knows how to sort by date, so we don't need to support that.
-                fh = new FileHandler("%h/" + Platform.logsPath() + "/vZome60_%u_%g.log", 500000, 10);
+                fh = new FileHandler("%h/" + Platform.logsPath() + "/vZome7.0_%u_%g.log", 500000, 10);
             } catch (Exception e1) {
                 rootLogger.log(Level.WARNING, "unable to set up vZome file log handler", e1);
                 try {


### PR DESCRIPTION
I still get occasional ConcurrentModificationExceptions thrown which lock up the model rendering. What do you think of this solution? I think it's easier than synchronizing access to all of the related collections.

P.S. I also bumped the log file version number to 7.0.