### PR TITLE
Fix fog shader code to compile on David's ATI Radeon laptop

### DIFF
--- a/core/src/main/java/com/vzome/opengl/OpenGlUtilities.java
+++ b/core/src/main/java/com/vzome/opengl/OpenGlUtilities.java
@@ -1,9 +1,19 @@
 package com.vzome.opengl;
 
 import java.nio.FloatBuffer;
+import java.util.logging.Logger;
 
 public class OpenGlUtilities
 {
+    private static final Logger lOGGER = Logger.getLogger( new Throwable().getStackTrace()[0].getClassName() );
+    
+    public static void logConfiguration( OpenGlShim gl )
+    {
+    	String msg = gl.getGLSLVersionString();
+    	// could add more hardware or driver into here
+    	lOGGER.config(msg);
+    }
+    
     static int storeBuffer( OpenGlShim gl, FloatBuffer clientBuffer, int oldId )
     {
         if ( oldId != -1 ) {
@@ -33,9 +43,20 @@ public class OpenGlUtilities
     static void checkGLError( OpenGlShim gl, String func )
     {
         int error;
+        int qty = 0;
+        String delim = " ";
+        StringBuffer buf = new StringBuffer();
         while ((error = gl.glGetError()) != 0) {
-            System.out.println( func + ": glError " + error);
-            throw new RuntimeException(func + ": glError " + error);
+        	buf.append(delim);
+        	buf.append(error);
+        	delim = ", ";
+        	qty++;
+        }
+        if(qty != 0) {
+        	logConfiguration(gl);
+        	String msg = func + ": glError" + (qty == 1 ? "" : "s") + buf.toString();
+        	lOGGER.warning(msg);
+        	throw new RuntimeException(msg);
         }
     }
 
@@ -63,7 +84,7 @@ public class OpenGlUtilities
         // If the compilation failed, delete the shader.
         if (compileStatus[0] == 0) {
             String problem = gl.glGetShaderInfoLog(shader);
-            System .out.println(  "Error compiling shader: " + problem );
+            lOGGER.severe(code + "\nError compiling shader: " + problem );
             gl.glDeleteShader(shader);
             shader = 0;
         }

--- a/core/src/main/java/com/vzome/opengl/OutlineRenderer.java
+++ b/core/src/main/java/com/vzome/opengl/OutlineRenderer.java
@@ -73,9 +73,8 @@ public class OutlineRenderer implements InstancedGeometry.BufferStorage, Rendere
                 "\n" + 
                 "float getFogFactor( float d )\n" + 
                 "{\n" + 
-                "    if ( d >= 1 ) return 1;\n" + 
-                "    if ( d <= u_FogMin ) return 0;\n" + 
-                "\n" + 
+                "    if ( d >= 1 ) return 1.0;\n" + 
+                "    if ( d <= u_FogMin ) return 0.0;\n" + 
                 "    return 1 - (1 - d) / (1 - u_FogMin);\n" + 
                 "}\n" + 
                 "float LinearizeDepth(float depth) \n" + 

--- a/core/src/main/java/com/vzome/opengl/SolidRenderer.java
+++ b/core/src/main/java/com/vzome/opengl/SolidRenderer.java
@@ -102,8 +102,8 @@ public class SolidRenderer implements InstancedGeometry.BufferStorage, Renderer
                 "\n" + 
                 "float getFogFactor( float d )\n" + 
                 "{\n" + 
-                "    if ( d >= 1 ) return 1;\n" + 
-                "    if ( d <= u_FogMin ) return 0;\n" + 
+                "    if ( d >= 1 ) return 1.0;\n" + 
+                "    if ( d <= u_FogMin ) return 0.0;\n" + 
                 "    return 1 - (1 - d) / (1 - u_FogMin);\n" + 
                 "}\n" + 
                 "float LinearizeDepth(float depth) \n" + 


### PR DESCRIPTION
Avoid fatal exception when fog shader fails to compile because getFogFactor must specifically return floats rather than ints (e.g. 1.0 instead of just 1). Problem was in both SolidRenderer and OutlineRenderer. Problem was hardware specific, so error logging was also improved in case we need to identify similar openGL issues for other users.