### PR TITLE
Better file name defaults in export/save dialogs

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
@@ -1272,6 +1272,7 @@ public class DocumentController extends DefaultController implements Controller3
             // App controller will set topDocument, or remove the document.
             firePropertyChange( "visible", null, value );
         } else if ( "name".equals( cmd ) ) {
+            this .properties .setProperty( "window.file", (String) value );
             // App controller is listening, will change its map
             firePropertyChange( "name", null, value );
         } else if ( "backgroundColor".equals( cmd ) ) {

--- a/desktop/src/main/java/org/vorthmann/zome/ui/ControllerFileAction.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/ControllerFileAction.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -86,15 +87,30 @@ public class ControllerFileAction implements ActionListener
         if ( directory == null )
             directory = this .mController .getProperty( this .mOpening? "last-open-directory.vZome" : "last-save-directory.vZome" );
         mFileChooser .setDirectory( directory );
+
+        String fileName = this .mController .getProperty( "window.file" );
+        if ( fileName != null && ! this .mOpening ) {
+            Path filePath = new File( fileName ) .toPath();
+            fileName = filePath .getFileName() .toString();
+            int index = fileName .lastIndexOf( "." );
+            if ( index > 0 )
+            {
+                fileName = fileName .substring( 0, index );
+            }
+            fileName = fileName + "." + mExtension;
+            mFileChooser .setFile( fileName );
+        }
+
         mFileChooser .setVisible( true );
-        String fileName = mFileChooser .getFile();
+        fileName = mFileChooser .getFile();
         if ( fileName == null )
         {
             logger .info( "file action cancelled" );
             return;
         }
-        if ( ! mOpening && ! fileName .endsWith( "." + mExtension ) )
+        if ( ! mOpening && ! fileName .endsWith( "." + mExtension ) ) {
             fileName = fileName + "." + mExtension;
+        }
         directory = mFileChooser .getDirectory();  // cache this for convenience, for the next use
         this .mController .setProperty( this .getDirectoryProperty(), directory ); // set it for other windows
         File file = new File( directory, fileName );

--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
@@ -129,7 +129,7 @@ public class DocumentFrame extends JFrame implements PropertyChangeListener, Con
 
         String path = mController .getProperty( "window.file" );
         if ( path != null )
-        	this .mFile = new File( path ); // this enables "save" in localActions
+            this .mFile = new File( path ); // this enables "save" in localActions
 
         // TODO: compute these booleans once here, and don't recompute in DocumentMenuBar
 


### PR DESCRIPTION
I'm now calling FileDialog.setFile() to prepare the file name with the
right extension.  If the file has been opened or saved, then the
"window.file" property should be non-null, and I'm using that to set up
the file name, stripping off the extension (presumably .vZome) and adding
the correct one.

Note that the whole business of "window.title", "window.file", and "name"
properties is pretty confusing, in addition to DocumentFrame.mFile state.
I should probably unify "window.file" and "name" properties.  Until this
commit, "window.file" was only set for opened files, not for saved ones.
Now it should be an invariant.