### PR TITLE
Fix for the wrong-symmetry bug for ReplaceWithShape

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
@@ -593,6 +593,11 @@ public class DocumentController extends DefaultController implements Controller3
                 }
                 break;
 
+
+            case "ReplaceWithShape":
+                this .getSymmetryController() .doAction( action, e );
+                break;
+
             case "toggleFrameLabels":
                 {
                     showFrameLabels = ! showFrameLabels;

--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentMenuBar.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentMenuBar.java
@@ -394,7 +394,7 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
         menu.add( enableIf( isEditor, createMenuItem( "Point Reflection", "pointsymm" ) ) );
 
         menu .addSeparator();
-        menu.add( enableIf( isEditor, createMenuItem( "Replace With Panels", "ReplaceWithShape", symmetryController, KeyEvent .CHAR_UNDEFINED, 0 ) ) );
+        menu.add( enableIf( isEditor, createMenuItem( "Replace With Panels", "ReplaceWithShape", controller, KeyEvent .CHAR_UNDEFINED, 0 ) ) );
 
         menu .addSeparator();
         menu .add( enableIf( isEditor, createMenuItem( "Generate Polytope...", "showPolytopesDialog", KeyEvent.VK_P, COMMAND_OPTION ) ) );


### PR DESCRIPTION
In DocumentMenuBar, we look up the *initial* symmetryController, and use
that for many of the items in the "Tools" menu.  This seems bizarre,
since of course it does not adapt to symmetry system changes!

Nonetheless, it may work for most of those commands, but it clearly fails
for ReplaceWithShape, since you can only get the shape for the default
symmetry system.

The fix was easy... use the DocumentController, and there dispatch to
the current symmetryController.

I do need to test some of the "oldTools" like axialsymm... there seems to
be a good chance that they also get stuck in the wrong system.  At the
very least, if they work correctly, it is only because we never even
retain the context from the symmetryController, instead reconstructing
the symmetry system deeper in core.