### PR TITLE
Fixed the bug making panels white on symmetry switch

### DIFF
--- a/core/src/main/java/com/vzome/core/render/RenderedManifestation.java
+++ b/core/src/main/java/com/vzome/core/render/RenderedManifestation.java
@@ -312,7 +312,7 @@ public class RenderedManifestation
     public void resetAttributes( RenderedModel.OrbitSource orbitSource, Shapes shapes, boolean oneSidedPanels, boolean colorPanels )
     {
         if ( this .mManifestation instanceof Panel ) {
-            resetPanelAttributes(orbitSource, oneSidedPanels, colorPanels);
+            resetPanelAttributes( orbitSource, shapes, oneSidedPanels, colorPanels );
         }
         else if ( shapes == null ) {
             return; // rendering a symmetry model with panels only
@@ -328,7 +328,7 @@ public class RenderedManifestation
             throw new UnsupportedOperationException( "only strut, ball, and panel shapes currently supported" );
     }
 
-    private void resetPanelAttributes( RenderedModel.OrbitSource orbitSource, boolean oneSidedPanels, boolean colorPanels )
+    private void resetPanelAttributes( RenderedModel.OrbitSource orbitSource, Shapes shapes, boolean oneSidedPanels, boolean colorPanels )
     {
         Panel panel = (Panel) this .mManifestation;
         Polyhedron shape = makePanelPolyhedron( panel, oneSidedPanels );
@@ -342,12 +342,13 @@ public class RenderedManifestation
             return;
 
         this .setOrientation( orbitSource .getSymmetry() .getField() .identityMatrix( 3 ) );
-        this .setColor( Color.WHITE );
 
         try {
             Axis axis = orbitSource .getAxis( normal );
-            if ( axis == null )
+            if ( axis == null ) {
+                this .setColor( Color.WHITE );
                 return;
+            }
 
             // This lets the Panel represent Planes better.
             panel .setZoneVector( axis .normal() );
@@ -355,8 +356,13 @@ public class RenderedManifestation
             Direction orbit = axis .getDirection();
 
             Color color = this .mManifestation .getColor();
-            if ( color == null )
-                color = orbitSource .getColor( orbit ) .getPastel();
+            if ( color == null ) {
+                color = shapes .getColor( orbit );
+                if ( color == null )
+                    color = orbitSource .getColor( orbit );
+                if ( color != null )
+                    color = color .getPastel();
+            }
             this .setColor( color );
         } catch ( IllegalStateException e ) {
             if ( logger .isLoggable( Level.WARNING ) )


### PR DESCRIPTION
The old logic of defaulting the color to white doesn't work now that the
Manifestation may set its color from the RM.  This means that the "color-
saving" logic later always saves white.

While I was fixing this, I added shape-specific colors, to be consistent
with strut coloring.