### PR TITLE
Fix octasymm command when invoked from main menu for SqrtPhiField

### DIFF
--- a/core/src/main/java/com/vzome/fields/sqrtphi/SqrtPhiFieldApplication.java
+++ b/core/src/main/java/com/vzome/fields/sqrtphi/SqrtPhiFieldApplication.java
@@ -99,7 +99,7 @@ public class SqrtPhiFieldApplication extends DefaultFieldApplication
         private final Command tetrasymm = new CommandTetrahedralSymmetry( icosaSymm );
         private final Command axialsymm = new CommandAxialSymmetry( icosaSymm );
         private final Command h4symmetry = new CommandQuaternionSymmetry( H4, H4 );
-        private final Command octasymm = new CommandSymmetry( icosaSymm );
+        private final Command octasymm = new CommandSymmetry( new OctahedralSymmetry( getField(), "", "" ) );
         
 //        private final AbstractShapes octahedralShapes = new OctahedralShapes( "octahedral", "octahedra", this .icosaSymm );
         private final AbstractShapes tinyIcosaShapes = new ExportedVEFShapes( null, "sqrtPhi/tinyIcosahedra", "tiny icosahedra", icosaSymm);
@@ -226,7 +226,7 @@ public class SqrtPhiFieldApplication extends DefaultFieldApplication
         		.createStandardOrbits( "blue" );
 
         private final Command axialsymm = new CommandAxialSymmetry( pentaSymm );
-        private final Command octasymm = new CommandSymmetry( pentaSymm );
+        private final Command octasymm = new CommandSymmetry( new OctahedralSymmetry( getField(), "", "" ) );
         
         private final AbstractShapes octahedralShapes = new ExportedVEFShapes( null, "sqrtPhi/octahedra", "octahedra", pentaSymm );
         private final AbstractShapes kostickShapes = new ExportedVEFShapes( null, "sqrtPhi/fivefold", "Kostick", pentaSymm, octahedralShapes );


### PR DESCRIPTION
* When invoked from the main menu, CommandSymmetry was using the wrong symmetry so it effectively generated the same result as CommandAxialSymmetry.
* This commit fixes the behavior when invoking the octasymm command from the main menu for new models. It works regardless of the current symmetry setting.
* There is no problem opening existing models that were created with this erroneous behavior because the original "symmetry.group" is read from the vZome file, not the corrected SymmetryPerspective.

* TODO: Note that the octasymm command is implemented by some SymmetryPerspectives but not others. For consistent behavior and a single code path, it should be implemented once in DefaultFieldApplication.getLegacyCommand() with rather than being duplicated in the getLegacyCommand() of individual SymmetryPerspectives. I plan to do exactly that in the near future, perhaps as part of generalizing an IcosahedralSymmetryPerspective for use with the PolygonField .
