### PR TITLE
Fixed the mysterious reversing panel

### DIFF
--- a/core/src/main/java/com/vzome/core/commands/CommandPolygon.java
+++ b/core/src/main/java/com/vzome/core/commands/CommandPolygon.java
@@ -34,6 +34,12 @@ public class CommandPolygon extends AbstractCommand
     }
     
     @Override
+    public boolean ordersSelection()
+    {
+        return true;
+    }
+
+    @Override
     public ConstructionList apply( ConstructionList parameters, AttributeMap attrs, ConstructionChanges effects ) throws Failure
     {
         List<Point> points = new ArrayList<>();


### PR DESCRIPTION
The purple-strut-model bug that triggered all my efforts at building a
debugger is now resolved.  It turns out that CommandPolygon was not using
the ordered-selection flag, amazingly.  This means that if you build a
panel, then undo just that command, and build the panel again (not redo!),
the second panel will be the reverse of the first.