### PR TITLE
Added the FreeMove undoable edit

### DIFF
--- a/core/src/main/java/com/vzome/core/commands/CommandTransform.java
+++ b/core/src/main/java/com/vzome/core/commands/CommandTransform.java
@@ -7,12 +7,8 @@ import com.vzome.core.construction.Construction;
 import com.vzome.core.construction.ConstructionChanges;
 import com.vzome.core.construction.ConstructionList;
 import com.vzome.core.construction.Point;
-import com.vzome.core.construction.Polygon;
 import com.vzome.core.construction.Segment;
 import com.vzome.core.construction.Transformation;
-import com.vzome.core.construction.TransformedPoint;
-import com.vzome.core.construction.TransformedPolygon;
-import com.vzome.core.construction.TransformedSegment;
 import com.vzome.core.math.symmetry.Symmetry;
 
 /**
@@ -66,16 +62,7 @@ public abstract class CommandTransform extends AbstractCommand
         final ConstructionList output = new ConstructionList();
         effects .constructionAdded( transform );
         for (Construction param : params) {
-            Construction result = null;
-            if (param instanceof Point) {
-                result = new TransformedPoint(transform, (Point) param);
-            } else if (param instanceof Segment) {
-                result = new TransformedSegment(transform, (Segment) param);
-            } else if (param instanceof Polygon) {
-                result = new TransformedPolygon(transform, (Polygon) param);
-            } else {
-                // TODO handle other constructions 
-            }
+            Construction result = transform .transform( param );
             if ( result == null )
                 continue;
             effects .constructionAdded( result );

--- a/core/src/main/java/com/vzome/core/construction/MoveAndRotate.java
+++ b/core/src/main/java/com/vzome/core/construction/MoveAndRotate.java
@@ -1,0 +1,29 @@
+package com.vzome.core.construction;
+
+import com.vzome.core.algebra.AlgebraicMatrix;
+import com.vzome.core.algebra.AlgebraicVector;
+
+public class MoveAndRotate extends Transformation
+{
+    private final MatrixTransformation rotation;
+    private final Translation translation;
+
+    public MoveAndRotate( AlgebraicMatrix rotation, AlgebraicVector start, AlgebraicVector end )
+    {
+        super( start .getField() );
+        this .rotation = new MatrixTransformation( rotation, start );
+        this .translation = new Translation( end .minus( start ) );
+    }
+
+    @Override
+    protected boolean mapParamsToState()
+    {
+        return this .rotation .mapParamsToState() && this .translation .mapParamsToState();
+    }
+
+    @Override
+    public AlgebraicVector transform( AlgebraicVector arg )
+    {
+        return this .translation .transform( this .rotation .transform( arg ) );
+    }
+}

--- a/core/src/main/java/com/vzome/core/construction/Transformation.java
+++ b/core/src/main/java/com/vzome/core/construction/Transformation.java
@@ -114,6 +114,20 @@ public abstract class Transformation extends Construction
         arg = arg .plus( mOffset );
         return arg;
     }
+    
+    public Construction transform( Construction c )
+    {
+        if ( c instanceof Point ) {
+            return new TransformedPoint( this, (Point) c );
+        } else if ( c instanceof Segment ) {
+            return new TransformedSegment( this, (Segment) c );
+        } else if ( c instanceof Polygon ) {
+            return new TransformedPolygon( this, (Polygon) c );
+        } else {
+            // TODO handle other constructions
+            return null;
+        }
+    }
 
     @Override
     public Element getXml( Document doc )

--- a/core/src/main/java/com/vzome/core/edits/AffineTransformAll.java
+++ b/core/src/main/java/com/vzome/core/edits/AffineTransformAll.java
@@ -8,12 +8,8 @@ import com.vzome.core.commands.Command.Failure;
 import com.vzome.core.construction.ChangeOfBasis;
 import com.vzome.core.construction.Construction;
 import com.vzome.core.construction.Point;
-import com.vzome.core.construction.Polygon;
 import com.vzome.core.construction.Segment;
 import com.vzome.core.construction.Transformation;
-import com.vzome.core.construction.TransformedPoint;
-import com.vzome.core.construction.TransformedPolygon;
-import com.vzome.core.construction.TransformedSegment;
 import com.vzome.core.editor.ChangeManifestations;
 import com.vzome.core.editor.EditorModel;
 import com.vzome.core.model.Manifestation;
@@ -58,16 +54,7 @@ public class AffineTransformAll extends ChangeManifestations
             if ( m .getRenderedObject() == null )
                 continue;
             Construction c = m .getConstructions() .next();
-            Construction result = null;
-            if ( c instanceof Point ) {
-                result = new TransformedPoint( transform, (Point) c );
-            } else if ( c instanceof Segment ) {
-                result = new TransformedSegment( transform, (Segment) c );
-            } else if ( c instanceof Polygon ) {
-                result = new TransformedPolygon( transform, (Polygon) c );
-            } else {
-                // TODO handle other constructions 
-            }
+            Construction result = transform .transform( c );
             select( manifestConstruction( result ) );
         }
         redo();

--- a/core/src/main/java/com/vzome/core/edits/DodecagonSymmetry.java
+++ b/core/src/main/java/com/vzome/core/edits/DodecagonSymmetry.java
@@ -6,13 +6,8 @@ package com.vzome.core.edits;
 
 import com.vzome.core.construction.Construction;
 import com.vzome.core.construction.Point;
-import com.vzome.core.construction.Polygon;
-import com.vzome.core.construction.Segment;
 import com.vzome.core.construction.SymmetryTransformation;
 import com.vzome.core.construction.Transformation;
-import com.vzome.core.construction.TransformedPoint;
-import com.vzome.core.construction.TransformedPolygon;
-import com.vzome.core.construction.TransformedSegment;
 import com.vzome.core.editor.ChangeManifestations;
 import com.vzome.core.editor.EditorModel;
 import com.vzome.core.math.symmetry.Symmetry;
@@ -41,15 +36,7 @@ public class DodecagonSymmetry extends ChangeManifestations
 
             for ( int i = 0; i < 11; i++ )
             {
-                if ( c instanceof Point ) {
-                    c = new TransformedPoint( transform, (Point) c );
-                } else if ( c instanceof Segment ) {
-                    c = new TransformedSegment( transform, (Segment) c );
-                } else if ( c instanceof Polygon ) {
-                    c = new TransformedPolygon( transform, (Polygon) c );
-                } else {
-                    // TODO handle other constructions 
-                }
+                c = transform .transform( c );
                 if ( c == null )
                     continue;
                 select( manifestConstruction( c ) );

--- a/core/src/main/java/com/vzome/core/edits/FreeMove.java
+++ b/core/src/main/java/com/vzome/core/edits/FreeMove.java
@@ -1,0 +1,77 @@
+package com.vzome.core.edits;
+
+import java.util.Map;
+
+import org.w3c.dom.Element;
+
+import com.vzome.core.algebra.AlgebraicMatrix;
+import com.vzome.core.algebra.AlgebraicVector;
+import com.vzome.core.commands.Command;
+import com.vzome.core.commands.Command.Failure;
+import com.vzome.core.commands.XmlSaveFormat;
+import com.vzome.core.construction.Construction;
+import com.vzome.core.construction.MoveAndRotate;
+import com.vzome.core.construction.Transformation;
+import com.vzome.core.editor.ChangeManifestations;
+import com.vzome.core.editor.EditorModel;
+import com.vzome.core.model.Manifestation;
+
+public class FreeMove extends ChangeManifestations
+{
+    private Manifestation objectToMove;
+    private Transformation moveAndRotate;
+
+    public FreeMove( EditorModel editor )
+    {
+        super( editor .getSelection(), editor .getRealizedModel() );
+    }
+
+    @Override
+    public void configure( Map<String,Object> props )
+    {
+        Manifestation object = (Manifestation) props .get( "picked" );
+        if ( object != null ) // first creation from the editor
+        {
+            this .objectToMove = object;
+        }
+        AlgebraicVector destination = (AlgebraicVector) props .get( "location" );
+        AlgebraicMatrix rotation = (AlgebraicMatrix) props .get( "rotation" );
+        if ( destination != null && rotation != null ) // first creation from the editor
+        {
+            this .moveAndRotate = new MoveAndRotate( rotation, object .getLocation(), destination );
+        }
+    }
+
+    @Override
+    public void perform() throws Command.Failure
+    {
+        Construction c = this .objectToMove .toConstruction();
+
+        // Since vZome code is not really expecting locations and rotations to change, we will
+        //   implement this as a delete + create.
+        this .deleteManifestation( this .objectToMove );
+        this .manifestConstruction( this .moveAndRotate .transform( c ) );
+        
+        super .perform();
+    }
+
+    @Override
+    protected String getXmlElementName()
+    {
+        return "FreeMove";
+    }
+
+    @Override
+    protected void getXmlAttributes( Element element )
+    {
+//        DomUtils.addAttribute( element, "vector1", vector1 .toParsableString() );
+//        DomUtils.addAttribute( element, "vector2", vector2 .toParsableString() );
+    }
+
+    @Override
+    protected void setXmlAttributes( Element xml, XmlSaveFormat format ) throws Failure
+    {
+//        vector1 = format.parseRationalVector( xml, "vector1" );
+//        vector2 = format.parseRationalVector( xml, "vector2" );
+    }
+}

--- a/core/src/main/java/com/vzome/core/edits/TransformSelection.java
+++ b/core/src/main/java/com/vzome/core/edits/TransformSelection.java
@@ -7,13 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.vzome.core.construction.Construction;
-import com.vzome.core.construction.Point;
-import com.vzome.core.construction.Polygon;
-import com.vzome.core.construction.Segment;
 import com.vzome.core.construction.Transformation;
-import com.vzome.core.construction.TransformedPoint;
-import com.vzome.core.construction.TransformedPolygon;
-import com.vzome.core.construction.TransformedSegment;
 import com.vzome.core.editor.ChangeManifestations;
 import com.vzome.core.editor.Selection;
 import com.vzome.core.model.Manifestation;
@@ -44,16 +38,7 @@ public class TransformSelection extends ChangeManifestations
             if ( m .getRenderedObject() == null )
                 continue;
             Construction c = m .getConstructions() .next();
-            Construction result = null;
-            if ( c instanceof Point ) {
-                result = new TransformedPoint( transform, (Point) c );
-            } else if ( c instanceof Segment ) {
-                result = new TransformedSegment( transform, (Segment) c );
-            } else if ( c instanceof Polygon ) {
-                result = new TransformedPolygon( transform, (Polygon) c );
-            } else {
-                // TODO handle other constructions 
-            }
+            Construction result = transform .transform( c );
             select( manifestConstruction( result ), true );
         }
         redo();

--- a/core/src/main/java/com/vzome/core/tools/TransformationTool.java
+++ b/core/src/main/java/com/vzome/core/tools/TransformationTool.java
@@ -7,12 +7,7 @@ import java.util.Arrays;
 
 import com.vzome.core.construction.Construction;
 import com.vzome.core.construction.Point;
-import com.vzome.core.construction.Polygon;
-import com.vzome.core.construction.Segment;
 import com.vzome.core.construction.Transformation;
-import com.vzome.core.construction.TransformedPoint;
-import com.vzome.core.construction.TransformedPolygon;
-import com.vzome.core.construction.TransformedSegment;
 import com.vzome.core.editor.ChangeManifestations;
 import com.vzome.core.editor.Tool;
 import com.vzome.core.editor.ToolsModel;
@@ -73,16 +68,7 @@ public abstract class TransformationTool extends Tool
     public void performEdit( Construction c, ChangeManifestations applyTool )
     {
         for (Transformation transform : transforms) {
-            Construction result = null;
-            if (c instanceof Point) {
-                result = new TransformedPoint(transform, (Point) c);
-            } else if (c instanceof Segment) {
-                result = new TransformedSegment(transform, (Segment) c);
-            } else if (c instanceof Polygon) {
-                result = new TransformedPolygon(transform, (Polygon) c);
-            } else {
-                // TODO handle other constructions 
-            }
+            Construction result = transform .transform( c );
             if ( result == null )
                 continue;
             applyTool .manifestConstruction( result );

--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
@@ -43,6 +43,7 @@ import org.vorthmann.zome.app.impl.PartsController.PartInfo;
 import org.vorthmann.zome.ui.PartsPanel.PartsPanelActionEvent;
 
 import com.vzome.core.algebra.AlgebraicField;
+import com.vzome.core.algebra.AlgebraicMatrix;
 import com.vzome.core.algebra.AlgebraicNumber;
 import com.vzome.core.algebra.AlgebraicVector;
 import com.vzome.core.algebra.PentagonField;
@@ -1379,6 +1380,20 @@ public class DocumentController extends DefaultController implements Controller3
                 LengthController lmodel = (LengthController) symmetryController .buildController .getSubController( "currentLength" );
                 lmodel .setActualLength( length );
                 break;
+            }
+            
+            // This is only for manual testing of the FreeMove edit, needed for VR grabbing.
+            case "testMoveAndRotate": {
+                Map<String,Object> props = new HashMap<>();
+                props .put( "picked", pickedManifestation );
+                Strut strut = (Strut) pickedManifestation;
+                props .put( "location", strut .getEnd() ); // move the strut to its own end location
+                Axis zone = symmetryController .getZone( strut .getOffset() );
+                Direction orbit = zone .getOrbit();
+                Symmetry symmetry = orbit .getSymmetry();
+                AlgebraicMatrix rotation = symmetry .getMatrix( zone .getOrientation() );
+                props .put( "rotation", rotation .inverse() ); // invert the strut orientation, so the result is always the canonical zone
+                documentModel .doEdit( "FreeMove", props );
             }
 
             default:

--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/PickingController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/PickingController.java
@@ -52,7 +52,8 @@ public class PickingController extends DefaultController implements Controller
         case "SelectParallelStruts":
         case "AdjustSelectionByOrbitLength/selectSimilarStruts":
 		case "ReplaceWithShape":
-        	this .delegate .doManifestationAction( this .pickedManifestation, action );
+        case "testMoveAndRotate":
+		    this .delegate .doManifestationAction( this .pickedManifestation, action );
         	break;
             
 		default:
@@ -91,6 +92,7 @@ public class PickingController extends DefaultController implements Controller
             case "SelectParallelStruts":
             case "AdjustSelectionByOrbitLength/selectSimilarStruts":
             case "setBuildOrbitAndLength":
+            case "testMoveAndRotate":
                 result[ i ] = pickedManifestation instanceof Strut;
                 break;
 

--- a/desktop/src/main/java/org/vorthmann/zome/ui/ApplicationUI.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/ApplicationUI.java
@@ -311,10 +311,10 @@ public final class ApplicationUI implements ActionListener, PropertyChangeListen
             if ( splash != null )
                 splash .dispose();
             
-            ui .debugger = new DapAdapter(); // inert unless we start the server
             String debugPortStr = ui .mController .getProperty( "debug.adapter.port" );
             if ( debugPortStr != null ) {
                 try {
+                    ui .debugger = new DapAdapter(); // inert unless we start the server
                     Integer debugPort = Integer .parseInt( debugPortStr );
                     ui .debugger .startServer( debugPort, ui .mController );
                 } catch ( NumberFormatException e ) {

--- a/desktop/src/main/java/org/vorthmann/zome/ui/ModelPanel.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/ModelPanel.java
@@ -486,6 +486,9 @@ public class ModelPanel extends JPanel implements PropertyChangeListener, Symmet
 
             this .add( setMenuAction( "setBuildOrbitAndLength", new JMenuItem( "Build With This" ) ) );
             this .add( enabler .setMenuAction( "showProperties-"+key, this .controller, new JMenuItem( "Show Properties" ) ) );
+
+            // This is only for manual testing of the FreeMove edit, needed for VR grabbing.
+            // this .add( setMenuAction( "testMoveAndRotate", new JMenuItem( "Move and Rotate" ) ) );
         }
 
         private JMenuItem setMenuAction( String action, JMenuItem control )


### PR DESCRIPTION
This edit is needed for VR, where an object can be grabbed and moved to
a new location and orientation.

I also refactored a bit to create Transformation.transform(Construction),
which knows what to do with points, segments, and polygons.

Finally, I deferred the creation of the DapAdapter until we know we need
it.  It was failing to build in Eclipse, missing the DAP JAR for some
reason.