### PR TITLE
Remove unused Symmetry.defaultStyle and make OctahedralSymmetry.frameColor protected

### DIFF
--- a/core/src/main/java/com/vzome/core/kinds/AbstractSymmetryPerspective.java
+++ b/core/src/main/java/com/vzome/core/kinds/AbstractSymmetryPerspective.java
@@ -76,7 +76,7 @@ public abstract class AbstractSymmetryPerspective implements SymmetryPerspective
         switch ( action ) {
         case "octasymm":
             // this will be availble to all SymmetryPerspectives even if they are not Octahedral
-            return new CommandSymmetry( new OctahedralSymmetry(getSymmetry().getField(), "", "") );
+            return new CommandSymmetry( new OctahedralSymmetry(getSymmetry().getField(), "blue") );
 
         default:
             return null;

--- a/core/src/main/java/com/vzome/core/kinds/AbstractSymmetryPerspective.java
+++ b/core/src/main/java/com/vzome/core/kinds/AbstractSymmetryPerspective.java
@@ -75,9 +75,18 @@ public abstract class AbstractSymmetryPerspective implements SymmetryPerspective
     {
         switch ( action ) {
         case "octasymm":
-            // this will be availble to all SymmetryPerspectives even if they are not Octahedral
-            return new CommandSymmetry( new OctahedralSymmetry(getSymmetry().getField(), "blue") );
-
+        {
+            Symmetry octaSymm = getSymmetry();
+            if(! (octaSymm instanceof OctahedralSymmetry) ) {
+                // only make a new OctahedralSymmetry if necessary
+                octaSymm = new OctahedralSymmetry(octaSymm.getField());
+            }
+            // This command will be availble to all SymmetryPerspectives even if they are not Octahedral
+            // TODO: This legacy command should probably eventually be removed
+            // after we ensure that doing so is backward compatible. 
+            return new CommandSymmetry( octaSymm );
+        }
+        
         default:
             return null;
         }

--- a/core/src/main/java/com/vzome/core/kinds/HeptagonFieldApplication.java
+++ b/core/src/main/java/com/vzome/core/kinds/HeptagonFieldApplication.java
@@ -48,7 +48,7 @@ public class HeptagonFieldApplication extends DefaultFieldApplication
     private class HeptagonalSymmetryPerspective extends AbstractSymmetryPerspective
 	{
 	    HeptagonalSymmetryPerspective(boolean corrected) {
-	        super(new HeptagonalAntiprismSymmetry(getField(), "blue", "heptagonal antiprism", corrected).createStandardOrbits( "blue" ));
+	        super(new HeptagonalAntiprismSymmetry(getField(), "blue", corrected).createStandardOrbits( "blue" ));
 	        AbstractShapes octahedralShapes = new OctahedralShapes( "octahedral", "triangular antiprism", symmetry );
 	        AbstractShapes antiprismShapes = new ExportedVEFShapes( null, "heptagon/antiprism", "heptagonal antiprism", symmetry, octahedralShapes );
 	        

--- a/core/src/main/java/com/vzome/core/kinds/IcosahedralSymmetryPerspective.java
+++ b/core/src/main/java/com/vzome/core/kinds/IcosahedralSymmetryPerspective.java
@@ -44,7 +44,7 @@ public class IcosahedralSymmetryPerspective extends AbstractSymmetryPerspective 
     private final Command cmdVanOss600cell;
 
     public IcosahedralSymmetryPerspective(AlgebraicField field) {
-        this(new IcosahedralSymmetry(field, "solid connectors") );
+        this( new IcosahedralSymmetry(field) );
     }
     
     protected IcosahedralSymmetryPerspective(IcosahedralSymmetry symm) {

--- a/core/src/main/java/com/vzome/core/kinds/OctahedralSymmetryPerspective.java
+++ b/core/src/main/java/com/vzome/core/kinds/OctahedralSymmetryPerspective.java
@@ -22,7 +22,7 @@ import com.vzome.core.viewing.OctahedralShapes;
 public final class OctahedralSymmetryPerspective extends AbstractSymmetryPerspective
 {
 	public OctahedralSymmetryPerspective( AlgebraicField field ) {
-		super(new OctahedralSymmetry( field, "blue" ) );
+		super(new OctahedralSymmetry( field ) );
         setDefaultGeometry( new OctahedralShapes( "octahedral", "octahedra", symmetry ) );
 	}
 	

--- a/core/src/main/java/com/vzome/core/kinds/OctahedralSymmetryPerspective.java
+++ b/core/src/main/java/com/vzome/core/kinds/OctahedralSymmetryPerspective.java
@@ -22,7 +22,7 @@ import com.vzome.core.viewing.OctahedralShapes;
 public final class OctahedralSymmetryPerspective extends AbstractSymmetryPerspective
 {
 	public OctahedralSymmetryPerspective( AlgebraicField field ) {
-		super(new OctahedralSymmetry( field, "blue", "small octahedra" ) );
+		super(new OctahedralSymmetry( field, "blue" ) );
         setDefaultGeometry( new OctahedralShapes( "octahedral", "octahedra", symmetry ) );
 	}
 	

--- a/core/src/main/java/com/vzome/core/kinds/RootThreeFieldApplication.java
+++ b/core/src/main/java/com/vzome/core/kinds/RootThreeFieldApplication.java
@@ -53,7 +53,7 @@ public class RootThreeFieldApplication extends DefaultFieldApplication
         octahedralPerspective .setDefaultGeometry( defaultShapes );
     }
 
-    private final SymmetryPerspective dodecagonalPerspective = new AbstractSymmetryPerspective(new DodecagonalSymmetry( getField(), "prisms" ))
+    private final SymmetryPerspective dodecagonalPerspective = new AbstractSymmetryPerspective(new DodecagonalSymmetry( getField() ))
     {
         {
             AbstractShapes defaultShapes = new ExportedVEFShapes( null, "dodecagon3d", "prisms", symmetry );

--- a/core/src/main/java/com/vzome/core/kinds/RootTwoFieldApplication.java
+++ b/core/src/main/java/com/vzome/core/kinds/RootTwoFieldApplication.java
@@ -81,7 +81,7 @@ public class RootTwoFieldApplication extends DefaultFieldApplication
             switch ( which ) {
 
             case BLUE:
-                return this .getDirection( "orange" );
+                return this .getDirection( this. frameColor );
 
             case RED:
                 return this .getDirection( "magenta" );
@@ -98,7 +98,7 @@ public class RootTwoFieldApplication extends DefaultFieldApplication
         protected AlgebraicVector[] getOrbitTriangle()
         {
             AlgebraicVector magentaVertex = this .getDirection( "magenta" ) .getPrototype();
-            AlgebraicVector orangeVertex = this .getDirection( "orange" ) .getPrototype();
+            AlgebraicVector orangeVertex = this .getDirection( this. frameColor ) .getPrototype();
             AlgebraicVector yellowVertex = this .getDirection( "yellow" ) .getPrototype();
             return new AlgebraicVector[] { magentaVertex, orangeVertex, yellowVertex };
         }

--- a/core/src/main/java/com/vzome/core/kinds/RootTwoFieldApplication.java
+++ b/core/src/main/java/com/vzome/core/kinds/RootTwoFieldApplication.java
@@ -67,7 +67,7 @@ public class RootTwoFieldApplication extends DefaultFieldApplication
      * field is just the Integers!
      */
 
-    private final Symmetry synestructicsSymmetry = new OctahedralSymmetry( getField(), "orange", "Synestructics" )
+    private final Symmetry synestructicsSymmetry = new OctahedralSymmetry( getField(), "orange" )
     {
         @Override
         public String getName()

--- a/core/src/main/java/com/vzome/core/kinds/SnubDodecFieldApplication.java
+++ b/core/src/main/java/com/vzome/core/kinds/SnubDodecFieldApplication.java
@@ -38,7 +38,7 @@ public class SnubDodecFieldApplication extends DefaultFieldApplication
         super( new SnubDodecField() );
         
         AlgebraicField field = this.getField();
-        IcosahedralSymmetry icosaSymm = new IcosahedralSymmetry( field, "solid connectors" ) 
+        IcosahedralSymmetry icosaSymm = new IcosahedralSymmetry( field ) 
         {
             @Override
             protected void createOtherOrbits()

--- a/core/src/main/java/com/vzome/core/math/symmetry/AbstractSymmetry.java
+++ b/core/src/main/java/com/vzome/core/math/symmetry/AbstractSymmetry.java
@@ -37,24 +37,20 @@ public abstract class AbstractSymmetry implements Symmetry
 
     protected final AlgebraicField mField;
 
-    protected final String defaultStyle;
-
     private AlgebraicMatrix principalReflection = null;
 
     private OrbitDotLocator dotLocator;
 
-    protected AbstractSymmetry( int order, AlgebraicField field, String frameColor, String defaultStyle )
+    protected AbstractSymmetry( int order, AlgebraicField field, String frameColor )
     {
-        this( order, field, frameColor, defaultStyle, null );
+        this( order, field, frameColor, null );
     }
 
-    protected AbstractSymmetry( int order, AlgebraicField field, String frameColor, String defaultStyle, AlgebraicMatrix principalReflection )
+    protected AbstractSymmetry( int order, AlgebraicField field, String frameColor, AlgebraicMatrix principalReflection )
     {
         mField = field;
 
         this.principalReflection = principalReflection;
-
-        this .defaultStyle = defaultStyle;
 
         mOrientations = new Permutation[ order ];
         mMatrices = new AlgebraicMatrix[ order ];
@@ -126,13 +122,6 @@ public abstract class AbstractSymmetry implements Symmetry
     protected abstract void createOtherOrbits();
 
     protected abstract void createInitialPermutations();
-
-    @Override
-    @JsonIgnore
-    public String getDefaultStyle()
-    {
-        return this .defaultStyle;
-    }
 
     @Override
     @JsonIgnore
@@ -544,6 +533,7 @@ public abstract class AbstractSymmetry implements Symmetry
         return new AlgebraicVector[] { blueVertex, redVertex, yellowVertex };
     }
 
+    @Override
     public String computeOrbitDots()
     {
         this.dotLocator = new OrbitDotLocator( this, this .getOrbitTriangle() );
@@ -553,6 +543,7 @@ public abstract class AbstractSymmetry implements Symmetry
         return dotLocator .getDebuggerOutput(); // stop logging new orbits
     }
 
+    @Override
     public boolean reverseOrbitTriangle()
     {
         return false;

--- a/core/src/main/java/com/vzome/core/math/symmetry/DodecagonalSymmetry.java
+++ b/core/src/main/java/com/vzome/core/math/symmetry/DodecagonalSymmetry.java
@@ -18,9 +18,9 @@ public class DodecagonalSymmetry extends AbstractSymmetry
 	public final Permutation IDENTITY = new Permutation( this, null );
 
     
-    public DodecagonalSymmetry( AlgebraicField field, String defaultStyle )
+    public DodecagonalSymmetry( AlgebraicField field)
     {
-        super( ORDER, field, "blue", defaultStyle );
+        super( ORDER, field, "blue" );
     }
     
     @Override

--- a/core/src/main/java/com/vzome/core/math/symmetry/IcosahedralSymmetry.java
+++ b/core/src/main/java/com/vzome/core/math/symmetry/IcosahedralSymmetry.java
@@ -8,7 +8,6 @@ import com.vzome.core.algebra.AlgebraicField;
 import com.vzome.core.algebra.AlgebraicMatrix;
 import com.vzome.core.algebra.AlgebraicNumber;
 import com.vzome.core.algebra.AlgebraicVector;
-import com.vzome.core.algebra.PentagonField;
 
 
 /**
@@ -24,13 +23,9 @@ public class IcosahedralSymmetry extends AbstractSymmetry
 
 	private Axis preferredAxis;
     
-	public static void main(String[] args) {
-		new IcosahedralSymmetry( new PentagonField(), "" );
-	}
-	
-    public IcosahedralSymmetry( AlgebraicField field, String defaultStyle )
+    public IcosahedralSymmetry( AlgebraicField field )
     {
-        super( 60, field, "blue", defaultStyle );
+        super( 60, field, "blue" );
         
         for ( int i = 0; i < this.INCIDENCES.length; i++ ) {
             this .INCIDENCES[ i ][ 0 ] = getPermutation( i ) .mapIndex( 30 );

--- a/core/src/main/java/com/vzome/core/math/symmetry/OctahedralSymmetry.java
+++ b/core/src/main/java/com/vzome/core/math/symmetry/OctahedralSymmetry.java
@@ -19,9 +19,9 @@ public class OctahedralSymmetry extends AbstractSymmetry
     
     private final String frameColor;
     
-    public OctahedralSymmetry( AlgebraicField field, String frameColor, String defaultStyle )
+    public OctahedralSymmetry( AlgebraicField field, String frameColor )
     {
-        super( ORDER, field, frameColor, defaultStyle );
+        super( ORDER, field, frameColor );
         this.frameColor = frameColor;
         tetrahedralSubgroup = closure( new int[] { 0, 2, 4 } );
     }
@@ -45,6 +45,7 @@ public class OctahedralSymmetry extends AbstractSymmetry
         }
     }
 
+    @Override
     public boolean reverseOrbitTriangle()
     {
         return true;

--- a/core/src/main/java/com/vzome/core/math/symmetry/OctahedralSymmetry.java
+++ b/core/src/main/java/com/vzome/core/math/symmetry/OctahedralSymmetry.java
@@ -17,9 +17,15 @@ public class OctahedralSymmetry extends AbstractSymmetry
 
     public final Permutation IDENTITY = new Permutation( this, null );
     
-    private final String frameColor;
-    
-    public OctahedralSymmetry( AlgebraicField field, String frameColor )
+    protected final String frameColor;
+
+    public OctahedralSymmetry( AlgebraicField field ) {
+        this( field, "blue");
+    }
+
+    // Only a derived class is allowed to specify a different frame color
+    // Currently only the RootTwoFieldApplication.synestructicsSymmetry does so.
+    protected OctahedralSymmetry( AlgebraicField field, String frameColor )
     {
         super( ORDER, field, frameColor );
         this.frameColor = frameColor;

--- a/core/src/main/java/com/vzome/core/math/symmetry/Symmetry.java
+++ b/core/src/main/java/com/vzome/core/math/symmetry/Symmetry.java
@@ -69,8 +69,6 @@ public interface Symmetry extends Iterable<Direction>, Embedding
     
     Direction createNewZoneOrbit( String name, int prototype, int rotatedPrototype, AlgebraicVector vector );
 
-    String getDefaultStyle();
-
     public abstract int[] getIncidentOrientations( int orientation );
 
     public abstract Direction getSpecialOrbit( SpecialOrbit which );

--- a/core/src/main/java/com/vzome/core/tools/SymmetryTool.java
+++ b/core/src/main/java/com/vzome/core/tools/SymmetryTool.java
@@ -209,7 +209,7 @@ public class SymmetryTool extends TransformationTool
 	            }
 	            if ( prepareTool ) {
 	                AlgebraicMatrix inverse = orientation .inverse();
-	                OctahedralSymmetry octa = new OctahedralSymmetry( symmetry .getField(), null, null );
+	                OctahedralSymmetry octa = new OctahedralSymmetry( symmetry .getField(), null );
 	                int order = octa .getChiralOrder();
 	                this .transforms = new Transformation[ order-1 ];
 	                for ( int i = 0; i < order-1; i++ ) {

--- a/core/src/main/java/com/vzome/core/tools/SymmetryTool.java
+++ b/core/src/main/java/com/vzome/core/tools/SymmetryTool.java
@@ -203,13 +203,20 @@ public class SymmetryTool extends TransformationTool
 	                    break;
 
 	                default:
+	                    // TODO: Test this with the RootTwo.synestructicsSymmetry
+	                    // and if that's broke, then make this more generalized so it does work 
 	                    return "selected alignment strut is not an octahedral axis.";
 	                }
 	                orientation = symmetry .getMatrix( blueIndex );
 	            }
 	            if ( prepareTool ) {
 	                AlgebraicMatrix inverse = orientation .inverse();
-	                OctahedralSymmetry octa = new OctahedralSymmetry( symmetry .getField(), null );
+                    // Only make a new OctahedralSymmetry if necessary
+	                // TODO: When would it be necessary?
+	                // Maybe when loading a legacy file - Dunno - DJH ???
+	                OctahedralSymmetry octa = (symmetry instanceof OctahedralSymmetry) 
+	                        ? (OctahedralSymmetry) symmetry
+	                        : new OctahedralSymmetry( symmetry .getField() );
 	                int order = octa .getChiralOrder();
 	                this .transforms = new Transformation[ order-1 ];
 	                for ( int i = 0; i < order-1; i++ ) {

--- a/core/src/main/java/com/vzome/fields/heptagon/HeptagonalAntiprismSymmetry.java
+++ b/core/src/main/java/com/vzome/fields/heptagon/HeptagonalAntiprismSymmetry.java
@@ -19,14 +19,14 @@ public class HeptagonalAntiprismSymmetry extends AbstractSymmetry
 	private final boolean correctedOrbits;
     private Axis preferredAxis;
 
-    public HeptagonalAntiprismSymmetry( AlgebraicField field, String frameColor, String defaultStyle )
+    public HeptagonalAntiprismSymmetry( AlgebraicField field, String frameColor)
 	{
-		this( field, frameColor, defaultStyle, false);
+		this( field, frameColor, false);
 	}
 
-	public HeptagonalAntiprismSymmetry( AlgebraicField field, String frameColor, String defaultStyle, boolean correctedOrbits )
+	public HeptagonalAntiprismSymmetry( AlgebraicField field, String frameColor, boolean correctedOrbits )
 	{
-		super( 14, field, frameColor, defaultStyle,
+		super( 14, field, frameColor,
 					correctedOrbits?
 							// reflection in Z (red) will yield the negative zones
 							new AlgebraicMatrix( field .basisVector( 3, AlgebraicVector.X ),

--- a/core/src/main/java/com/vzome/fields/heptagon/TriangularAntiprismSymmetry.java
+++ b/core/src/main/java/com/vzome/fields/heptagon/TriangularAntiprismSymmetry.java
@@ -13,9 +13,9 @@ public class TriangularAntiprismSymmetry extends OctahedralSymmetry
 {
     private final Matrix3d SHEAR;
 
-	public TriangularAntiprismSymmetry( AlgebraicField field, String frameColor, String defaultStyle )
+	public TriangularAntiprismSymmetry( AlgebraicField field, String frameColor )
 	{
-		super( field, frameColor, defaultStyle );
+		super( field, frameColor );
 
         HeptagonField hf = (HeptagonField) this .mField;
         final double rho = hf.getUnitTerm(1).evaluate();
@@ -49,12 +49,6 @@ public class TriangularAntiprismSymmetry extends OctahedralSymmetry
 
     @Override
     public String getName()
-    {
-        return "triangular antiprism";
-    }
-
-    @Override
-    public String getDefaultStyle()
     {
         return "triangular antiprism";
     }

--- a/core/src/main/java/com/vzome/fields/sqrtphi/PentagonalAntiprismSymmetry.java
+++ b/core/src/main/java/com/vzome/fields/sqrtphi/PentagonalAntiprismSymmetry.java
@@ -42,9 +42,9 @@ public class PentagonalAntiprismSymmetry extends AbstractSymmetry
 
     private Axis preferredAxis;
         
-    public PentagonalAntiprismSymmetry( AlgebraicField field, String frameColor, String defaultStyle )
+    public PentagonalAntiprismSymmetry( AlgebraicField field, String frameColor )
 	{
-		super( 10, field, frameColor, defaultStyle, field .createMatrix( PRINCIPAL_REFLECTION ) );
+		super( 10, field, frameColor, field .createMatrix( PRINCIPAL_REFLECTION ) );
 		// calls createInitialPermutations, createFrameOrbit, createOtherOrbits
 	}
 

--- a/core/src/main/java/com/vzome/fields/sqrtphi/SqrtPhiFieldApplication.java
+++ b/core/src/main/java/com/vzome/fields/sqrtphi/SqrtPhiFieldApplication.java
@@ -81,7 +81,7 @@ public class SqrtPhiFieldApplication extends DefaultFieldApplication
 	}
 	
     private final IcosahedralSymmetryPerspective icosahedralPerspective = new IcosahedralSymmetryPerspective( 
-            new IcosahedralSymmetry( getField(), "small octahedra" ) ) 
+            new IcosahedralSymmetry( getField() ) ) 
     {
         {
             final IcosahedralSymmetry icosaSymm = this.getSymmetry();
@@ -99,7 +99,7 @@ public class SqrtPhiFieldApplication extends DefaultFieldApplication
     };
     
     private final SymmetryPerspective pentagonalPerspective = new AbstractSymmetryPerspective(
-            new PentagonalAntiprismSymmetry( getField(), "small octahedra", null ) ) 
+            new PentagonalAntiprismSymmetry( getField(), null ) ) 
     {
         {
             final PentagonalAntiprismSymmetry pentaSymm = getSymmetry();

--- a/core/src/test/java/com/vzome/core/apps/DumpBlueAngles.java
+++ b/core/src/test/java/com/vzome/core/apps/DumpBlueAngles.java
@@ -16,7 +16,7 @@ public class DumpBlueAngles {
     {
     	final double EPSILON = 5E-10f;
 
-        Symmetry icosa = new IcosahedralSymmetry( new PentagonField(), "solid connectors" );
+        Symmetry icosa = new IcosahedralSymmetry( new PentagonField() );
         Direction blue = icosa .getDirection( "blue" );
         
         Map<Double, Axis[]> blueAngles = new HashMap<>();

--- a/core/src/test/java/com/vzome/core/editor/RunZomodScript.java
+++ b/core/src/test/java/com/vzome/core/editor/RunZomodScript.java
@@ -27,7 +27,7 @@ public class RunZomodScript extends RunZomicScript
 	@Override
     protected ZomicStatement parseScript( String script ) throws Failure
     {
-        Parser parser = new Parser( new IcosahedralSymmetry( new PentagonField(), "default" ));
+        Parser parser = new Parser( new IcosahedralSymmetry( new PentagonField() ));
         List<String> errors = new ArrayList<>();
         ZomicStatement program = parser .parse(
             new ByteArrayInputStream( script .getBytes() ), new ErrorHandler.Default( errors ), "" );

--- a/core/src/test/java/com/vzome/core/generic/ComparableDirectionTest.java
+++ b/core/src/test/java/com/vzome/core/generic/ComparableDirectionTest.java
@@ -23,7 +23,7 @@ public class ComparableDirectionTest extends ComparableTest<Direction> {
 	private final Direction[] ordered3Values;
 
 	public ComparableDirectionTest() {
-        Symmetry symmetry = new IcosahedralSymmetry( new PentagonField(), "default" );
+        Symmetry symmetry = new IcosahedralSymmetry( new PentagonField() );
 		ArrayList<Direction> list = new ArrayList<>();
         Direction[] o3V = null;
         for(String dirName : symmetry.getDirectionNames()) {
@@ -35,7 +35,7 @@ public class ComparableDirectionTest extends ComparableTest<Direction> {
 		testValues = list.toArray(new Direction[list.size()]);
 
 		list.clear();
-        symmetry = new OctahedralSymmetry( new HeptagonField(), "blue", "octahedra" );
+        symmetry = new OctahedralSymmetry( new HeptagonField(), "blue" );
         for(String dirName : symmetry.getDirectionNames()) {
             list.add(symmetry.getDirection(dirName));
         }

--- a/core/src/test/java/com/vzome/core/generic/ComparableDirectionTest.java
+++ b/core/src/test/java/com/vzome/core/generic/ComparableDirectionTest.java
@@ -35,7 +35,7 @@ public class ComparableDirectionTest extends ComparableTest<Direction> {
 		testValues = list.toArray(new Direction[list.size()]);
 
 		list.clear();
-        symmetry = new OctahedralSymmetry( new HeptagonField(), "blue" );
+        symmetry = new OctahedralSymmetry( new HeptagonField() );
         for(String dirName : symmetry.getDirectionNames()) {
             list.add(symmetry.getDirection(dirName));
         }

--- a/core/src/test/java/com/vzome/core/math/symmetry/SymmetryTest.java
+++ b/core/src/test/java/com/vzome/core/math/symmetry/SymmetryTest.java
@@ -19,7 +19,7 @@ public class SymmetryTest
     @Test
     public void testAxisIncidence()
     {
-        IcosahedralSymmetry symm = new IcosahedralSymmetry( new PentagonField(), null );
+        IcosahedralSymmetry symm = new IcosahedralSymmetry( new PentagonField() );
         
         assertTrue( Arrays.equals( new int[]{ 22, 50, 19 }, symm .getIncidentOrientations( 10 ) ) );
         assertTrue( Arrays.equals( new int[]{ 20, 52, 17 }, symm .getIncidentOrientations( 44 ) ) );
@@ -29,7 +29,7 @@ public class SymmetryTest
     public void testGetAxis()
     {
         RealVector vector = new RealVector( 0.1, 0.1, 3.0 ); // should be orientation -47
-        IcosahedralSymmetry symm = new IcosahedralSymmetry( new PentagonField(), null );
+        IcosahedralSymmetry symm = new IcosahedralSymmetry( new PentagonField() );
         
         Direction orbit = symm .getDirection( "red" );
         Axis axis = orbit .getAxis( vector );
@@ -135,7 +135,7 @@ public class SymmetryTest
     @Test
     public void testGetAxis2()
     {
-        IcosahedralSymmetry symm = new IcosahedralSymmetry( new PentagonField(), null );
+        IcosahedralSymmetry symm = new IcosahedralSymmetry( new PentagonField() );
         
         Direction orbit = symm .getDirection( "turquoise" );
         Axis expected = orbit .getAxis( Symmetry.MINUS, 23 );
@@ -148,7 +148,7 @@ public class SymmetryTest
     @Test
     public void testTetrahedral()
     {
-        IcosahedralSymmetry symm = new IcosahedralSymmetry( new PentagonField(), null );
+        IcosahedralSymmetry symm = new IcosahedralSymmetry( new PentagonField() );
         
         Axis greenZone = symm .getDirection( "green" ) .getAxis( Symmetry.MINUS, 23 );
         Axis blueZone = symm .getDirection( "blue" ) .getAxis( Symmetry.PLUS, 31 );

--- a/core/src/test/java/com/vzome/core/zomic/ZomicASTTest.java
+++ b/core/src/test/java/com/vzome/core/zomic/ZomicASTTest.java
@@ -59,7 +59,7 @@ public class ZomicASTTest
 	private final ZomicNamingConvention namingConvention;
 	
 	public ZomicASTTest() {
-		symmetry = new IcosahedralSymmetry( new PentagonField(), "default" );
+		symmetry = new IcosahedralSymmetry( new PentagonField() );
 		namingConvention = new ZomicNamingConvention(symmetry);
 		initColors();	
 	}

--- a/core/src/test/java/com/vzome/core/zomic/program/PrintVisitor.java
+++ b/core/src/test/java/com/vzome/core/zomic/program/PrintVisitor.java
@@ -224,7 +224,7 @@ public class PrintVisitor extends Visitor .Default{
 			}
 
 			PentagonField field = new PentagonField();
-			IcosahedralSymmetry symmetry = new IcosahedralSymmetry( field, "solid connectors" );
+			IcosahedralSymmetry symmetry = new IcosahedralSymmetry( field );
 			ZomicStatement program;
 			if(useNewParser) {
 				program = ZomicASTCompiler.compile( file, symmetry);

--- a/core/src/test/java/com/vzome/fields/heptagon/HeptagonalAntiprismSymmetryTest.java
+++ b/core/src/test/java/com/vzome/fields/heptagon/HeptagonalAntiprismSymmetryTest.java
@@ -1,6 +1,6 @@
 package com.vzome.fields.heptagon;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
@@ -18,7 +18,7 @@ public class HeptagonalAntiprismSymmetryTest {
 	public void testPermutations()
 	{
 		HeptagonField field = new HeptagonField();
-		Symmetry symm = new HeptagonalAntiprismSymmetry( field, "blue", null );
+		Symmetry symm = new HeptagonalAntiprismSymmetry( field, "blue" );
 
 		Permutation perm7 = symm .getPermutation( 3 );
 		assertEquals( 7, perm7 .getOrder() );
@@ -41,7 +41,7 @@ public class HeptagonalAntiprismSymmetryTest {
 	public void testOrientations()
 	{
 		HeptagonField field = new HeptagonField();
-		HeptagonalAntiprismSymmetry symm = new HeptagonalAntiprismSymmetry( field, "blue", null );
+		HeptagonalAntiprismSymmetry symm = new HeptagonalAntiprismSymmetry( field, "blue" );
 
 		AlgebraicMatrix m2 = symm .getMatrix( 2 );
 		AlgebraicMatrix m4 = symm .getMatrix( 4 );
@@ -54,7 +54,7 @@ public class HeptagonalAntiprismSymmetryTest {
     public void testGetAxisUncorrected()
     {
         HeptagonField field = new HeptagonField();
-        HeptagonalAntiprismSymmetry symm = new HeptagonalAntiprismSymmetry( field, "blue", "heptagonal antiprism" );
+        HeptagonalAntiprismSymmetry symm = new HeptagonalAntiprismSymmetry( field, "blue" );
 		symm .createStandardOrbits( "blue" );
 
         RealVector v1 = new RealVector( 0.1, 0.1, 3.0 );
@@ -105,7 +105,7 @@ public class HeptagonalAntiprismSymmetryTest {
     public void testGetAxisCorrected()
     {
         HeptagonField field = new HeptagonField();
-        HeptagonalAntiprismSymmetry symm = new HeptagonalAntiprismSymmetry( field, "blue", "heptagonal antiprism corrected", true );
+        HeptagonalAntiprismSymmetry symm = new HeptagonalAntiprismSymmetry( field, "blue", true );
 		symm .createStandardOrbits( "blue" );
 
         RealVector v1 = new RealVector( 0.5, 0.1, 0.1 );


### PR DESCRIPTION
Minor cleanup of the Symmetry class, just for my own clarity. Comments in the commits should explain the changes. No functional changes.