### PR TITLE
Add yellow direction to heptagonal antiprism symmetry

### DIFF
--- a/core/src/main/java/com/vzome/fields/heptagon/HeptagonalAntiprismSymmetry.java
+++ b/core/src/main/java/com/vzome/fields/heptagon/HeptagonalAntiprismSymmetry.java
@@ -148,6 +148,10 @@ public class HeptagonalAntiprismSymmetry extends AbstractSymmetry
         Direction blueOrbit = createZoneOrbit( frameColor, 0, 7, this .mField .basisVector( 3, AlgebraicVector.X ), true );
         blueOrbit .setDotLocation( 0d, 1d );
 
+        AlgebraicVector yellowVector = mField.createIntegerVector(new int[][]{ { 1, 0, 0 },  {-2, 0, 1 },  { 0, 0, 0 } } );
+        AlgebraicNumber yellowScalar= mField.createRational(2).dividedBy(mField.createAlgebraicNumber(new int[] { 3, 2,-2 }));
+        createZoneOrbit( "yellow", 0, 7, yellowVector, true, false, yellowScalar);
+
         return this;
     }
     
@@ -186,21 +190,11 @@ public class HeptagonalAntiprismSymmetry extends AbstractSymmetry
 	{
 		return null; // TODO
 	}
-    
+
     @Override
-    protected AlgebraicVector[] getOrbitTriangle()
+    public boolean reverseOrbitTriangle()
     {
-        HeptagonField hf = (HeptagonField) this .getField();
-        
-        AlgebraicVector blueVertex = hf .basisVector( 3, AlgebraicVector.X );
-        AlgebraicVector redVertex = hf .basisVector( 3, AlgebraicVector.Z );
-        
-        AlgebraicNumber s = hf .getAffineScalar().reciprocal(); // reciprocal of sigma
-        AlgebraicVector orthoVertex = hf .origin( 3 )
-                .setComponent( AlgebraicVector.X, hf .one() )
-                .setComponent( AlgebraicVector.Y, s .negate() );
-        
-        return new AlgebraicVector[] { blueVertex, redVertex, orthoVertex };
+        return true;
     }
 
 	@Override
@@ -209,13 +203,13 @@ public class HeptagonalAntiprismSymmetry extends AbstractSymmetry
         switch ( which ) {
 
         case BLUE:
-            return this .getDirection( "blue" );
+            return this .getDirection( "blue" );  // TODO: should use frameColor
 
         case RED:
             return this .getDirection( "red" );
 
         case YELLOW:
-            return this .getDirection( "blue" );
+            return this .getDirection( "yellow" ); 
 
         default:
             return null;

--- a/core/src/test/java/com/vzome/core/kinds/FieldApplicationTest.java
+++ b/core/src/test/java/com/vzome/core/kinds/FieldApplicationTest.java
@@ -199,11 +199,11 @@ public class FieldApplicationTest
             break;
 
         case "heptagonal antiprism":
-            addTo(testNames, "red", "blue");
+            addTo(testNames, "red", "blue", "yellow");
             break;
 
         case "heptagonal antiprism corrected":
-            addTo(testNames, "red", "blue");
+            addTo(testNames, "red", "blue", "yellow");
             break;
 
         case "synestructics":

--- a/desktop/src/main/resources/org/vorthmann/zome/app/heptagonal antiprism.vZome
+++ b/desktop/src/main/resources/org/vorthmann/zome/app/heptagonal antiprism.vZome
@@ -1,322 +1,552 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<vzome:vZome xmlns:vzome="http://xml.vzome.com/vZome/4.0.0/" buildNumber="NONE" coreVersion="0.9.0" edition="vZome" field="heptagon" version="6.0">
-  <EditHistory editNumber="260" lastStickyEdit="105">
-    <StrutCreation anchor="0 0 0 0 0 0 0 0 0" index="0" len="1 5 4" symm="heptagonal antiprism"/>
-    <StrutCreation anchor="0 0 0 0 0 0 0 0 0" index="3" len="1 5 4" sense="minus" symm="heptagonal antiprism"/>
-    <BeginBlock/>
-    <SelectManifestation point="1 5 4 1 -4 -1 0 0 0"/>
-    <SelectManifestation point="1 5 4 0 0 0 0 0 0"/>
-    <DeselectAll/>
-    <EndBlock/>
-    <Branch>
-      <StrutCreation anchor="0 0 0 0 0 0 0 0 0" dir="red" index="0" len="0 2 1" symm="heptagonal antiprism"/>
-      <SelectManifestation endSegment="0 0 0 0 0 0 0 2 1" startSegment="0 0 0 0 0 0 0 0 0"/>
-      <RotationTool corrected="true" full="true" name="axial symmetry.1" symmetry="heptagonal antiprism"/>
-    </Branch>
-    <StrutCreation anchor="0 0 0 0 0 0 0 0 0" dir="red" index="0" len="1 5 4" symm="heptagonal antiprism"/>
-    <BeginBlock/>
-    <SelectManifestation point="1 5 4 0 0 0 0 0 0"/>
-    <SelectManifestation point="1 5 4 1 -4 -1 0 0 0"/>
-    <EndBlock/>
-    <ApplyTool name="axial symmetry.1" selectInputs="true"/>
-    <StrutCreation anchor="0 0 0 0 0 0 0 0 0" dir="red" index="7" len="1 5 4" symm="heptagonal antiprism"/>
-    <BeginBlock/>
-    <SelectManifestation point="0 0 0 0 0 0 1 5 4"/>
-    <SelectManifestation point="4 0 5 -4 0 -5 0 0 0"/>
-    <DeselectAll/>
-    <SelectManifestation point="0 0 0 0 0 0 1 5 4"/>
-    <SelectManifestation point="1 5 4 0 0 0 0 0 0"/>
-    <EndBlock/>
-    <JoinPoints closedLoop="false"/>
-    <DeselectAll/>
-    <StrutCreation anchor="1 5 4 0 0 0 0 0 0" dir="2" index="9" len="0 1 0" sense="minus" symm="heptagonal antiprism"/>
-    <StrutCreation anchor="0 0 0 0 0 0 1 5 4" dir="2" index="9" len="0 1 0" symm="heptagonal antiprism"/>
-    <SelectManifestation point="0 1 0 0 0 0 1 4 4"/>
-    <ApplyTool name="axial symmetry.1" selectInputs="true"/>
-    <DeselectAll/>
-    <StrutCreation anchor="0 0 0 0 0 0 1 5 4" dir="2" index="1" len="0 1 0" sense="minus" symm="heptagonal antiprism"/>
-    <SelectManifestation point="0 1 0 1 -1 0 1 4 4"/>
-    <ApplyTool name="axial symmetry.1" selectInputs="true"/>
-    <BeginBlock/>
-    <DeselectAll/>
-    <SelectManifestation endSegment="0 1 0 1 -1 0 1 4 4" startSegment="0 0 0 0 0 0 1 5 4"/>
-    <SelectManifestation endSegment="0 1 0 0 0 0 1 4 4" startSegment="0 0 0 0 0 0 1 5 4"/>
-    <EndBlock/>
-    <Delete/>
-    <BeginBlock/>
-    <SelectManifestation point="1 5 4 0 0 0 0 0 0"/>
-    <SelectManifestation point="1 5 4 1 -4 -1 0 0 0"/>
-    <SelectManifestation point="1 5 4 1 -4 -1 0 0 0"/>
-    <DeselectAll/>
-    <SelectManifestation point="1 5 4 1 -4 -1 0 0 0"/>
-    <EndBlock/>
-    <ApplyTool name="axial symmetry.1" selectInputs="true"/>
-    <Delete/>
-    <BeginBlock/>
-    <SelectManifestation point="1 5 4 0 0 0 0 0 0"/>
-    <SelectManifestation point="4 0 5 -4 0 -5 0 0 0"/>
-    <EndBlock/>
-    <JoinPoints closedLoop="false"/>
-    <BeginBlock/>
-    <DeselectAll/>
-    <SelectManifestation endSegment="1 5 4 1 -4 -1 0 0 0" startSegment="0 0 0 0 0 0 0 0 0"/>
-    <SelectManifestation endSegment="4 0 5 -4 0 -5 0 0 0" startSegment="1 5 4 0 0 0 0 0 0"/>
-    <EndBlock/>
-    <StrutIntersection/>
-    <StrutCreation anchor="1 5 4 0 0 0 0 0 0" dir="1" index="8" len="1 0 0" symm="heptagonal antiprism"/>
-    <StrutCreation anchor="1 5 4 0 0 0 0 0 0" dir="1" index="6" len="1 0 0" symm="heptagonal antiprism"/>
-    <BeginBlock/>
-    <SelectManifestation point="1 -1 1 -1 1 -1 1 4 4"/>
-    <SelectManifestation point="0 1 0 1 -1 0 1 4 4"/>
-    <DeselectAll/>
-    <SelectManifestation point="0 1 0 1 -1 0 1 4 4"/>
-    <SelectManifestation point="0 1 0 0 0 0 1 4 4"/>
-    <DeselectAll/>
-    <SelectManifestation point="0 -1 0 -1 1 0 1 4 4"/>
-    <SelectManifestation point="0 -1 0 0 0 0 1 4 4"/>
-    <DeselectAll/>
-    <SelectManifestation point="0 1 0 1 -1 0 1 4 4"/>
-    <EndBlock/>
-    <ApplyTool name="axial symmetry.1" selectInputs="true"/>
-    <Delete/>
-    <BeginBlock/>
-    <SelectManifestation point="0 0 0 0 0 0 1 5 4"/>
-    <SelectManifestation point="5/2 5/2 9/2 -2 0 -5/2 0 0 0"/>
-    <EndBlock/>
-    <JoinPoints closedLoop="false"/>
-    <StrutCreation anchor="0 0 0 0 0 0 1 5 4" dir="3" index="0" len="0 1 0" symm="heptagonal antiprism"/>
-    <BeginBlock/>
-    <SelectManifestation point="1/2 0 1/2 -1/2 1/2 -1/2 1 4 4"/>
-    <SelectManifestation point="0 1 0 0 0 0 1 4 4"/>
-    <DeselectAll/>
-    <SelectManifestation point="1/2 0 1/2 -1/2 1/2 -1/2 1 4 4"/>
-    <EndBlock/>
-    <ApplyTool name="axial symmetry.1" selectInputs="true"/>
-    <BeginBlock/>
-    <DeselectAll/>
-    <SelectManifestation point="0 -1 0 -1 1 0 1 4 4"/>
-    <SelectManifestation point="1/2 -1 0 -1/2 1 0 1 4 4"/>
-    <DeselectAll/>
-    <SelectManifestation point="0 -1 0 -1 1 0 1 4 4"/>
-    <SelectManifestation point="-1/2 0 -1/2 0 0 0 1 4 4"/>
-    <DeselectAll/>
-    <SelectManifestation endSegment="0 0 0 0 0 0 1 5 4" startSegment="0 0 0 0 0 0 0 0 0"/>
+<vzome:vZome xmlns:vzome="http://xml.vzome.com/vZome/4.0.0/" buildNumber="DEV" coreVersion="7.0" edition="vZome" field="heptagon" version="7.0">
+  <EditHistory editNumber="37" lastStickyEdit="-1">
     <SelectManifestation point="0 0 0 0 0 0 0 0 0"/>
-    <EndBlock/>
-    <MirrorTool name="mirror.1"/>
-    <BeginBlock/>
-    <DeselectAll/>
-    <SelectManifestation endSegment="1 5 4 0 0 0 0 0 0" startSegment="0 0 0 0 0 0 0 0 0"/>
-    <SelectManifestation point="0 0 0 0 0 0 0 0 0"/>
-    <EndBlock/>
-    <RotationTool corrected="true" full="true" name="axial symmetry.2" symmetry="heptagonal antiprism"/>
-    <BeginBlock/>
-    <DeselectAll/>
-    <SelectManifestation point="-1/2 1 0 1/2 -1/2 1/2 1 4 4"/>
-    <SelectManifestation point="1/2 0 1/2 -1/2 1/2 -1/2 1 4 4"/>
-    <EndBlock/>
-    <ApplyTool name="axial symmetry.2" selectInputs="true"/>
-    <BeginBlock/>
-    <DeselectAll/>
-    <SelectManifestation point="0 1 0 0 0 0 1 4 4"/>
-    <EndBlock/>
-    <ApplyTool name="axial symmetry.2" selectInputs="true"/>
-    <BeginBlock/>
-    <BeginBlock/>
-    <DeselectAll/>
-    <SelectManifestation point="5/2 5/2 9/2 -2 0 -5/2 0 0 0"/>
-    <EndBlock/>
-    <ApplyTool name="axial symmetry.2" selectInputs="true"/>
-    <BeginBlock/>
-    <DeselectAll/>
-    <SelectManifestation endSegment="1 5 4 0 0 0 0 0 0" startSegment="0 0 0 0 0 0 1 5 4"/>
-    <EndBlock/>
     <Delete/>
-    <StrutCreation anchor="1 5 4 0 0 0 0 0 0" dir="2" index="9" len="1 0 1" sense="minus" symm="heptagonal antiprism"/>
-    <SelectManifestation endSegment="4 0 5 -4 0 -5 0 0 0" startSegment="1 5 4 0 0 0 0 0 0"/>
-    <Delete/>
-    <StrutCreation anchor="1 5 4 0 0 0 0 0 0" dir="1" index="8" len="0 1 0" symm="heptagonal antiprism"/>
+    <LoadVEF projection="Quaternion" quaternion="1 0 0 0 0 0 0 0 0 0 0 0" scale="1/56 0 -1/56">vZome VEF 6 field heptagon
+
+170
+(0,0,0) (-128,-288,32) (-16,160,-80) (0,0,0)
+(0,0,0) (-148,-228,-12) (-8,80,-40) (0,0,0)
+(0,0,0) (-148,-228,-12) (20,136,-40) (0,0,0)
+(0,0,0) (-168,-168,-56) (0,0,0) (0,0,0)
+(0,0,0) (-168,-168,-56) (56,112,0) (0,0,0)
+(0,0,0) (-188,-108,-100) (8,-80,40) (0,0,0)
+(0,0,0) (-188,-108,-100) (92,88,40) (0,0,0)
+(0,0,0) (-208,-48,-144) (16,-160,80) (0,0,0)
+(0,0,0) (-208,-48,-144) (128,64,80) (0,0,0)
+(0,0,0) (-112,-252,28) (-14,140,-70) (-21,-21,-7)
+(0,0,0) (-112,-252,28) (-14,140,-70) (21,21,7)
+(0,0,0) (-147,-147,-49) (0,0,0) (-21,-21,-7)
+(0,0,0) (-147,-147,-49) (0,0,0) (21,21,7)
+(0,0,0) (-147,-147,-49) (49,98,0) (-21,-21,-7)
+(0,0,0) (-147,-147,-49) (49,98,0) (21,21,7)
+(0,0,0) (-188,-52,-128) (-20,-136,40) (0,0,0)
+(0,0,0) (-188,-52,-128) (148,60,96) (0,0,0)
+(0,0,0) (-182,-42,-126) (14,-140,70) (-21,-21,-7)
+(0,0,0) (-182,-42,-126) (14,-140,70) (21,21,7)
+(0,0,0) (-182,-42,-126) (112,56,70) (-21,-21,-7)
+(0,0,0) (-182,-42,-126) (112,56,70) (21,21,7)
+(0,0,0) (-168,-56,-112) (-56,-112,0) (0,0,0)
+(0,0,0) (-168,-56,-112) (168,56,112) (0,0,0)
+(0,0,0) (-148,-60,-96) (-92,-88,-40) (0,0,0)
+(0,0,0) (-148,-60,-96) (188,52,128) (0,0,0)
+(0,0,0) (-147,-49,-98) (-49,-98,0) (-21,-21,-7)
+(0,0,0) (-147,-49,-98) (-49,-98,0) (21,21,7)
+(0,0,0) (-147,-49,-98) (147,49,98) (-21,-21,-7)
+(0,0,0) (-147,-49,-98) (147,49,98) (21,21,7)
+(0,0,0) (-128,-64,-80) (-128,-64,-80) (0,0,0)
+(0,0,0) (-128,-64,-80) (208,48,144) (0,0,0)
+(0,0,0) (-112,-56,-70) (-112,-56,-70) (-21,-21,-7)
+(0,0,0) (-112,-56,-70) (-112,-56,-70) (21,21,7)
+(0,0,0) (-112,-56,-70) (182,42,126) (-21,-21,-7)
+(0,0,0) (-112,-56,-70) (182,42,126) (21,21,7)
+(0,0,0) (-92,-88,-40) (-148,-60,-96) (0,0,0)
+(0,0,0) (-92,-88,-40) (188,108,100) (0,0,0)
+(0,0,0) (-56,-112,0) (-168,-56,-112) (0,0,0)
+(0,0,0) (-56,-112,0) (168,168,56) (0,0,0)
+(0,0,0) (-49,-98,0) (-147,-49,-98) (-21,-21,-7)
+(0,0,0) (-49,-98,0) (-147,-49,-98) (21,21,7)
+(0,0,0) (-49,-98,0) (147,147,49) (-21,-21,-7)
+(0,0,0) (-49,-98,0) (147,147,49) (21,21,7)
+(0,0,0) (-20,-136,40) (-188,-52,-128) (0,0,0)
+(0,0,0) (-20,-136,40) (148,228,12) (0,0,0)
+(0,0,0) (16,-160,80) (-208,-48,-144) (0,0,0)
+(0,0,0) (16,-160,80) (128,288,-32) (0,0,0)
+(0,0,0) (14,-140,70) (-182,-42,-126) (-21,-21,-7)
+(0,0,0) (14,-140,70) (-182,-42,-126) (21,21,7)
+(0,0,0) (14,-140,70) (112,252,-28) (-21,-21,-7)
+(0,0,0) (14,-140,70) (112,252,-28) (21,21,7)
+(0,0,0) (-16,-36,4) (-2,20,-10) (-147,-147,-49)
+(0,0,0) (-16,-36,4) (-2,20,-10) (147,147,49)
+(0,0,0) (-21,-21,-7) (0,0,0) (-147,-147,-49)
+(0,0,0) (-21,-21,-7) (0,0,0) (147,147,49)
+(0,0,0) (-21,-21,-7) (7,14,0) (-147,-147,-49)
+(0,0,0) (-21,-21,-7) (7,14,0) (147,147,49)
+(0,0,0) (-26,-6,-18) (2,-20,10) (-147,-147,-49)
+(0,0,0) (-26,-6,-18) (2,-20,10) (147,147,49)
+(0,0,0) (-26,-6,-18) (16,8,10) (-147,-147,-49)
+(0,0,0) (-26,-6,-18) (16,8,10) (147,147,49)
+(0,0,0) (8,-80,40) (-188,-108,-100) (0,0,0)
+(0,0,0) (8,-80,40) (148,228,12) (0,0,0)
+(0,0,0) (-21,-7,-14) (-7,-14,0) (-147,-147,-49)
+(0,0,0) (-21,-7,-14) (-7,-14,0) (147,147,49)
+(0,0,0) (-21,-7,-14) (21,7,14) (-147,-147,-49)
+(0,0,0) (-21,-7,-14) (21,7,14) (147,147,49)
+(0,0,0) (-16,-8,-10) (-16,-8,-10) (-147,-147,-49)
+(0,0,0) (-16,-8,-10) (-16,-8,-10) (147,147,49)
+(0,0,0) (-16,-8,-10) (26,6,18) (-147,-147,-49)
+(0,0,0) (-16,-8,-10) (26,6,18) (147,147,49)
+(0,0,0) (-7,-14,0) (-21,-7,-14) (-147,-147,-49)
+(0,0,0) (-7,-14,0) (-21,-7,-14) (147,147,49)
+(0,0,0) (-7,-14,0) (21,21,7) (-147,-147,-49)
+(0,0,0) (-7,-14,0) (21,21,7) (147,147,49)
+(0,0,0) (2,-20,10) (-26,-6,-18) (-147,-147,-49)
+(0,0,0) (2,-20,10) (-26,-6,-18) (147,147,49)
+(0,0,0) (2,-20,10) (16,36,-4) (-147,-147,-49)
+(0,0,0) (2,-20,10) (16,36,-4) (147,147,49)
+(0,0,0) (0,0,0) (-168,-168,-56) (0,0,0)
+(0,0,0) (0,0,0) (-147,-147,-49) (-21,-21,-7)
+(0,0,0) (0,0,0) (-147,-147,-49) (21,21,7)
+(0,0,0) (0,0,0) (-21,-21,-7) (-147,-147,-49)
+(0,0,0) (0,0,0) (-21,-21,-7) (147,147,49)
+(0,0,0) (0,0,0) (0,0,0) (-168,-168,-56)
+(0,0,0) (0,0,0) (0,0,0) (168,168,56)
+(0,0,0) (0,0,0) (21,21,7) (-147,-147,-49)
+(0,0,0) (0,0,0) (21,21,7) (147,147,49)
+(0,0,0) (0,0,0) (147,147,49) (-21,-21,-7)
+(0,0,0) (0,0,0) (147,147,49) (21,21,7)
+(0,0,0) (0,0,0) (168,168,56) (0,0,0)
+(0,0,0) (-2,20,-10) (-16,-36,4) (-147,-147,-49)
+(0,0,0) (-2,20,-10) (-16,-36,4) (147,147,49)
+(0,0,0) (-2,20,-10) (26,6,18) (-147,-147,-49)
+(0,0,0) (-2,20,-10) (26,6,18) (147,147,49)
+(0,0,0) (7,14,0) (-21,-21,-7) (-147,-147,-49)
+(0,0,0) (7,14,0) (-21,-21,-7) (147,147,49)
+(0,0,0) (7,14,0) (21,7,14) (-147,-147,-49)
+(0,0,0) (7,14,0) (21,7,14) (147,147,49)
+(0,0,0) (16,8,10) (-26,-6,-18) (-147,-147,-49)
+(0,0,0) (16,8,10) (-26,-6,-18) (147,147,49)
+(0,0,0) (16,8,10) (16,8,10) (-147,-147,-49)
+(0,0,0) (16,8,10) (16,8,10) (147,147,49)
+(0,0,0) (21,7,14) (-21,-7,-14) (-147,-147,-49)
+(0,0,0) (21,7,14) (-21,-7,-14) (147,147,49)
+(0,0,0) (21,7,14) (7,14,0) (-147,-147,-49)
+(0,0,0) (21,7,14) (7,14,0) (147,147,49)
+(0,0,0) (-8,80,-40) (-148,-228,-12) (0,0,0)
+(0,0,0) (-8,80,-40) (188,108,100) (0,0,0)
+(0,0,0) (26,6,18) (-16,-8,-10) (-147,-147,-49)
+(0,0,0) (26,6,18) (-16,-8,-10) (147,147,49)
+(0,0,0) (26,6,18) (-2,20,-10) (-147,-147,-49)
+(0,0,0) (26,6,18) (-2,20,-10) (147,147,49)
+(0,0,0) (21,21,7) (-7,-14,0) (-147,-147,-49)
+(0,0,0) (21,21,7) (-7,-14,0) (147,147,49)
+(0,0,0) (21,21,7) (0,0,0) (-147,-147,-49)
+(0,0,0) (21,21,7) (0,0,0) (147,147,49)
+(0,0,0) (16,36,-4) (2,-20,10) (-147,-147,-49)
+(0,0,0) (16,36,-4) (2,-20,10) (147,147,49)
+(0,0,0) (-14,140,-70) (-112,-252,28) (-21,-21,-7)
+(0,0,0) (-14,140,-70) (-112,-252,28) (21,21,7)
+(0,0,0) (-14,140,-70) (182,42,126) (-21,-21,-7)
+(0,0,0) (-14,140,-70) (182,42,126) (21,21,7)
+(0,0,0) (-16,160,-80) (-128,-288,32) (0,0,0)
+(0,0,0) (-16,160,-80) (208,48,144) (0,0,0)
+(0,0,0) (20,136,-40) (-148,-228,-12) (0,0,0)
+(0,0,0) (20,136,-40) (188,52,128) (0,0,0)
+(0,0,0) (49,98,0) (-147,-147,-49) (-21,-21,-7)
+(0,0,0) (49,98,0) (-147,-147,-49) (21,21,7)
+(0,0,0) (49,98,0) (147,49,98) (-21,-21,-7)
+(0,0,0) (49,98,0) (147,49,98) (21,21,7)
+(0,0,0) (56,112,0) (-168,-168,-56) (0,0,0)
+(0,0,0) (56,112,0) (168,56,112) (0,0,0)
+(0,0,0) (92,88,40) (-188,-108,-100) (0,0,0)
+(0,0,0) (92,88,40) (148,60,96) (0,0,0)
+(0,0,0) (112,56,70) (-182,-42,-126) (-21,-21,-7)
+(0,0,0) (112,56,70) (-182,-42,-126) (21,21,7)
+(0,0,0) (112,56,70) (112,56,70) (-21,-21,-7)
+(0,0,0) (112,56,70) (112,56,70) (21,21,7)
+(0,0,0) (128,64,80) (-208,-48,-144) (0,0,0)
+(0,0,0) (128,64,80) (128,64,80) (0,0,0)
+(0,0,0) (147,49,98) (-147,-49,-98) (-21,-21,-7)
+(0,0,0) (147,49,98) (-147,-49,-98) (21,21,7)
+(0,0,0) (147,49,98) (49,98,0) (-21,-21,-7)
+(0,0,0) (147,49,98) (49,98,0) (21,21,7)
+(0,0,0) (148,60,96) (-188,-52,-128) (0,0,0)
+(0,0,0) (148,60,96) (92,88,40) (0,0,0)
+(0,0,0) (168,56,112) (-168,-56,-112) (0,0,0)
+(0,0,0) (168,56,112) (56,112,0) (0,0,0)
+(0,0,0) (182,42,126) (-112,-56,-70) (-21,-21,-7)
+(0,0,0) (182,42,126) (-112,-56,-70) (21,21,7)
+(0,0,0) (182,42,126) (-14,140,-70) (-21,-21,-7)
+(0,0,0) (182,42,126) (-14,140,-70) (21,21,7)
+(0,0,0) (188,52,128) (-148,-60,-96) (0,0,0)
+(0,0,0) (188,52,128) (20,136,-40) (0,0,0)
+(0,0,0) (147,147,49) (-49,-98,0) (-21,-21,-7)
+(0,0,0) (147,147,49) (-49,-98,0) (21,21,7)
+(0,0,0) (147,147,49) (0,0,0) (-21,-21,-7)
+(0,0,0) (147,147,49) (0,0,0) (21,21,7)
+(0,0,0) (112,252,-28) (14,-140,70) (-21,-21,-7)
+(0,0,0) (112,252,-28) (14,-140,70) (21,21,7)
+(0,0,0) (208,48,144) (-128,-64,-80) (0,0,0)
+(0,0,0) (208,48,144) (-16,160,-80) (0,0,0)
+(0,0,0) (188,108,100) (-92,-88,-40) (0,0,0)
+(0,0,0) (188,108,100) (-8,80,-40) (0,0,0)
+(0,0,0) (168,168,56) (-56,-112,0) (0,0,0)
+(0,0,0) (168,168,56) (0,0,0) (0,0,0)
+(0,0,0) (148,228,12) (-20,-136,40) (0,0,0)
+(0,0,0) (148,228,12) (8,-80,40) (0,0,0)
+(0,0,0) (128,288,-32) (16,-160,80) (0,0,0)
+
+
+
+0
+
+
+
+224
+3  1 0 9 
+3  1 3 12 
+3  2 0 10 
+3  2 4 13 
+3  5 3 11 
+3  5 7 18 
+3  6 4 14 
+3  6 8 19 
+3  9 0 2 
+3  10 0 1 
+3  11 3 1 
+3  12 3 5 
+3  13 4 6 
+3  14 4 2 
+3  15 7 17 
+3  15 21 26 
+3  16 8 20 
+3  16 22 27 
+3  17 7 5 
+3  18 7 15 
+3  19 8 16 
+3  20 8 6 
+3  23 21 25 
+3  23 29 32 
+3  24 22 28 
+3  24 30 33 
+3  25 21 15 
+3  26 21 23 
+3  27 22 24 
+3  28 22 16 
+3  31 29 23 
+3  32 29 35 
+3  33 30 36 
+3  34 30 24 
+3  35 29 31 
+3  35 37 40 
+3  36 30 34 
+3  36 38 41 
+3  39 37 35 
+3  40 37 43 
+3  41 38 44 
+3  42 38 36 
+3  43 37 39 
+3  43 45 48 
+3  44 38 42 
+3  44 46 49 
+3  47 45 43 
+3  48 45 61 
+3  49 46 62 
+3  50 46 44 
+3  61 45 47 
+3  61 79 81 
+3  62 46 50 
+3  62 90 88 
+3  80 79 61 
+3  81 79 107 
+3  84 51 55 
+3  84 53 51 
+3  84 55 59 
+3  84 57 53 
+3  84 59 65 
+3  84 63 57 
+3  84 65 69 
+3  84 67 63 
+3  84 69 73 
+3  84 71 67 
+3  84 73 77 
+3  84 75 71 
+3  84 77 86 
+3  84 82 75 
+3  84 86 93 
+3  84 91 82 
+3  84 93 97 
+3  84 95 91 
+3  84 97 101 
+3  84 99 95 
+3  84 101 105 
+3  84 103 99 
+3  84 105 111 
+3  84 109 103 
+3  84 111 115 
+3  84 113 109 
+3  84 115 117 
+3  84 117 113 
+3  85 52 54 
+3  85 54 58 
+3  85 56 52 
+3  85 58 64 
+3  85 60 56 
+3  85 64 68 
+3  85 66 60 
+3  85 68 72 
+3  85 70 66 
+3  85 72 76 
+3  85 74 70 
+3  85 76 83 
+3  85 78 74 
+3  85 83 92 
+3  85 87 78 
+3  85 92 96 
+3  85 94 87 
+3  85 96 100 
+3  85 98 94 
+3  85 100 104 
+3  85 102 98 
+3  85 104 110 
+3  85 106 102 
+3  85 110 114 
+3  85 112 106 
+3  85 114 118 
+3  85 116 112 
+3  85 118 116 
+3  88 90 108 
+3  89 90 62 
+3  107 79 80 
+3  107 123 120 
+3  108 90 89 
+3  108 124 121 
+3  119 123 107 
+3  120 123 125 
+3  121 124 126 
+3  122 124 108 
+3  125 123 119 
+3  125 131 128 
+3  126 124 122 
+3  126 132 129 
+3  127 131 125 
+3  128 131 133 
+3  129 132 134 
+3  130 132 126 
+3  133 131 127 
+3  133 139 136 
+3  134 132 130 
+3  134 140 137 
+3  135 139 133 
+3  136 139 145 
+3  137 140 146 
+3  138 140 134 
+3  141 147 145 
+3  142 147 153 
+3  143 148 154 
+3  144 148 146 
+3  145 139 135 
+3  145 147 142 
+3  146 140 138 
+3  146 148 143 
+3  149 161 153 
+3  150 161 163 
+3  151 162 164 
+3  152 162 154 
+3  153 147 141 
+3  153 161 150 
+3  154 148 144 
+3  154 162 151 
+3  155 165 163 
+3  156 165 167 
+3  157 166 168 
+3  158 166 164 
+3  159 169 167 
+3  160 169 168 
+3  163 161 149 
+3  163 165 156 
+3  164 162 152 
+3  164 166 157 
+3  167 165 155 
+3  167 169 160 
+3  168 166 158 
+3  168 169 159 
+5  51 9 2 13 55 
+5  52 10 1 12 54 
+5  53 11 1 9 51 
+5  54 12 5 18 58 
+5  55 13 6 19 59 
+5  56 14 2 10 52 
+5  57 17 5 11 53 
+5  58 18 15 26 64 
+5  59 19 16 27 65 
+5  60 20 6 14 56 
+5  63 25 15 17 57 
+5  64 26 23 32 68 
+5  65 27 24 33 69 
+5  66 28 16 20 60 
+5  67 31 23 25 63 
+5  68 32 35 40 72 
+5  69 33 36 41 73 
+5  70 34 24 28 66 
+5  71 39 35 31 67 
+5  72 40 43 48 76 
+5  73 41 44 49 77 
+5  74 42 36 34 70 
+5  75 47 43 39 71 
+5  76 48 61 81 83 
+5  77 49 62 88 86 
+5  78 50 44 42 74 
+5  82 80 61 47 75 
+5  83 81 107 120 92 
+5  86 88 108 121 93 
+5  87 89 62 50 78 
+5  91 119 107 80 82 
+5  92 120 125 128 96 
+5  93 121 126 129 97 
+5  94 122 108 89 87 
+5  95 127 125 119 91 
+5  96 128 133 136 100 
+5  97 129 134 137 101 
+5  98 130 126 122 94 
+5  99 135 133 127 95 
+5  100 136 145 142 104 
+5  101 137 146 143 105 
+5  102 138 134 130 98 
+5  103 141 145 135 99 
+5  104 142 153 150 110 
+5  105 143 154 151 111 
+5  106 144 146 138 102 
+5  109 149 153 141 103 
+5  110 150 163 156 114 
+5  111 151 164 157 115 
+5  112 152 154 144 106 
+5  113 155 163 149 109 
+5  114 156 167 160 118 
+5  115 157 168 159 117 
+5  116 158 164 152 112 
+5  117 159 167 155 113 
+5  118 160 168 158 116 
+
+
+
+0
+
+
+</LoadVEF>
     <BeginBlock/>
-    <SelectManifestation point="2 3 5 -1 1 -1 0 0 0"/>
-    <SelectManifestation point="1 4 4 0 0 0 0 1 0"/>
-    <SelectNeighbors/>
-    <EndBlock/>
-    <Delete/>
-    <BeginBlock/>
-    <SelectManifestation point="0 5 4 1 -1 1 0 0 0"/>
-    <SelectNeighbors/>
-    <EndBlock/>
-    <Delete/>
-    <BeginBlock/>
-    <SelectManifestation point="-1 7 3 1 -2 0 0 0 0"/>
-    <SelectManifestation endSegment="-1 7 3 1 -2 0 0 0 0" startSegment="1 5 4 0 0 0 0 0 0"/>
-    <SelectManifestation endSegment="-1 7 3 1 -2 0 0 0 0" startSegment="1 5 4 0 0 0 0 0 0"/>
-    <EndBlock/>
-    <ApplyTool name="axial symmetry.2" selectInputs="true"/>
-    <BeginBlock/>
-    <DeselectAll/>
-    <SelectManifestation point="0 5 3 0 0 0 1 0 1"/>
-    <SelectManifestation point="-1 7 3 1 -2 0 0 0 0"/>
-    <SelectManifestation point="1 5 4 0 0 0 0 0 0"/>
-    <EndBlock/>
-    <Polygon/>
-    <ApplyTool name="axial symmetry.2" selectInputs="true"/>
-    <BeginBlock/>
-    <DeselectAll/>
-    <SelectManifestation point="0 5 3 0 0 0 1 0 1"/>
-    <SelectManifestation point="1 5 4 0 0 0 0 0 0"/>
-    <SelectManifestation point="1 4 4 -1 2 0 0 0 0"/>
-    <EndBlock/>
-    <Polygon/>
-    <ApplyTool name="axial symmetry.2" selectInputs="true"/>
-    <DeselectAll/>
-    <StrutCreation anchor="0 0 0 0 0 0 1 5 4" dir="2" index="9" len="1 0 1" symm="heptagonal antiprism"/>
-    <BeginBlock/>
-    <SelectManifestation point="0 1 0 0 0 0 1 4 4"/>
-    <SelectManifestation point="-1/2 1 0 1/2 -1/2 1/2 1 4 4"/>
-    <EndBlock/>
-    <ApplyTool name="axial symmetry.1" selectInputs="true"/>
-    <Delete/>
-    <SelectManifestation endSegment="5/2 5/2 9/2 -2 0 -5/2 0 0 0" startSegment="0 0 0 0 0 0 1 5 4"/>
-    <Delete/>
-    <StrutCreation anchor="0 0 0 0 0 0 1 5 4" dir="3" index="0" len="1 0 1" symm="heptagonal antiprism"/>
-    <SelectManifestation endSegment="1/2 0 1/2 -1/2 1/2 -1/2 1 4 4" startSegment="0 0 0 0 0 0 1 5 4"/>
-    <Delete/>
-    <BeginBlock/>
-    <SelectManifestation point="-1/2 1 0 1/2 -1/2 1/2 -1 -4 -4"/>
-    <SelectManifestation point="0 1 0 0 0 0 -1 -4 -4"/>
-    <SelectManifestation point="1/2 0 1/2 -1/2 1/2 -1/2 -1 -4 -4"/>
-    <EndBlock/>
-    <Delete/>
-    <SelectManifestation point="0 1 1/2 1/2 -1 0 0 5 3"/>
-    <ApplyTool name="axial symmetry.1" selectInputs="true"/>
-    <BeginBlock/>
-    <DeselectAll/>
-    <SelectManifestation point="0 1 1/2 1/2 -1 0 0 5 3"/>
-    <SelectManifestation point="1 0 1 0 0 0 0 5 3"/>
-    <DeselectAll/>
-    <SelectManifestation point="0 0 0 0 0 0 1 5 4"/>
-    <SelectManifestation point="0 1 1/2 1/2 -1 0 0 5 3"/>
-    <SelectManifestation point="1 0 1 0 0 0 0 5 3"/>
-    <EndBlock/>
-    <Polygon/>
-    <BeginBlock/>
-    <DeselectAll/>
-    <SelectManifestation point="0 0 0 0 0 0 1 5 4"/>
-    <SelectManifestation point="1 0 1 0 0 0 0 5 3"/>
-    <SelectManifestation point="1 -1/2 1 -1/2 1 0 0 5 3"/>
-    <EndBlock/>
-    <Polygon/>
     <SelectManifestation>
-      <polygonVertex at="0 0 0 0 0 0 1 5 4"/>
-      <polygonVertex at="0 1 1/2 1/2 -1 0 0 5 3"/>
-      <polygonVertex at="1 0 1 0 0 0 0 5 3"/>
-    </SelectManifestation>
-    <ApplyTool name="axial symmetry.1" selectInputs="true"/>
-    <ApplyTool name="axial symmetry.2" selectInputs="true"/>
-    <setItemColor blue="71" green="7" red="244"/>
-    <BeginBlock/>
-    <SelectManifestation>
-      <polygonVertex at="0 5 3 0 0 0 1 0 1"/>
-      <polygonVertex at="-1 7 3 1 -2 0 0 0 0"/>
-      <polygonVertex at="1 5 4 0 0 0 0 0 0"/>
+      <polygonVertex at="11/7 47/14 26/7 4/7 -1/7 5/7 0 0 0"/>
+      <polygonVertex at="2 3 4 0 0 0 0 0 0"/>
+      <polygonVertex at="7/4 21/8 7/2 0 0 0 1/4 3/8 1/2"/>
     </SelectManifestation>
     <SelectManifestation>
-      <polygonVertex at="0 5 3 0 0 0 -1 0 -1"/>
-      <polygonVertex at="1 5 4 0 0 0 0 0 0"/>
-      <polygonVertex at="-1 7 3 1 -2 0 0 0 0"/>
+      <polygonVertex at="7/4 21/8 7/2 0 0 0 -1/4 -3/8 -1/2"/>
+      <polygonVertex at="2 3 4 0 0 0 0 0 0"/>
+      <polygonVertex at="11/7 47/14 26/7 4/7 -1/7 5/7 0 0 0"/>
     </SelectManifestation>
     <SelectManifestation>
-      <polygonVertex at="0 5 3 0 0 0 -1 0 -1"/>
-      <polygonVertex at="1 4 4 -1 2 0 0 0 0"/>
-      <polygonVertex at="1 5 4 0 0 0 0 0 0"/>
+      <polygonVertex at="15/14 47/14 45/14 15/14 5/14 12/7 0 0 0"/>
+      <polygonVertex at="1 3 3 1 1 2 0 0 0"/>
+      <polygonVertex at="7/8 21/8 21/8 7/8 7/8 7/4 -1/4 -3/8 -1/2"/>
     </SelectManifestation>
     <SelectManifestation>
-      <polygonVertex at="0 5 3 0 0 0 1 0 1"/>
-      <polygonVertex at="1 5 4 0 0 0 0 0 0"/>
-      <polygonVertex at="1 4 4 -1 2 0 0 0 0"/>
+      <polygonVertex at="7/8 21/8 21/8 7/8 7/8 7/4 1/4 3/8 1/2"/>
+      <polygonVertex at="1 3 3 1 1 2 0 0 0"/>
+      <polygonVertex at="15/14 47/14 45/14 15/14 5/14 12/7 0 0 0"/>
     </SelectManifestation>
     <EndBlock/>
-    <ApplyTool name="axial symmetry.1" selectInputs="true"/>
-    <setItemColor blue="255" green="143" red="4"/>
+    <ApplyTool name="symmetry.builtin/heptagonal antiprism around origin" selectInputs="true"/>
+    <setItemColor blue="149" green="118" red="0"/>
     <BeginBlock/>
-    <SelectManifestation point="1 0 1 0 0 0 0 5 3"/>
-    <SelectManifestation point="0 1 1/2 1/2 -1 0 0 5 3"/>
-    <SelectManifestation point="5/2 5/2 9/2 -2 0 -5/2 0 0 0"/>
-    <SelectManifestation point="-1 7 3 1 -2 0 0 0 0"/>
-    <SelectManifestation point="0 5 3 0 0 0 1 0 1"/>
-    <EndBlock/>
-    <Polygon/>
-    <BeginBlock/>
-    <SelectManifestation point="1 -1/2 1 -1/2 1 0 0 5 3"/>
-    <SelectManifestation point="1 0 1 0 0 0 0 5 3"/>
-    <SelectManifestation point="0 5 3 0 0 0 1 0 1"/>
-    <SelectManifestation point="1 4 4 -1 2 0 0 0 0"/>
-    <SelectManifestation point="0 9/2 5/2 2 0 5/2 0 0 0"/>
-    <EndBlock/>
-    <Polygon/>
-    <ApplyTool name="axial symmetry.2" selectInputs="true"/>
-    <ApplyTool name="axial symmetry.1" selectInputs="true"/>
-    <BeginBlock/>
-    <DeselectAll/>
     <SelectManifestation>
-      <polygonVertex at="1 0 1 0 0 0 0 5 3"/>
-      <polygonVertex at="0 1 1/2 1/2 -1 0 0 5 3"/>
-      <polygonVertex at="5/2 5/2 9/2 -2 0 -5/2 0 0 0"/>
-      <polygonVertex at="-1 7 3 1 -2 0 0 0 0"/>
-      <polygonVertex at="0 5 3 0 0 0 1 0 1"/>
+      <polygonVertex at="15/14 47/14 45/14 15/14 5/14 12/7 0 0 0"/>
+      <polygonVertex at="8/7 26/7 24/7 8/7 -2/7 10/7 0 0 0"/>
+      <polygonVertex at="1 13/4 3 1 -1/4 5/4 1/4 3/8 1/2"/>
+    </SelectManifestation>
+    <SelectManifestation>
+      <polygonVertex at="1 13/4 3 1 -1/4 5/4 -1/4 -3/8 -1/2"/>
+      <polygonVertex at="8/7 26/7 24/7 8/7 -2/7 10/7 0 0 0"/>
+      <polygonVertex at="15/14 47/14 45/14 15/14 5/14 12/7 0 0 0"/>
+    </SelectManifestation>
+    <SelectManifestation>
+      <polygonVertex at="13/14 37/14 39/14 13/14 23/14 16/7 0 0 0"/>
+      <polygonVertex at="6/7 16/7 18/7 6/7 16/7 18/7 0 0 0"/>
+      <polygonVertex at="3/4 2 9/4 3/4 2 9/4 -1/4 -3/8 -1/2"/>
+    </SelectManifestation>
+    <SelectManifestation>
+      <polygonVertex at="3/4 2 9/4 3/4 2 9/4 1/4 3/8 1/2"/>
+      <polygonVertex at="6/7 16/7 18/7 6/7 16/7 18/7 0 0 0"/>
+      <polygonVertex at="13/14 37/14 39/14 13/14 23/14 16/7 0 0 0"/>
+    </SelectManifestation>
+    <SelectManifestation>
+      <polygonVertex at="13/14 23/14 16/7 13/14 37/14 39/14 0 0 0"/>
+      <polygonVertex at="6/7 16/7 18/7 6/7 16/7 18/7 0 0 0"/>
+      <polygonVertex at="3/4 2 9/4 3/4 2 9/4 1/4 3/8 1/2"/>
+    </SelectManifestation>
+    <SelectManifestation>
+      <polygonVertex at="3/4 2 9/4 3/4 2 9/4 -1/4 -3/8 -1/2"/>
+      <polygonVertex at="6/7 16/7 18/7 6/7 16/7 18/7 0 0 0"/>
+      <polygonVertex at="13/14 23/14 16/7 13/14 37/14 39/14 0 0 0"/>
+    </SelectManifestation>
+    <SelectManifestation>
+      <polygonVertex at="15/14 5/14 12/7 15/14 47/14 45/14 0 0 0"/>
+      <polygonVertex at="8/7 -2/7 10/7 8/7 26/7 24/7 0 0 0"/>
+      <polygonVertex at="1 -1/4 5/4 1 13/4 3 -1/4 -3/8 -1/2"/>
+    </SelectManifestation>
+    <SelectManifestation>
+      <polygonVertex at="1 -1/4 5/4 1 13/4 3 1/4 3/8 1/2"/>
+      <polygonVertex at="8/7 -2/7 10/7 8/7 26/7 24/7 0 0 0"/>
+      <polygonVertex at="15/14 5/14 12/7 15/14 47/14 45/14 0 0 0"/>
     </SelectManifestation>
     <EndBlock/>
-    <ApplyTool name="axial symmetry.2" selectInputs="true"/>
-    <ApplyTool name="axial symmetry.1" selectInputs="true"/>
+    <ApplyTool name="symmetry.builtin/heptagonal antiprism around origin" selectInputs="true"/>
+    <setItemColor blue="0" green="160" red="240"/>
+    <BeginBlock/>
+    <SelectManifestation>
+      <polygonVertex at="0 0 0 0 0 0 2 3 4"/>
+      <polygonVertex at="1/7 13/28 3/7 1/7 -1/28 5/28 7/4 21/8 7/2"/>
+      <polygonVertex at="1/4 3/8 1/2 0 0 0 7/4 21/8 7/2"/>
+    </SelectManifestation>
+    <SelectManifestation>
+      <polygonVertex at="0 0 0 0 0 0 2 3 4"/>
+      <polygonVertex at="1/8 3/8 3/8 1/8 1/8 1/4 7/4 21/8 7/2"/>
+      <polygonVertex at="1/7 13/28 3/7 1/7 -1/28 5/28 7/4 21/8 7/2"/>
+    </SelectManifestation>
+    <SelectManifestation>
+      <polygonVertex at="0 0 0 0 0 0 2 3 4"/>
+      <polygonVertex at="3/28 2/7 9/28 3/28 2/7 9/28 7/4 21/8 7/2"/>
+      <polygonVertex at="1/8 3/8 3/8 1/8 1/8 1/4 7/4 21/8 7/2"/>
+    </SelectManifestation>
+    <SelectManifestation>
+      <polygonVertex at="0 0 0 0 0 0 2 3 4"/>
+      <polygonVertex at="1/8 1/8 1/4 1/8 3/8 3/8 7/4 21/8 7/2"/>
+      <polygonVertex at="3/28 2/7 9/28 3/28 2/7 9/28 7/4 21/8 7/2"/>
+    </SelectManifestation>
+    <EndBlock/>
+    <ApplyTool name="symmetry.builtin/heptagonal antiprism around origin" selectInputs="true"/>
+    <setItemColor blue="0" green="0" red="172"/>
+    <BeginBlock/>
+    <SelectManifestation>
+      <polygonVertex at="1/8 3/8 3/8 1/8 1/8 1/4 7/4 21/8 7/2"/>
+      <polygonVertex at="7/8 21/8 21/8 7/8 7/8 7/4 1/4 3/8 1/2"/>
+      <polygonVertex at="15/14 47/14 45/14 15/14 5/14 12/7 0 0 0"/>
+      <polygonVertex at="1 13/4 3 1 -1/4 5/4 1/4 3/8 1/2"/>
+      <polygonVertex at="1/7 13/28 3/7 1/7 -1/28 5/28 7/4 21/8 7/2"/>
+    </SelectManifestation>
+    <SelectManifestation>
+      <polygonVertex at="1/8 1/8 1/4 1/8 3/8 3/8 7/4 21/8 7/2"/>
+      <polygonVertex at="7/8 7/8 7/4 7/8 21/8 21/8 1/4 3/8 1/2"/>
+      <polygonVertex at="13/14 23/14 16/7 13/14 37/14 39/14 0 0 0"/>
+      <polygonVertex at="3/4 2 9/4 3/4 2 9/4 1/4 3/8 1/2"/>
+      <polygonVertex at="3/28 2/7 9/28 3/28 2/7 9/28 7/4 21/8 7/2"/>
+    </SelectManifestation>
+    <EndBlock/>
+    <ApplyTool name="symmetry.builtin/heptagonal antiprism around origin" selectInputs="true"/>
     <setItemColor blue="102" green="102" red="102"/>
-    <BeginBlock/>
-    <SelectManifestation point="0 0 0 0 0 0 1 5 4"/>
-    <SelectNeighbors/>
-    <SelectNeighbors/>
-    <SelectNeighbors/>
-    <SelectNeighbors/>
-    <SelectNeighbors/>
-    <SelectNeighbors/>
-    <EndBlock/>
-    <Delete/>
-    <SelectManifestation point="0 9/2 5/2 2 0 5/2 0 0 0"/>
-    <ApplyTool name="axial symmetry.1" selectInputs="true"/>
-    <Delete/>
-    <SelectManifestation point="-1 4 1 4 0 5 0 0 0"/>
-    <ApplyTool name="axial symmetry.1" selectInputs="true"/>
-    <Delete/>
-    <SelectManifestation point="1 4 4 -1 2 0 0 0 0"/>
-    <Delete/>
-    <SelectManifestation point="1 -1/2 1 -1/2 1 0 0 5 3"/>
-    <ApplyTool name="axial symmetry.1" selectInputs="true"/>
-    <Delete/>
   </EditHistory>
-  <notes xmlns:xml="http://www.w3.org/XML/1998/namespace"/>
+  <notes/>
   <sceneModel ambientLight="41,41,41" background="175,200,220">
     <directionalLight color="235,235,228" x="1.0" y="-1.0" z="-1.0"/>
     <directionalLight color="228,228,235" x="-1.0" y="0.0" z="0.0"/>
     <directionalLight color="30,30,30" x="0.0" y="0.0" z="-1.0"/>
   </sceneModel>
   <Viewing>
-    <ViewModel distance="182.88900756835938" far="365.77801513671994" near="0.45722252573404343" parallel="false" stereoAngle="0.0" width="82.30005340576162">
+    <ViewModel distance="108.73126983642578" far="217.46253967285156" near="0.2718281786416199" parallel="false" stereoAngle="0.0" width="48.9290714263916">
       <LookAtPoint x="0.0" y="0.0" z="0.0"/>
-      <UpDirection x="0.0" y="1.0" z="0.0"/>
-      <LookDirection x="0.0" y="0.0" z="-1.0"/>
+      <UpDirection x="0" y="1" z="0"/>
+      <LookDirection x="0.22888931336826165" y="-0.16444720908042404" z="-0.9594617228693746"/>
     </ViewModel>
   </Viewing>
-  <SymmetrySystem name="heptagonal antiprism" renderingStyle="heptagonal antiprism">
+  <SymmetrySystem name="heptagonal antiprism corrected" renderingStyle="heptagonal antiprism">
     <Direction color="175,0,0" name="red"/>
     <Direction color="0,118,149" name="blue"/>
-    <Direction color="255,255,255" name="1" prototype="2 -2 0 -1 2 -1 0 0 0"/>
-    <Direction color="255,255,255" name="2" prototype="0 1 -1 1 0 0 1 0 0"/>
-    <Direction color="255,255,255" name="3" prototype="0 1/2 0 1/2 -1/2 0 -1 0 0"/>
-    <Direction color="255,255,255" name="4" prototype="-1/2 1 0 -1 1 -1/2 -1/2 1 0"/>
-    <Direction color="255,255,255" name="5" prototype="1/2 -1/2 1/2 1/2 0 0 1/2 -1/2 1/2"/>
-    <Direction color="255,255,255" name="6" prototype="1 -1 1/2 1 -1 1 -1/2 1 0"/>
-    <Direction color="255,255,255" name="7" prototype="0 -1/2 0 0 1/2 0 -1/2 1 0"/>
-    <Direction color="255,255,255" name="8" prototype="-1 1 -1 -1 1 -1/2 -1/2 1 0"/>
-    <Direction color="255,255,255" name="9" prototype="-1/2 0 0 -1/2 1/2 -1/2 1/2 -1/2 1/2"/>
-    <Direction color="255,255,255" name="10" prototype="1 -1 1/2 1/2 -1 0 -1/2 1 0"/>
+    <Direction color="240,160,0" name="yellow"/>
+    <Direction color="255,255,255" name="1" prototype="-1/7 -3/14 -17/56 -5/112 -1/28 -1/14 -1/7 -3/14 -17/56"/>
+    <Direction color="255,255,255" name="2" prototype="-3/28 -25/112 -29/112 5/112 1/28 1/14 1/7 3/14 17/56"/>
+    <Direction color="255,255,255" name="3" prototype="-3/28 -25/112 -29/112 -9/112 -17/112 -5/28 -1/7 -3/14 -17/56"/>
+    <Direction color="255,255,255" name="4" prototype="-9/112 -17/112 -5/28 9/112 17/112 5/28 1/7 3/14 17/56"/>
   </SymmetrySystem>
+  <Tools/>
 </vzome:vZome>


### PR DESCRIPTION
* Updated the heptagonal antiprism trackball to show the new yellow directions.

* Adding a proper yellow direction also makes the orbit triangle show everything including automatic struts in the correct position.

* Still need to make a yellow strut model instead of using the automatic shape, but I'm going to wait until the open issue regarding strut rendering in the heptagon field is fixed so I can see how the new struts are actually rendered.