### PR TITLE
Add new showOrbitTriangle diagnostic command to desktop app

### DIFF
--- a/core/src/main/java/com/vzome/core/algebra/AlgebraicVector.java
+++ b/core/src/main/java/com/vzome/core/algebra/AlgebraicVector.java
@@ -121,6 +121,17 @@ public final class AlgebraicVector implements Comparable<AlgebraicVector>
         return toString( AlgebraicField .DEFAULT_FORMAT );
     }
 
+    /**
+     * Formats an AlgebraicVector as a String using the specified format.
+     *  
+     * @param format may be any of the following:
+     * {@code AlgebraicField.DEFAULT_FORMAT = 0; // 4 + 3φ}
+     * {@code AlgebraicField.EXPRESSION_FORMAT = 1; // 4 +3*phi}
+     * {@code AlgebraicField.ZOMIC_FORMAT = 2; // 4 3}
+     * {@code AlgebraicField.VEF_FORMAT = 3; // (3,4)}
+     * 
+     * @return this vector formatted as specified
+     */
     public final String toString(int format)
     {
         return this .getVectorExpression( format );
@@ -237,6 +248,15 @@ public final class AlgebraicVector implements Comparable<AlgebraicVector>
             return new AlgebraicVector( this .coordinates[ 0 ], this .coordinates[ 1 ], this .coordinates[ 2 ] );
     }
 
+    /**
+     * 
+     * @param buf a StringBuffer to which the formatted vector will be appended.
+     * @param format may be any of the following:
+     * {@code AlgebraicField.DEFAULT_FORMAT = 0; // 4 + 3φ}
+     * {@code AlgebraicField.EXPRESSION_FORMAT = 1; // 4 +3*phi}
+     * {@code AlgebraicField.ZOMIC_FORMAT = 2; // 4 3}
+     * {@code AlgebraicField.VEF_FORMAT = 3; // (3,4)}
+     */
     public void getVectorExpression( StringBuffer buf, int format )
     {
         if ( format == AlgebraicField.DEFAULT_FORMAT )
@@ -253,6 +273,20 @@ public final class AlgebraicVector implements Comparable<AlgebraicVector>
             buf .append( ")" );
     }
 
+    /**
+     * Formats an AlgebraicVector as a String using the specified format.
+     * 
+     * Note that {@code AlgebraicVector.toString(int format)} is just a wrapper for this method.
+     * TODO: Avoid the redundancy by deprecating this method, then replacing it with toString(format)
+     *  
+     * @param format may be any of the following:
+     * {@code AlgebraicField.DEFAULT_FORMAT = 0; // 4 + 3φ}
+     * {@code AlgebraicField.EXPRESSION_FORMAT = 1; // 4 +3*phi}
+     * {@code AlgebraicField.ZOMIC_FORMAT = 2; // 4 3}
+     * {@code AlgebraicField.VEF_FORMAT = 3; // (3,4)}
+     * 
+     * @return this vector formatted as specified
+     */
     public String getVectorExpression( int format )
     {
         StringBuffer buf = new StringBuffer();

--- a/core/src/main/java/com/vzome/core/edits/LoadVEF.java
+++ b/core/src/main/java/com/vzome/core/edits/LoadVEF.java
@@ -52,9 +52,12 @@ public class LoadVEF extends ChangeManifestations
             scale = field .one();
         }
 
-        String projectionName = (String) params .get( "mode" );
-        switch ( projectionName ) {
+        String mode = (String) params .getOrDefault( "mode", "" );
 
+        switch ( mode ) {
+        case "":
+            break;
+            
         case "clipboard":
             if( vefData != null && ! vefData.startsWith("vZome VEF" ))
                 // Although older VEF formats don't all include the header and could possibly be successfully pasted here,
@@ -69,7 +72,7 @@ public class LoadVEF extends ChangeManifestations
             break;
         
         default:
-            setProjection( projectionName, field );
+            setProjection( mode, field );
             break;
         }
     }

--- a/core/src/main/java/com/vzome/core/kinds/RootTwoFieldApplication.java
+++ b/core/src/main/java/com/vzome/core/kinds/RootTwoFieldApplication.java
@@ -95,7 +95,7 @@ public class RootTwoFieldApplication extends DefaultFieldApplication
         }
 
         @Override
-        protected AlgebraicVector[] getOrbitTriangle()
+        public AlgebraicVector[] getOrbitTriangle()
         {
             AlgebraicVector magentaVertex = this .getDirection( "magenta" ) .getPrototype();
             AlgebraicVector orangeVertex = this .getDirection( this. frameColor ) .getPrototype();

--- a/core/src/main/java/com/vzome/core/math/symmetry/AbstractSymmetry.java
+++ b/core/src/main/java/com/vzome/core/math/symmetry/AbstractSymmetry.java
@@ -525,7 +525,7 @@ public abstract class AbstractSymmetry implements Symmetry
         return this .principalReflection; // may be null, that's OK for the legacy case (which is broken)
     }
     
-    protected AlgebraicVector[] getOrbitTriangle()
+    public AlgebraicVector[] getOrbitTriangle()
     {
         AlgebraicVector blueVertex = this .getSpecialOrbit( SpecialOrbit.BLUE ) .getPrototype();
         AlgebraicVector redVertex = this .getSpecialOrbit( SpecialOrbit.RED ) .getPrototype();

--- a/core/src/main/java/com/vzome/core/math/symmetry/IcosahedralSymmetry.java
+++ b/core/src/main/java/com/vzome/core/math/symmetry/IcosahedralSymmetry.java
@@ -135,7 +135,7 @@ public class IcosahedralSymmetry extends AbstractSymmetry
     }
 
     @Override
-    protected AlgebraicVector[] getOrbitTriangle()
+    public AlgebraicVector[] getOrbitTriangle()
     {
         AlgebraicNumber twice = mField .createRational( 2 );
         AlgebraicVector blueVertex = this .getDirection( "blue" ) .getPrototype() .scale( twice );

--- a/core/src/main/java/com/vzome/core/math/symmetry/OctahedralSymmetry.java
+++ b/core/src/main/java/com/vzome/core/math/symmetry/OctahedralSymmetry.java
@@ -58,7 +58,7 @@ public class OctahedralSymmetry extends AbstractSymmetry
     }
 
     @Override
-    protected AlgebraicVector[] getOrbitTriangle()
+    public AlgebraicVector[] getOrbitTriangle()
     {
         AlgebraicVector greenVertex = this .getDirection( "green" ) .getPrototype();
         AlgebraicVector blueVertex = this .getDirection( "blue" ) .getPrototype();

--- a/core/src/main/java/com/vzome/core/math/symmetry/Symmetry.java
+++ b/core/src/main/java/com/vzome/core/math/symmetry/Symmetry.java
@@ -82,6 +82,8 @@ public interface Symmetry extends Iterable<Direction>, Embedding
 	 */
 	public abstract AlgebraicMatrix getPrincipalReflection();
 	
+	public AlgebraicVector[] getOrbitTriangle();
+	
 	/**
 	 * Compute the orbit triangle dots for all existing orbits,
 	 * and leave behind an OrbitDotLocator for new ones.

--- a/core/src/main/java/com/vzome/fields/heptagon/HeptagonalAntiprismSymmetry.java
+++ b/core/src/main/java/com/vzome/fields/heptagon/HeptagonalAntiprismSymmetry.java
@@ -188,7 +188,7 @@ public class HeptagonalAntiprismSymmetry extends AbstractSymmetry
 	}
     
     @Override
-    protected AlgebraicVector[] getOrbitTriangle()
+    public AlgebraicVector[] getOrbitTriangle()
     {
         HeptagonField hf = (HeptagonField) this .getField();
         

--- a/core/src/main/java/com/vzome/fields/sqrtphi/PentagonalAntiprismSymmetry.java
+++ b/core/src/main/java/com/vzome/fields/sqrtphi/PentagonalAntiprismSymmetry.java
@@ -88,7 +88,7 @@ public class PentagonalAntiprismSymmetry extends AbstractSymmetry
     protected void createOtherOrbits() {}
 
     @Override
-    protected AlgebraicVector[] getOrbitTriangle()
+    public AlgebraicVector[] getOrbitTriangle()
     {
         AlgebraicVector redVertex = this .mField .createVector( FIVEFOLD_AXIS );
         AlgebraicVector greenVertex = this .mField .createVector( TWOFOLD_AXIS );

--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
@@ -686,6 +686,27 @@ public class DocumentController extends DefaultController implements Controller3
                 }
                 break;
     
+            case "showOrbitTriangle": // invoked from custom menu
+            {
+                AlgebraicVector[] orbitTriangle = 
+                getSymmetryController().getSymmetry().getOrbitTriangle();
+                StringBuffer buf = new StringBuffer();
+                // We don't need the VEF header here, so skip it.
+                // Specify that the vectors are all 3D
+                // so we don't need v.inflateTo4d() in the loop below
+                buf.append("dimension 3\n\n3");// always 3 vertices too
+                for(AlgebraicVector v : orbitTriangle) {
+                    buf.append("\n");
+                    v.getVectorExpression(buf, AlgebraicField.VEF_FORMAT);
+                }
+                // 0 edges, 1 triangular panel and 0 balls
+                buf.append("\n\n0\n\n1\n3  0 1 2\n\n0\n");
+                Map<String, Object> params = new HashMap<>();
+                params .put( "vef", buf.toString() );
+                documentModel .doEdit( "LoadVEF", params );
+            }
+            break;
+
             default:
                 if ( action.startsWith( "setSymmetry." ) ) {
                     String system = action.substring( "setSymmetry.".length() );


### PR DESCRIPTION
This command simply adds a triangle to the model at the 3 vectors returned by getOrbitTriangle().
No new command in core. Implemented in desktop app via LoadVEF. Invoked by custom menu entry.