### PR TITLE
Implement SqrtPhi built-in red mirror tool

### DIFF
--- a/core/src/main/java/com/vzome/core/tools/MirrorTool.java
+++ b/core/src/main/java/com/vzome/core/tools/MirrorTool.java
@@ -18,9 +18,12 @@ import com.vzome.core.construction.SegmentJoiningPoints;
 import com.vzome.core.construction.Transformation;
 import com.vzome.core.editor.AbstractToolFactory;
 import com.vzome.core.editor.Selection;
+import com.vzome.core.editor.SymmetrySystem;
 import com.vzome.core.editor.Tool;
 import com.vzome.core.editor.ToolsModel;
 import com.vzome.core.math.symmetry.Direction;
+import com.vzome.core.math.symmetry.Symmetry;
+import com.vzome.core.math.symmetry.Symmetry.SpecialOrbit;
 import com.vzome.core.model.Connector;
 import com.vzome.core.model.Manifestation;
 import com.vzome.core.model.Panel;
@@ -65,9 +68,13 @@ public class MirrorTool extends TransformationTool
         }
     }
 
+    protected final SymmetrySystem symmSys;
+    
     public MirrorTool( String id, ToolsModel tools )
     {
         super( id, tools );
+        // symmSys may be null for some test cases, but shouldn't be otherwise
+        symmSys = tools.getEditorModel().getSymmetrySystem();
     }
 
     @Override
@@ -83,6 +90,17 @@ public class MirrorTool extends TransformationTool
             AlgebraicField field = originPoint .getField();
             AlgebraicVector zAxis = field .basisVector( 3, AlgebraicVector .Z ) .scale( field .createPower( Direction.USER_SCALE ) );
             Point p2 = new FreePoint( zAxis );
+            axis = new SegmentJoiningPoints( center, p2 );
+            this .addParameter( axis );
+        }
+        else if ( this .getId() .equals( "mirror.builtin/reflection through red plane" ) )
+        {
+            center = originPoint;
+            this .addParameter( center );
+            // this is intended to be used by antiprism symmetries which only have one red axis
+            // and it's not the XY plane. Initially, that's only the SqrtPhiField.
+            AlgebraicVector redAxis = symmSys.getSymmetry().getSpecialOrbit(SpecialOrbit.RED).getAxis(Symmetry.PLUS, 0).normal();
+            Point p2 = new FreePoint( redAxis );
             axis = new SegmentJoiningPoints( center, p2 );
             this .addParameter( axis );
         }
@@ -155,9 +173,17 @@ public class MirrorTool extends TransformationTool
                 return "mirror tool requires a single panel,\n"
                 + "or a single strut and a single center ball";
         }
-        else
-            return "mirror tool requires a single panel,\n"
+        else {
+            String msg = "mirror tool requires a single panel,\n"
             + "or a single strut and a single center ball";
+            if ( prepareTool ) {
+                // tool will fail when it's used,
+                // so let's fail now to avoid finding the bug later.
+                throw new IllegalStateException("Failed to prepare tool: " + msg);
+            } else {
+                return msg;
+            }
+        }
 
         if ( prepareTool ) {
             this .transforms = new Transformation[ 1 ];


### PR DESCRIPTION
Tool was never fully implemented, but was shown on the toolbar. It threw an NPE when clicked.
