### PR TITLE
Fix BUG_ACCOMMODATION in PlaneProjection

### DIFF
--- a/core/src/main/java/com/vzome/core/construction/PlaneProjection.java
+++ b/core/src/main/java/com/vzome/core/construction/PlaneProjection.java
@@ -2,7 +2,11 @@
 
 package com.vzome.core.construction;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.vzome.core.algebra.AlgebraicVector;
+import com.vzome.core.algebra.AlgebraicVectors;
 
 
 /**
@@ -48,4 +52,52 @@ public class PlaneProjection extends Transformation
         return point .getLocation();
     }
 
+    @Override
+    public Construction transform( Construction c )
+    {
+        if ( c instanceof Segment ) {
+            if(AlgebraicVectors.areParallel(projectionVector, ((Segment) c).getOffset())) {
+                // If this segment is parallel to projectionVector,
+                // then the segment will be transformed to a point. 
+                return new LinePlaneIntersectionPoint(projectionPlane, new LineExtensionOfSegment((Segment) c));
+            }
+        } else if ( c instanceof Polygon ) {
+            Polygon p = (Polygon) c;
+            List<AlgebraicVector> points = new ArrayList<>(1 + p.getVertexCount());
+            points.add(p.getVertex(0).plus(projectionVector));
+            for(int i = 0; i < p.getVertexCount(); i++) {
+                points.add(p.getVertex(i));
+            }
+            if(AlgebraicVectors.areCoplanar(points)) {
+                // If this polygon is is parallel to projectionVector,
+                // then its vertices will be transformed 
+                // to a degenerate polygon with all vertices being collinear.
+                // Rather than projecting each individual edge as a Segment,
+                // some of which could then project down to a point,
+                // we'll return a single Segment 
+                // with its end points at the min and max points 
+                // of the degenerate projected Polygon.
+                p = (Polygon) super.transform( p );
+                AlgebraicVector min = p.getVertex(0);
+                AlgebraicVector max = min;
+                for(int i = 1; i < p.getVertexCount(); i++) {
+                    AlgebraicVector v = p.getVertex(i);
+                    if(v.compareTo(min) == -1) {
+                        min = v;
+                    }
+                    if(v.compareTo(max) == 1) {
+                        max = v;
+                    }
+                }
+                Point p1 = new FreePoint(min);
+                Point p2 = new FreePoint(max);
+                return new SegmentJoiningPoints(p1, p2);
+            }
+        }
+        // At this point, we know that the projection won't reduce 
+        // the construction to a lower dimensional class
+        // such as Polygon -> Segment or Segment -> Point,
+        // so it's OK to call the base class
+        return super.transform( c );
+    }
 }

--- a/core/src/regression/files/2020/04-Apr/19-David-FixProjectionToPlane/FixProjectionToPlane.vZome
+++ b/core/src/regression/files/2020/04-Apr/19-David-FixProjectionToPlane/FixProjectionToPlane.vZome
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<vzome:vZome xmlns:vzome="http://xml.vzome.com/vZome/4.0.0/" buildNumber="DEV" coreVersion="7.0" edition="vZome" field="golden" version="7.0">
+  <EditHistory editNumber="112" lastStickyEdit="61">
+    <SelectManifestation point="0 0 0 0 0 0"/>
+    <StrutCreation anchor="0 0 0 0 0 0" index="0" len="2 4"/>
+    <SelectManifestation point="2 4 0 0 0 0"/>
+    <ApplyTool name="icosahedral.builtin/icosahedral around origin" selectInputs="true"/>
+    <BeginBlock/>
+    <DeselectAll/>
+    <SelectManifestation point="-1 -2 2 3 -1 -1"/>
+    <SelectManifestation point="-1 -2 2 3 1 1"/>
+    <SelectManifestation point="-1 -2 -2 -3 1 1"/>
+    <SelectManifestation point="-1 -2 -2 -3 -1 -1"/>
+    <EndBlock/>
+    <Polygon/>
+    <BeginBlock/>
+    <DeselectAll/>
+    <SelectManifestation point="-2 -4 0 0 0 0"/>
+    <SelectManifestation point="0 0 0 0 0 0"/>
+    <SelectManifestation point="2 4 0 0 0 0"/>
+    <EndBlock/>
+    <Delete/>
+    <BeginBlock/>
+    <SelectManifestation point="2 3 1 1 1 2"/>
+    <SelectManifestation point="1 2 2 3 1 1"/>
+    <SelectManifestation point="1 1 1 2 2 3"/>
+    <EndBlock/>
+    <Polygon/>
+    <BeginBlock/>
+    <SelectManifestation point="2 3 1 1 -1 -2"/>
+    <SelectManifestation point="-2 -3 1 1 -1 -2"/>
+    <SelectManifestation point="-2 -3 -1 -1 -1 -2"/>
+    <SelectManifestation point="2 3 -1 -1 -1 -2"/>
+    <EndBlock/>
+    <Polygon/>
+    <BeginBlock/>
+    <DeselectAll/>
+    <SelectManifestation point="0 0 0 0 2 4"/>
+    <SelectManifestation point="1 1 -1 -2 2 3"/>
+    <SelectManifestation point="1 2 -2 -3 1 1"/>
+    <SelectManifestation point="1 2 -2 -3 -1 -1"/>
+    <SelectManifestation point="1 1 -1 -2 -2 -3"/>
+    <SelectManifestation point="0 0 0 0 -2 -4"/>
+    <SelectManifestation point="-1 -1 1 2 -2 -3"/>
+    <SelectManifestation point="-1 -2 2 3 -1 -1"/>
+    <SelectManifestation point="-1 -2 2 3 1 1"/>
+    <SelectManifestation point="-1 -1 1 2 2 3"/>
+    <EndBlock/>
+    <JoinPoints closedLoop="false"/>
+    <BeginBlock/>
+    <DeselectAll/>
+    <SelectManifestation point="-1 -1 1 2 2 3"/>
+    <SelectManifestation point="0 0 0 0 2 4"/>
+    <EndBlock/>
+    <JoinPoints closedLoop="false"/>
+    <DeselectAll/>
+    <StrutCreation anchor="1 2 -2 -3 1 1" dir="red" index="0" len="1 2"/>
+    <StrutCreation anchor="1 2 -2 -3 -1 -1" dir="red" index="0" len="1 2"/>
+    <StrutCreation anchor="-1 -2 2 3 1 1" dir="red" index="0" len="1 2"/>
+    <StrutCreation anchor="-1 -2 2 3 -1 -1" dir="red" index="0" len="1 2"/>
+    <StrutCreation anchor="0 0 0 0 2 4" dir="yellow" index="8" len="1 1"/>
+    <StrutCreation anchor="1 1 -1 -2 -2 -3" dir="yellow" index="0" len="1 1"/>
+    <SelectManifestation>
+      <polygonVertex at="-1 -2 2 3 -1 -1"/>
+      <polygonVertex at="-1 -2 2 3 1 1"/>
+      <polygonVertex at="-1 -2 -2 -3 1 1"/>
+      <polygonVertex at="-1 -2 -2 -3 -1 -1"/>
+    </SelectManifestation>
+    <ProjectionTool name="tool-0"/>
+    <BeginBlock/>
+    <DeselectAll/>
+    <SelectManifestation>
+      <polygonVertex at="2 3 1 1 -1 -2"/>
+      <polygonVertex at="-2 -3 1 1 -1 -2"/>
+      <polygonVertex at="-2 -3 -1 -1 -1 -2"/>
+      <polygonVertex at="2 3 -1 -1 -1 -2"/>
+    </SelectManifestation>
+    <EndBlock/>
+    <ApplyTool deleteInputs="true" name="tool-0"/>
+    <SelectManifestation>
+      <polygonVertex at="2 3 1 1 1 2"/>
+      <polygonVertex at="1 2 2 3 1 1"/>
+      <polygonVertex at="1 1 1 2 2 3"/>
+    </SelectManifestation>
+    <ApplyTool deleteInputs="true" name="tool-0"/>
+    <BeginBlock/>
+    <DeselectAll/>
+    <SelectManifestation endSegment="2 4 0 0 0 0" startSegment="0 0 0 0 0 0"/>
+    <EndBlock/>
+    <ApplyTool deleteInputs="true" name="tool-0"/>
+    <BeginBlock/>
+    <DeselectAll/>
+    <SelectManifestation endSegment="-1 -2 1 1 -1 -2" startSegment="-1 -2 -1 -1 -1 -2"/>
+    <EndBlock/>
+    <ShowVertices/>
+    <BeginBlock/>
+    <DeselectAll/>
+    <SelectManifestation point="-1 -2 -1 -1 -1 -2"/>
+    <SelectManifestation point="-1 -2 1 1 -1 -2"/>
+    <SelectManifestation point="-1 -2 0 0 0 0"/>
+    <EndBlock/>
+    <Polygon/>
+    <BeginBlock/>
+    <DeselectAll/>
+    <SelectManifestation>
+      <polygonVertex at="-1 -2 1 1 1 2"/>
+      <polygonVertex at="-1 -2 2 3 1 1"/>
+      <polygonVertex at="-1 -2 1 2 2 3"/>
+    </SelectManifestation>
+    <EndBlock/>
+    <ShowVertices/>
+    <BeginBlock/>
+    <DeselectAll/>
+    <SelectManifestation point="-1 -2 1 1 1 2"/>
+    <SelectManifestation point="-1 -2 0 0 0 0"/>
+    <SelectManifestation point="-1 -2 -2 -3 1 1"/>
+    <EndBlock/>
+    <Polygon/>
+    <BeginBlock/>
+    <DeselectAll/>
+    <SelectAll/>
+    <EndBlock/>
+    <ApplyTool deleteInputs="true" name="tool-0"/>
+    <BeginBlock/>
+    <DeselectAll/>
+    <SelectManifestation endSegment="-1 -2 -1 -2 2 3" startSegment="-1 -2 0 0 2 4"/>
+    <SelectManifestation endSegment="-1 -2 0 0 2 4" startSegment="-1 -2 1 2 2 3"/>
+    <SelectManifestation endSegment="-1 -2 1 2 -2 -3" startSegment="-1 -2 0 0 -2 -4"/>
+    <SelectManifestation endSegment="-1 -2 0 0 -2 -4" startSegment="-1 -2 -1 -2 -2 -3"/>
+    <SelectNeighbors/>
+    <EndBlock/>
+    <ConvexHull2d/>
+    <DeselectAll/>
+  </EditHistory>
+  <notes/>
+  <sceneModel ambientLight="41,41,41" background="175,200,220">
+    <directionalLight color="235,235,228" x="1.0" y="-1.0" z="-1.0"/>
+    <directionalLight color="228,228,235" x="-1.0" y="0.0" z="0.0"/>
+    <directionalLight color="30,30,30" x="0.0" y="0.0" z="-1.0"/>
+  </sceneModel>
+  <Viewing>
+    <ViewModel distance="102.39925384521484" far="204.7985076904297" near="0.2559981384277066" parallel="false" stereoAngle="0.0" width="46.07966423034668">
+      <LookAtPoint x="0.0" y="0.0" z="0.0"/>
+      <UpDirection x="-0.19296348082425974" y="-0.9405315357317116" z="0.27958098176080376"/>
+      <LookDirection x="-0.981033407324841" y="0.17958882402847626" z="-0.07294729602037482"/>
+    </ViewModel>
+  </Viewing>
+  <SymmetrySystem name="icosahedral" renderingStyle="solid connectors">
+    <Direction color="0,118,149" name="blue"/>
+    <Direction color="175,0,0" name="red"/>
+    <Direction color="240,160,0" name="yellow"/>
+    <Direction color="0,141,54" name="green"/>
+    <Direction color="220,76,0" name="orange"/>
+    <Direction color="108,0,198" name="purple"/>
+    <Direction color="30,30,30" name="black"/>
+    <Direction color="175,135,255" name="lavender"/>
+    <Direction color="100,113,0" name="olive"/>
+    <Direction color="117,0,50" name="maroon"/>
+    <Direction color="255,51,143" name="rose"/>
+    <Direction color="0,0,153" name="navy"/>
+    <Direction color="18,205,148" name="turquoise"/>
+    <Direction color="255,126,106" name="coral"/>
+    <Direction color="230,245,62" name="sulfur"/>
+    <Direction color="154,117,74" name="sand"/>
+    <Direction color="116,195,0" name="apple"/>
+    <Direction color="136,37,0" name="cinnamon"/>
+    <Direction color="18,73,48" name="spruce"/>
+    <Direction color="107,53,26" name="brown"/>
+  </SymmetrySystem>
+  <Tools>
+    <Tool deleteInputs="true" id="tool-0" label="projection 0"/>
+  </Tools>
+</vzome:vZome>

--- a/core/src/regression/files/sniff-test.vZome-files
+++ b/core/src/regression/files/sniff-test.vZome-files
@@ -149,3 +149,6 @@ format-2.1.0-models.vZome-files
 
 # Two new SnubDodec directions
 2020/03-Mar/06-David-SnubDodec/SnubDodecFromConvexHull.vZome
+
+# Fix PlaneProjection when Panel is projected down to Segment or Segment is projected down to a Point
+2020/04-Apr/19-David-FixProjectionToPlane/FixProjectionToPlane.vZome


### PR DESCRIPTION
* Return an appropriate Construction when a Panel is projected down to a Segment or a Segment is projected down to a Point.
* This occurs when the projection vector is collinear with a strut or coplanar with a Panel.
* This was previously returning a degenerate Construction of the same general type as the one being projected which caused a subsequent BUG_ACCOMMODATION to be logged.
* Added a new model to the regression suite which specifically uses the RenderedManifestations generated by these conditions.