### PR TITLE
Fix serialization problem for legacy quaternion commands

### DIFF
--- a/core/src/main/java/com/vzome/core/commands/CommandImportVEFData.java
+++ b/core/src/main/java/com/vzome/core/commands/CommandImportVEFData.java
@@ -104,7 +104,7 @@ public class CommandImportVEFData extends AbstractCommand
     public void getXml( Element result, AttributeMap attributes )
     {
         if ( quaternionVector != null )
-        	DomUtils .addAttribute( result, "quaternion", quaternionVector .toString() );
+        	DomUtils .addAttribute( result, "quaternion", quaternionVector .toParsableString() );
         
         super .getXml( result, attributes );
     }

--- a/core/src/main/java/com/vzome/core/commands/CommandUniformH4Polytope.java
+++ b/core/src/main/java/com/vzome/core/commands/CommandUniformH4Polytope.java
@@ -219,7 +219,7 @@ public class CommandUniformH4Polytope extends CommandTransform
     public void getXml( Element result, AttributeMap attributes )
     {
         if ( quaternionVector != null )
-        	DomUtils .addAttribute( result, "quaternion", quaternionVector .toString() );        
+            DomUtils .addAttribute( result, "quaternion", quaternionVector .toParsableString() );        
         super .getXml( result, attributes );
     }
 


### PR DESCRIPTION
At some point, we must have changed the meaning of AV.toString().  The
defect occurred when saving a file that used one of these old commands.