### PR TITLE
Retaining colors during transformations

### DIFF
--- a/core/src/main/java/com/vzome/core/construction/Construction.java
+++ b/core/src/main/java/com/vzome/core/construction/Construction.java
@@ -6,6 +6,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import com.vzome.core.algebra.AlgebraicField;
+import com.vzome.core.model.Color;
 
   
 
@@ -108,6 +109,8 @@ public abstract class Construction
     // here we accommodate loading vZome files that recorded command failures in their history
     
     private boolean failed = false;
+
+    private Color color;
     
     public void setFailed()
     {
@@ -119,4 +122,13 @@ public abstract class Construction
         return failed;
     }
 
+    public void setColor( Color color )
+    {
+        this .color = color;
+    }
+
+    public Color getColor()
+    {
+        return this .color;
+    }
 }

--- a/core/src/main/java/com/vzome/core/editor/ApplyTool.java
+++ b/core/src/main/java/com/vzome/core/editor/ApplyTool.java
@@ -52,6 +52,7 @@ public class ApplyTool extends ChangeManifestations
         {
             for (Manifestation man : inputs) {
                 Construction c = man .toConstruction();
+                c .setColor( man .getColor() );
 
                 tool .performEdit( c, this );
             }

--- a/core/src/main/java/com/vzome/core/editor/ChangeManifestations.java
+++ b/core/src/main/java/com/vzome/core/editor/ChangeManifestations.java
@@ -135,7 +135,7 @@ public abstract class ChangeManifestations extends ChangeSelection
         plan( new RenderManifestation( m, false ) );
     }
 
-    protected void colorManifestation( Manifestation m, Color color )
+    public void colorManifestation( Manifestation m, Color color )
     {
         plan( new ColorManifestation( m, color ) );
     }

--- a/core/src/main/java/com/vzome/core/model/Manifestation.java
+++ b/core/src/main/java/com/vzome/core/model/Manifestation.java
@@ -96,6 +96,8 @@ public abstract class Manifestation implements GroupElement
     public void setRenderedObject( RenderedManifestation obj )
     {
         mRendered = obj;
+        if ( obj != null )
+            this .color = obj .getColor();
     }
 
     public RenderedManifestation getRenderedObject()

--- a/core/src/main/java/com/vzome/core/tools/TransformationTool.java
+++ b/core/src/main/java/com/vzome/core/tools/TransformationTool.java
@@ -71,7 +71,9 @@ public abstract class TransformationTool extends Tool
             Construction result = transform .transform( c );
             if ( result == null )
                 continue;
-            applyTool .manifestConstruction( result );
+            result .setColor( c .getColor() ); // just for consistency
+            Manifestation m = applyTool .manifestConstruction( result );
+            applyTool .colorManifestation( m, c .getColor() );
         }
         applyTool .redo();
     }


### PR DESCRIPTION
It was easy enough to capture and transfer colors in ApplyTool and
TransformationTool.

The only glitch was that struts created by drag or join had no color, and
Manifestation.mRendered had been cleared by the time M.getColor()
was called.  Thus, the color setting in M.setRenderedObject().