### PR TITLE
Fixed NPE due to lesson model thumbnails

### DIFF
--- a/client/src/components/modelcanvas-three.js
+++ b/client/src/components/modelcanvas-three.js
@@ -72,8 +72,8 @@ const Lighting = ( { backgroundColor, ambientColor, directionalLights } ) => {
 
 /*
 TODO:
-  0. NPE
-  2. lighting component extract
+  2. lighting component extract (Redux context tunneling)
+  3. auto-load real logo model, internal
   3. UI overlay
   4. geometry cache
 */

--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
@@ -480,12 +480,13 @@ public class DocumentController extends DefaultController implements Scene.Provi
 
             boolean openUndone = propertyIsTrue( "open.undone" );
             boolean asTemplate = propertyIsTrue( "as.template" );
+            boolean headless = propertyIsTrue( "headless.open" );
 
             // used to finish loading a model history on a non-UI thread
             this .documentModel .finishLoading( openUndone, asTemplate );
                         
             // mainScene is not listening to mRenderedModel yet, so batch the rendering changes to it
-            if ( mainScene != null )
+            if ( !headless && mainScene != null )
             {
                 if ( editingModel )
                 {

--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/JsonClientShim.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/JsonClientShim.java
@@ -35,7 +35,7 @@ public abstract class JsonClientShim implements JsonClientRendering.EventDispatc
     private final JsonMapper mapper = new JsonMapper();
 
     private final static Logger rootLogger = Logger .getLogger("");
-
+    
     public JsonClientShim( String logLevel )
     {
         System .setProperty( "java.util.logging.SimpleFormatter.format", "%4$s: %5$s%n" );
@@ -73,6 +73,7 @@ public abstract class JsonClientShim implements JsonClientRendering.EventDispatc
         Properties props = new Properties();
         props .setProperty( "entitlement.model.edit", "true" );
         props .setProperty( "keep.alive", "true" );
+        props .setProperty( "headless.open", "true" );
 
         this .applicationController = new ApplicationController( new ApplicationController.UI()
         {   
@@ -80,13 +81,14 @@ public abstract class JsonClientShim implements JsonClientRendering.EventDispatc
             public void doAction( String action )
             {
                 rootLogger .warning( "WARNING: Unhandled UI event: " + action );
+                new RuntimeException( "WARNING: Unhandled UI event" ) .printStackTrace();
             }
         }, props, new J3dComponentFactory()
         {
             @Override
             public RenderingViewer createRenderingViewer( Scene scene )
             {
-                rootLogger .warning( "WARNING: createRenderingViewer called" );
+                // Can't happen, because of "headless.open" property setting above.
                 return null;
             }
         });
@@ -199,10 +201,10 @@ public abstract class JsonClientShim implements JsonClientRendering.EventDispatc
                 }
             };
             
-            String path = "/Users/vorth/Downloads/greenTetra.vZome";
+            String path = "/Users/vorth/Dropbox/vZome/attachments/2020/08-Aug/02-Scott-vZome-logo/vZomeLogo.vZome";
             shim .applicationController .doFileAction( "open", new File( path ) );
-            DocumentController documentController = shim .renderDocument( path );
 
+            DocumentController documentController = shim .renderDocument( path );
             documentController .doFileAction( "export.dae", new File( "/Users/vorth/Downloads/greenTetra.dae" ) );
         } catch (Throwable t) {
             t .printStackTrace();


### PR DESCRIPTION
I added a property for completely bypassing rendering sync in "finish.load",
called "headless.open", and I'm setting it in JsonClientShim.  This means
the lesson model is ignored.

This also avoids loading the classes that trigger "Graphics system is
initialized" from CheerpJ runtime.