### PR TITLE
Fixed defect in loading model using custom tetrahedral symmetry

### DIFF
--- a/core/src/main/java/com/vzome/core/editor/DocumentModel.java
+++ b/core/src/main/java/com/vzome/core/editor/DocumentModel.java
@@ -323,7 +323,7 @@ public class DocumentModel implements Snapshot .Recorder, UndoableEdit .Context
             return edit;
 
         String toolId = xml .getAttribute( "name" );
-        if ( toolId != null )
+        if ( toolId != null && ! "" .equals( toolId ) )
         {
             AbstractToolFactory factory = (AbstractToolFactory) this .toolFactories .get( name );
             if ( factory != null )

--- a/core/src/main/java/com/vzome/core/tools/TetrahedralToolFactory.java
+++ b/core/src/main/java/com/vzome/core/tools/TetrahedralToolFactory.java
@@ -41,6 +41,8 @@ public class TetrahedralToolFactory extends OctahedralToolFactory
 	@Override
 	public Tool createToolInternal( String id )
 	{
+	    if ( ! id .startsWith( "tetrahedral" ) )
+	        id = "tetrahedral." + id;
 		return new SymmetryTool( id, getSymmetry(), getToolsModel() );
 	}
 }


### PR DESCRIPTION
Built-in tetrahedral symmetry was always handled because of the test for
"." in the name of a tool, in AbstractToolFactor.deserializeTool().
However, for custom tetrahedral tools, the names were not prefixed this
way, so there was nothing in the serialization to distinguish tetrahedral
from octahedral or from icosahedral... the edit is always just "SymmetryTool".

The other option to fix this would be to register the TetrahedralToolFactory
explicitly in FieldApplication.registerToolFactories(), which is only for
deserialization, but that feels like a more impactful change than this one.