### PR TITLE
Updating JOGL to 2.4.0 to fix the NSWindow exception

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,14 +39,13 @@ subprojects {
     // this one is for javax.media.jai
     maven { url 'http://repository.springsource.com/maven/bundles/external' }
 
-    ivy { // not really an Ivy repo, but this pattern lets us automate the bare JAR downloads for java3d/*
-    // This failed due to issues mentioned here:
-    //   https://discuss.gradle.org/t/gradle-fails-to-download-a-dependency-if-http-head-is-not-supported-by-a-web-server/9885/3
-    //   https://discuss.gradle.org/t/use-github-releases-as-dependency-repository-plugin/15944/7
-    //  url "https://github.com/hharrison/"
-    //  layout "pattern", {
-    //    artifact "[organization]-core/releases/downloads/[revision]/[artifact].[ext]"
-    
+    ivy { // not really an Ivy repo, but this pattern lets us automate the bare JAR downloads for JOGL
+      url "http://jogamp.org/deployment"
+      layout "pattern", {
+        artifact "[revision]/jar/[artifact].[ext]"
+      }
+    }
+    ivy { // not really an Ivy repo, but this pattern lets us automate the bare JAR download for vecmath
       url "http://jogamp.org/deployment"
       layout "pattern", {
         artifact "[organization]/[revision]/[artifact].[ext]"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     compile     group: 'java3d',            name: 'vecmath',           version:'1.6.0-final'
     compile     group: 'org.python',        name: 'jython',            version:'2.7.1b3'
     compile     group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.5'
-    compile     group: 'org.jogamp.jogl',   name: 'jogl-all-main',     version:'2.3.2'
+    compile     group: 'org.jogamp', name: 'jogl-all', version:'v2.4.0-rc-20200307'
 
 	compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.9.3'
 	compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.9.3'

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -58,8 +58,25 @@ sourceSets {
 
 dependencies {
     compile group: 'java3d', name: 'vecmath', version:'1.6.0-final'
-    compile group: 'org.jogamp.gluegen', name: 'gluegen-rt-main', version:'2.3.2'
-    compile group: 'org.jogamp.jogl', name: 'jogl-all-main', version:'2.3.2'
+
+    compile group: 'org.jogamp', name: 'gluegen-rt', version:'v2.4.0-rc-20200307'
+    compile group: 'org.jogamp', name: 'gluegen-rt-natives-linux-aarch64', version:'v2.4.0-rc-20200307'
+    compile group: 'org.jogamp', name: 'gluegen-rt-natives-linux-amd64', version:'v2.4.0-rc-20200307'
+    compile group: 'org.jogamp', name: 'gluegen-rt-natives-linux-armv6hf', version:'v2.4.0-rc-20200307'
+    compile group: 'org.jogamp', name: 'gluegen-rt-natives-linux-i586', version:'v2.4.0-rc-20200307'
+    compile group: 'org.jogamp', name: 'gluegen-rt-natives-macosx-universal', version:'v2.4.0-rc-20200307'
+    compile group: 'org.jogamp', name: 'gluegen-rt-natives-windows-amd64', version:'v2.4.0-rc-20200307'
+    compile group: 'org.jogamp', name: 'gluegen-rt-natives-windows-i586', version:'v2.4.0-rc-20200307'
+
+    compile group: 'org.jogamp', name: 'jogl-all', version:'v2.4.0-rc-20200307'
+    compile group: 'org.jogamp', name: 'jogl-all-natives-linux-aarch64', version:'v2.4.0-rc-20200307'
+    compile group: 'org.jogamp', name: 'jogl-all-natives-linux-amd64', version:'v2.4.0-rc-20200307'
+    compile group: 'org.jogamp', name: 'jogl-all-natives-linux-armv6hf', version:'v2.4.0-rc-20200307'
+    compile group: 'org.jogamp', name: 'jogl-all-natives-linux-i586', version:'v2.4.0-rc-20200307'
+    compile group: 'org.jogamp', name: 'jogl-all-natives-macosx-universal', version:'v2.4.0-rc-20200307'
+    compile group: 'org.jogamp', name: 'jogl-all-natives-windows-amd64', version:'v2.4.0-rc-20200307'
+    compile group: 'org.jogamp', name: 'jogl-all-natives-windows-i586', version:'v2.4.0-rc-20200307'
+
     compile group: 'javax.media.jai', name: 'com.springsource.javax.media.jai.core', version:'1.1.3'
     compile group: 'org.eclipse.lsp4j', name: 'org.eclipse.lsp4j.debug', version: '0.8.1'
     

--- a/desktop/platform/mac/build.gradle
+++ b/desktop/platform/mac/build.gradle
@@ -50,6 +50,7 @@ macAppBundle {
     creatorCode = 'vZ60'
     icon = 'vZome-6.icns'
     bundleJRE = 'true'
+    jreHome = '/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home'
     javaProperties.putAll jvmArgs
     javaProperties.put 'java.ext.dirs', '.'
     arguments.addAll vzomeArgs


### PR DESCRIPTION
Due to my upgraded Catalina OS, what used to be a warning about some
native window APIs on Mac OS X has turned into an exception (as they
promised in the warning).  JOGL has a fix, according to Sven G, so I've
tried to upgrade to 2.4.0, although it is not available from Maven yet.

I found the RC builds, and adjusted the "Ivy" repos to pick them up.
I got a runtime error because they do not contain all the native libs
like the "jogl-all-main.jar", etc. that get published to Maven Central.
I manually listed all the necessary natives (7 each for jogl-all and
gluegen-rt), and now the app runs with "gr desktop:run".

In addition, I controlled the jreHome for the createApp task to OpenJDK 8,
and now the packaged Mac app also runs!  (The last release, 7.0.22, had
started to crash on startup, using JRE 1.8.0_152, with a curious NPE
while loading quaternion VEFs.)

I'll have to install OpenJDK 8 on the build machine.  I'll leave the Windows
build alone, for now.