### PR TITLE
Fixed trackball panel symmetry switch bug

### DIFF
--- a/desktop/src/main/java/com/vzome/desktop/controller/CameraController.java
+++ b/desktop/src/main/java/com/vzome/desktop/controller/CameraController.java
@@ -538,7 +538,12 @@ public class CameraController extends DefaultController implements Scene.Provide
     public void setSymmetry( RenderedModel model, Snapper snapper )
     {
         this .symmetryModel = model;
-        this .scene = new Scene( this .sceneLighting, false, model .getOrbitSource() .getSymmetry() .getChiralOrder() );
+        if ( this .scene == null )
+            // Lazy scene creation
+            // TODO: what if we don't start with the largest-order symmetry?
+            this .scene = new Scene( this .sceneLighting, false, model .getOrbitSource() .getSymmetry() .getChiralOrder() );
+        else
+            scene .reset();
         for ( RenderedManifestation rm : symmetryModel )
             scene .manifestationAdded( rm );
         this .snapper = snapper;


### PR DESCRIPTION
For 7.0.18, we changed where the Scene was created, so it is owned by
either the DocumentController or the CameraController.  However, we were
re-creating the scene in CameraController with every symmetry change, and
only the original was hooked up to the rendering.