### PR TITLE
Fixed automatic orbit bug

### DIFF
--- a/core/src/main/java/com/vzome/core/editor/EditorModelImpl.java
+++ b/core/src/main/java/com/vzome/core/editor/EditorModelImpl.java
@@ -3,6 +3,7 @@ package com.vzome.core.editor;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -208,6 +209,11 @@ public class EditorModelImpl implements LegacyEditorModel, SymmetryAware
     public OrbitSource getSymmetrySystem( String name )
     {
         return this .symmetrySystems .get( name );
+    }
+    
+    public Iterator<OrbitSource> getSymmetrySystems()
+    {
+        return this .symmetrySystems .values() .iterator();
     }
 
     @Override

--- a/core/src/regression/files/2020/11-Nov/21-Scott-regression/build-with-this-switch-symm.vZome
+++ b/core/src/regression/files/2020/11-Nov/21-Scott-regression/build-with-this-switch-symm.vZome
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<vzome:vZome xmlns:vzome="http://xml.vzome.com/vZome/4.0.0/" buildNumber="DEV" coreVersion="7.0" edition="vZome" field="golden" version="7.0">
+  <EditHistory editNumber="2" lastStickyEdit="-1">
+    <StrutCreation anchor="0 0 0 0 0 0" dir="rose" index="17" len="1 2"/>
+    <StrutCreation anchor="3 4 0 0 0 -1" dir="21" index="5" len="2 3" symm="octahedral"/>
+  </EditHistory>
+  <notes/>
+  <sceneModel ambientLight="41,41,41" background="178,205,230">
+    <directionalLight color="235,235,228" x="1.0" y="-1.0" z="-1.0"/>
+    <directionalLight color="228,228,235" x="-1.0" y="0.0" z="0.0"/>
+    <directionalLight color="30,30,30" x="0.0" y="0.0" z="-1.0"/>
+  </sceneModel>
+  <Viewing>
+    <ViewModel distance="108.73126983642578" far="217.46253967285156" near="0.27182817459106445" parallel="false" stereoAngle="0.0" width="48.92906951904297">
+      <LookAtPoint x="0.0" y="0.0" z="0.0"/>
+      <UpDirection x="0.0" y="1.0" z="0.0"/>
+      <LookDirection x="0.0" y="0.0" z="-1.0"/>
+    </ViewModel>
+  </Viewing>
+  <SymmetrySystem name="icosahedral" renderingStyle="solid connectors">
+    <Direction color="6,96,141" name="blue"/>
+    <Direction color="197,3,20" name="red"/>
+    <Direction color="245,163,1" name="yellow"/>
+    <Direction color="2,130,53" name="green"/>
+    <Direction color="236,89,1" name="orange"/>
+    <Direction color="113,64,178" name="purple"/>
+    <Direction color="36,35,38" name="black"/>
+    <Direction color="144,127,227" name="lavender"/>
+    <Direction color="116,104,1" name="olive"/>
+    <Direction color="141,2,41" name="maroon"/>
+    <Direction color="251,94,160" name="rose"/>
+    <Direction color="52,48,136" name="navy"/>
+    <Direction color="53,181,179" name="turquoise"/>
+    <Direction color="254,124,123" name="coral"/>
+    <Direction color="218,225,83" name="sulfur"/>
+    <Direction color="187,144,85" name="sand"/>
+    <Direction color="129,191,30" name="apple"/>
+    <Direction color="144,56,14" name="cinnamon"/>
+    <Direction color="12,84,55" name="spruce"/>
+    <Direction color="105,54,1" name="brown"/>
+    <Direction color="255,255,255" name="22" prototype="0 0 3 -1 -3 2"/>
+  </SymmetrySystem>
+  <OtherSymmetries>
+    <SymmetrySystem name="octahedral" renderingStyle="trapezoids">
+      <Direction color="6,96,141" name="blue"/>
+      <Direction color="245,163,1" name="yellow"/>
+      <Direction color="2,130,53" name="green"/>
+      <Direction color="144,127,227" name="lavender"/>
+      <Direction color="116,104,1" name="olive"/>
+      <Direction color="141,2,41" name="maroon"/>
+      <Direction color="105,54,1" name="brown"/>
+      <Direction color="197,3,20" name="red"/>
+      <Direction color="113,64,178" name="purple"/>
+      <Direction color="36,35,38" name="black"/>
+      <Direction color="53,181,179" name="turquoise"/>
+      <Direction color="255,255,255" name="21" prototype="3 -1 0 0 3 -2"/>
+    </SymmetrySystem>
+  </OtherSymmetries>
+  <Tools/>
+</vzome:vZome>

--- a/core/src/regression/files/2020/11-Nov/21-Scott-regression/heptagon-test.vZome
+++ b/core/src/regression/files/2020/11-Nov/21-Scott-regression/heptagon-test.vZome
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<vzome:vZome xmlns:vzome="http://xml.vzome.com/vZome/4.0.0/" buildNumber="dev" coreVersion="7.0" edition="vZome" field="heptagon" version="7.0">
+  <EditHistory editNumber="9" lastStickyEdit="-1">
+    <StrutCreation anchor="0 0 0 0 0 0 0 0 0" index="4" len="0 2 1" outbound="false" symm="heptagonal antiprism corrected"/>
+    <StrutCreation anchor="2 -1 2 -1 2 0 0 0 0" index="3" len="0 2 1" outbound="false" symm="heptagonal antiprism corrected"/>
+    <StrutCreation anchor="2 1 3 0 0 0 0 0 0" dir="green" index="11" len="0 2 1" symm="heptagonal antiprism corrected"/>
+    <StrutCreation anchor="2 1 3 0 0 0 0 0 0" dir="23" index="18" len="0 2 1" symm="octahedral"/>
+    <StrutCreation anchor="1 3 3 0 0 0 2 1 3" dir="23" index="9" len="0 2 1" symm="octahedral"/>
+    <StrutCreation anchor="1 3 3 0 0 0 2 1 3" dir="23" index="0" len="0 2 1" symm="octahedral"/>
+    <StrutCreation anchor="1 3 3 0 0 0 2 1 3" dir="23" index="1" len="0 2 1" symm="octahedral"/>
+    <StrutCreation anchor="1 3 3 0 0 0 2 1 3" dir="23" index="2" len="0 2 1" symm="octahedral"/>
+    <SelectManifestation point="1 3 3 1 -2 0 4 2 6"/>
+  </EditHistory>
+  <notes/>
+  <sceneModel ambientLight="41,41,41" background="178,205,230">
+    <directionalLight color="235,235,228" x="1.0" y="-1.0" z="-1.0"/>
+    <directionalLight color="228,228,235" x="-1.0" y="0.0" z="0.0"/>
+    <directionalLight color="30,30,30" x="0.0" y="0.0" z="-1.0"/>
+  </sceneModel>
+  <Viewing>
+    <ViewModel distance="102.39925384521484" far="204.7985076904297" near="0.2559981346130371" parallel="false" stereoAngle="0.0" width="46.07966613769531">
+      <LookAtPoint x="0.0" y="0.0" z="0.0"/>
+      <UpDirection x="0.0" y="1.0" z="0.0"/>
+      <LookDirection x="0.0" y="0.0" z="-1.0"/>
+    </ViewModel>
+  </Viewing>
+  <SymmetrySystem name="heptagonal antiprism corrected" renderingStyle="heptagonal antiprism">
+    <Direction color="197,3,20" name="red"/>
+    <Direction color="6,96,141" name="blue"/>
+    <Direction color="2,130,53" name="green"/>
+    <Direction color="255,255,255" name="24" prototype="0 -1 1 0 0 0 0 1 0"/>
+    <Direction color="255,255,255" name="25" prototype="0 -1 0 0 -1 1 0 0 0"/>
+    <Direction color="255,255,255" name="26" prototype="0 -1 0 0 0 0 0 -1 1"/>
+  </SymmetrySystem>
+  <OtherSymmetries>
+    <SymmetrySystem name="octahedral" renderingStyle="octahedra">
+      <Direction color="6,96,141" name="blue"/>
+      <Direction color="2,130,53" name="green"/>
+      <Direction color="245,163,1" name="yellow"/>
+      <Direction color="255,255,255" name="21" prototype="1 -1 1 -1 1 0 0 0 0"/>
+      <Direction color="255,255,255" name="22" prototype="0 1 0 1 -1 0 0 0 0"/>
+      <Direction color="255,255,255" name="23" prototype="0 -1 0 0 1 -1 0 0 0"/>
+    </SymmetrySystem>
+    <SymmetrySystem name="heptagonal antiprism" renderingStyle="heptagonal antiprism">
+      <Direction color="197,3,20" name="red"/>
+      <Direction color="6,96,141" name="blue"/>
+      <Direction color="2,130,53" name="green"/>
+    </SymmetrySystem>
+  </OtherSymmetries>
+  <Tools/>
+</vzome:vZome>

--- a/core/src/regression/files/sniff-test.vZome-files
+++ b/core/src/regression/files/sniff-test.vZome-files
@@ -155,3 +155,6 @@ format-2.1.0-models.vZome-files
 
 # simple and colored mesh import
 2020/04-Apr/26-Scott-regression
+
+# storing auto orbits from *all* symmetries
+2020/11-Nov/21-Scott-regression


### PR DESCRIPTION
John Hall tripped over this one, though I think I may have seen it before.

We have to store all symmetries, not just the current one, due to sequences like this:

  1. drag an icosahedral olive strut
  2. switch to octahedral symmetry
  3. do "build with this" on the olive strut
  4. drag out a strut
  5. switch back to icosahedral symmetry

The end result is that the command in step 4 records the name of an automatic orbit.
That automatic orbit must be captured in the file.

I have therefore added an "OtherSymmetries" element to the top-level.  For
backward-compatibility, this supplements the existing "SymmetrySystem"
element, rather than replacing it, and does not duplicate that system in the XML.