### PR TITLE
Fixed canonicalizeId bug for polygons

### DIFF
--- a/client/src/bundles/mesh.js
+++ b/client/src/bundles/mesh.js
@@ -47,9 +47,17 @@ const canonicalizedId = ( vectors ) =>
       min = strings[ i ]
     }
   }
+  // Since % does not actually perform a consistent sawtooth modulus function for negative numbers,
+  //  we add strings.length to force a positive number.
+  const get = i => strings[ ( strings.length + minIndex + i ) % strings.length ]
+
+  // We have the minimum (get(0)), now figure out which way to go
+  const incr = ( get( 1 ).localeCompare( get( -1 ) ) < 0 )? 1 : -1
+
   let sorted = ""
   for ( let j = 0; j < strings.length; j++ ) {
-    sorted += strings[ ( minIndex + j ) % strings.length ]
+    const next = get( j * incr )
+    sorted += next
   }
   return sorted
 }


### PR DESCRIPTION
It was sensitive to the order of the vectors argument.  Now it first
finds the minimum vector, then determines whether to increment in the
positive or negative direction.