### PR TITLE
Fixed CommandEdit constructor bug

### DIFF
--- a/client/src/bundles/jsweet.js
+++ b/client/src/bundles/jsweet.js
@@ -308,6 +308,10 @@ export const init = async ( window, store ) =>
 
   const xmlToEditClass = editName =>
   {
+    if ( editName === 'CommandEdit' ) {
+      // The constructor pattern is wrong
+      return undefined
+    }
     const legacyNames = {
       setItemColor: "ColorManifestations",
       BnPolyope: "B4Polytope",


### PR DESCRIPTION
The constructor is found by xmlToEditClass, but the signature is wrong,
so it fails.  The fix is to simply let 'CommandEdit' go to the else part,
by putting a special case in xmlToEditClass.