### PR TITLE
Adding a multi-design article route

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -6303,6 +6303,19 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -8320,6 +8333,25 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+    },
+    "mini-create-react-context": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "tiny-warning": "^1.0.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
     },
     "mini-css-extract-plugin": {
       "version": "0.9.0",
@@ -10833,6 +10865,52 @@
         "react-is": "^16.9.0"
       }
     },
+    "react-router": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
     "react-scripts": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.4.1.tgz",
@@ -11258,6 +11336,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -12705,6 +12788,11 @@
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+    },
     "tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
@@ -13115,6 +13203,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "react-bootstrap": "^1.3.0",
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.1",
+    "react-router-dom": "^5.2.0",
     "react-scripts": "^3.4.1",
     "react-three-fiber": "^4.1.0",
     "redux": "^4.0.5",

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -16,33 +16,6 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-.dropdown {
-  position: fixed;
-  left: 13%;
-  top: 1%;
-}
-
-#exporter {
-  position: fixed;
-  right: 1%;
-  top: 1%;
-}
-
-#editmenu {
-  position: fixed;
-  left: 1%;
-  top: 1%;
-}
-
 .FileInput {
   display: none;
-}
-
-button {
-  background-color: Transparent;
-  background-repeat:no-repeat;
-  border: none;
-  cursor:pointer;
-  overflow: hidden;
-  outline:none;
 }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,9 +1,5 @@
 import React from 'react'
-import { makeStyles } from '@material-ui/core/styles';
-
-// import Fab from '@material-ui/core/Fab'
-// import UndoRoundedIcon from '@material-ui/icons/UndoRounded'
-// import RedoRoundedIcon from '@material-ui/icons/RedoRounded'
+import { makeStyles } from '@material-ui/core/styles'
 
 import './App.css'
 
@@ -12,12 +8,8 @@ import ErrorAlert from './components/alert.js'
 import Spinner from './components/spinner.js'
 import VZomeAppBar from './components/appbar.js'
 import Debugger from './components/debugger.js'
-// import Exporter from './components/exporter.js'
-// import EditMenu from './components/editmenu.js'
 
 const useStyles = makeStyles((theme) => ({
-  root: {
-  },
   content: {
     flexGrow: 1,
     display: "contents",
@@ -34,17 +26,7 @@ function App() {
         <ModelCanvas/>
       </main>
       <ErrorAlert/> 
-      {/* <Fab color="primary" aria-label="undo">
-        <UndoRoundedIcon />
-      </Fab>
-      <Fab color="primary" aria-label="redo">
-        <RedoRoundedIcon />
-      </Fab> */}
-
-      {/* <Exporter/> */}
-      {/* <EditMenu/> */}
       <Spinner/>
-      {/* <div>Export icon made from <a href="http://www.onlinewebfonts.com/icon">Icon Fonts</a> is licensed by CC BY 3.0</div> */}
     </>
   );
 }

--- a/client/src/Article.js
+++ b/client/src/Article.js
@@ -1,0 +1,101 @@
+import React, { useEffect } from 'react'
+import { useDispatch } from 'react-redux'
+import { makeStyles } from '@material-ui/core/styles'
+import Container from '@material-ui/core/Container'
+import Paper from '@material-ui/core/Paper'
+import Typography from '@material-ui/core/Typography'
+
+import VZomeAppBar from './components/appbar.js'
+import ModelCanvas from './components/modelcanvas-three.js'
+
+const useStyles = makeStyles( (theme) => ({
+  viewer: {
+    height: "400px",
+    minHeight: "400px",
+    maxHeight: "60vh",
+    marginLeft: "15%",
+    marginRight: "15%",
+    marginTop: "15px",
+    marginBottom: "15px",
+    borderWidth: "medium",
+    borderRadius: "10px",
+    border: "solid",
+  },
+  paper: {
+    paddingLeft: "2%",
+    paddingRight: "2%",
+  }
+}));
+
+const Article = () =>
+{
+  // const dispatch = useDispatch();
+  // useEffect( () => {
+  //   console.log( 'USED EFFECT' )
+  //   const model = '120-cell'
+  //   dispatch( fetchModel( `/app/models/${model}.vZome`, model ) )
+  // })
+  const classes = useStyles();
+  return (
+    <>
+      <VZomeAppBar article/>
+      <Container maxWidth="md">
+        <Paper className={classes.paper}>
+          <Typography variant="h2" gutterBottom >
+            The 5-Cell and its Family
+          </Typography>
+          <Typography gutterBottom >
+            The 5-cell is the simplest 4-dimensional regular polytope, consisting of 5 equivalent tetrahedral cells.
+            We can experience this in three dimensions only by projecting from 4D down to 3D.
+            There is a well-known orthogonal projection that can be built in Zometool, shown below.
+            You can count the five tetrahedra: the outer green one, and the four interior tetrahedra with yellow edges
+            foreshortened by the projection.
+          </Typography>
+          <div className={classes.viewer}>
+            <ModelCanvas design='greenTetra' />
+          </div>
+          <Typography gutterBottom >
+            Until 2007, my friend David Richter and I believed that there was no other orthogonal 3D projection of the 5-cell 
+            that could be constructed with Zome. This turns out to be false. I stumbled upon such a projection,
+            and David saw immediately that this implied that the entire family of 9 uniform A4 polytopes could also be projected in this manner.
+            Furthermore, David showed that there are two other rZome-constructible projections, one using red, yellow, and blue,
+            and one using just yellow and blue.
+          </Typography>
+          <div className={classes.viewer}>
+            <ModelCanvas design='A4_18' />
+          </div>
+          <Typography gutterBottom >
+            The remarkable thing about this projection is that it exhibits "ghost symmetry". 
+            This is our term for a phenomenon wherein the symmetry of a 4D object is subtly exposed in a 3D projection. 
+            Specifically, in this example, the new projection of the 5-cell has a 3D symmetry group that is nearly as simple as you can get: 
+            two orthogonal mirrors. It certainly does not have any overt fivefold symmetry in 3D. 
+            Nonetheless, there are two axes along which one can project orthogonally to 2D and obtain perfect fivefold symmetry!
+            You can see this clearly if you zoom out in the 3d view, using your scroll wheel.
+          </Typography>
+          <Typography gutterBottom >
+            This article illustrates the "ghost symmetry" projection for each of the 8 uniform
+            that have the symmetry of the 5-cell, known as the A4 Coxeter group.
+            For more discussion of this group, 
+            see David's page on the other Zome projections of the A4 family.
+          </Typography>
+          <div className={classes.viewer}>
+            <ModelCanvas design='A4_9' />
+          </div>
+          <Typography gutterBottom >
+            All of these are constructible in real Zome, in principle. 
+            However, several of them are challenging to build, due to the false intersections at inconvenient places, 
+            or simply due to the high degree of interconnectedness, which makes it difficult to get all the struts in place at the same time. 
+            One alternative is to build the "hidden cell removed" versions, where half of the interior struts are omitted. 
+            This corresponds to projecting only one hemisphere of the 4D hypersphere into 3D.
+            Unfortunately, doing so will destroy the 5-fold symmetric shadows.
+          </Typography>
+          <div className={classes.viewer}>
+            <ModelCanvas design='A4_BD' />
+          </div>
+        </Paper>
+      </Container>
+    </>
+  );
+}
+
+export default Article;

--- a/client/src/bundles/camera.js
+++ b/client/src/bundles/camera.js
@@ -14,8 +14,8 @@ const vZomeInitialState = {  // These values match the camera in the default vZo
   near: 0.1491,
 }
 
-export const initialState = {  // These values match the camera in the default vZomeLogo model file
-  fov: convertFOV( 0.442 ),
+export const initialState = {
+  fov: convertFOV( 0.75 ), // 0.44 in vZome
   position: [ 0, 0, 75 ],
   lookAt: [ 0, 0, 0 ],
   up: [ 0, 1, 0 ],
@@ -29,10 +29,10 @@ export const reducer = ( state = initialState, action ) => {
     case CAMERA_DEFINED:
       const { position, lookAtPoint, upDirection, fieldOfView, nearClipDistance, farClipDistance } = action.payload
       return {
+        ...state,
         position: [ ...Object.values( position ) ],
         lookAt: [ ...Object.values( lookAtPoint ) ],
         up: [ ...Object.values( upDirection ) ],
-        fov: convertFOV( fieldOfView ),
         near: nearClipDistance,
         far: farClipDistance
       }
@@ -64,7 +64,7 @@ export const parseViewXml = ( viewingElement ) =>
   const z = lookAtPoint.z - distance * lookDirection.z
   const position = { x, y, z }
   const payload = {
-    position, lookAtPoint, upDirection, fieldOfView: 0.442, nearClipDistance, farClipDistance
+    position, lookAtPoint, upDirection, nearClipDistance, farClipDistance
   }
   return { type: CAMERA_DEFINED, payload }
 }

--- a/client/src/bundles/designs.js
+++ b/client/src/bundles/designs.js
@@ -12,12 +12,13 @@ export const designReducer = combineReducers( {
   mesh: undoable( mesh.reducer ),
   dbugger: undoable( dbugger.reducer ),
   camera: camera.reducer,
+  name: ( state="", action ) => state, // name cannot be changed (YET), so a constant reducer is fine
   success: ( state="", action ) => state, // success cannot be changed, so a constant reducer is fine
   fieldName: ( state="", action ) => state, // fieldName cannot be changed, so a constant reducer is fine
   shaperName: ( state="", action ) => state, // shaperName cannot be changed (YET!), so a constant reducer is fine
 })
 
-export const initializeDesign = ( field, shaperName ) => ({
+export const initializeDesign = ( field, name, shaperName ) => ({
   mesh: {
     past: [],
     present: mesh.justOrigin( field ),
@@ -28,6 +29,7 @@ export const initializeDesign = ( field, shaperName ) => ({
   camera: camera.initialState,
   fieldName: field.name,
   shaperName,
+  name,
 })
 
 const emptyState = {
@@ -43,38 +45,38 @@ const addNewModel = ( state, field ) =>
     current: name,
     data: {
       ...state.data,
-      [ name ]: initializeDesign( field )
+      [ name ]: initializeDesign( field, name )
     }
   }
 }
 
 export const newModel = field => ( { type: 'NEW_MODEL', payload: field } )
 
-export const switchModel = name => ( { type: 'SWITCH_MODEL', payload: name } )
+export const switchModel = id => ( { type: 'SWITCH_MODEL', payload: id } )
 
 export const renameModel = name => ( { type: 'RENAME_MODEL', payload: name } )
 
-export const loadingDesign = ( name, design ) => ( { type: 'LOADING_DESIGN', payload: { name, design } } )
+export const loadingDesign = ( id, design ) => ( { type: 'LOADING_DESIGN', payload: { id, design } } )
 
-export const loadedDesign = ( name, design ) => ( { type: 'LOADED_DESIGN', payload: { name, design } } )
+export const loadedDesign = ( id, design ) => ( { type: 'LOADED_DESIGN', payload: { id, design } } )
 
-export const selectDesignName = state => state.designs.current
+export const selectDesign = ( state, id ) => state.designs.data[ id ] || state.designs.data[ state.designs.current ]
 
-export const selectDesign = ( state, name ) => state.designs.data[ name || state.designs.current ]
+export const selectDesignName = ( state, id ) => selectDesign( state, id ).name
 
-export const selectMesh = ( state, name ) => selectDesign( state, name ).mesh.present
+export const selectMesh = ( state, id ) => selectDesign( state, id ).mesh.present
 
-export const selectDebugger = ( state, name ) => selectDesign( state, name ).dbugger.present
+export const selectDebugger = ( state, id ) => selectDesign( state, id ).dbugger.present
 
-export const selectCamera = ( state, name ) => selectDesign( state, name ).camera
+export const selectCamera = ( state, id ) => selectDesign( state, id ).camera
 
-export const selectSource = ( state, name ) => selectDebugger( state, name ).source
+export const selectSource = ( state, id ) => selectDebugger( state, id ).source
 
-export const selectField = ( state, name ) => state.fields[ selectDesign( state, name ).fieldName ]
+export const selectField = ( state, id ) => state.fields[ selectDesign( state, id ).fieldName ]
 
-export const selectShaper = ( state, name ) =>
+export const selectShaper = ( state, id ) =>
 {
-  const shaperName = selectDesign( state, name ).shaperName || "solid connectors"
+  const shaperName = selectDesign( state, id ).shaperName || "solid connectors"
   return state.shapers[ shaperName ]
 }
 
@@ -97,24 +99,24 @@ export const reducer = ( state = addNewModel( emptyState, goldenField ), action 
     }
 
     case 'LOADING_DESIGN': {
-      const { name, design } = action.payload
+      const { id, design } = action.payload
       return {
         ...state,
         data: {
           ...state.data,
-          [ name ]: design
+          [ id ]: design
         }
       }
     }
 
     case 'LOADED_DESIGN': {
-      const { name, design } = action.payload
+      const { id, design } = action.payload
       return {
         ...state,
-        current: name,
+        current: id,
         data: {
           ...state.data,
-          [ name ]: design
+          [ id ]: design
         }
       }
     }

--- a/client/src/bundles/files.js
+++ b/client/src/bundles/files.js
@@ -10,7 +10,7 @@ export const fileSelected = selected => ( dispatch, getState ) =>
   const reader = new FileReader();
   reader.onload = () =>
   {
-    getState().java.parser( selected.name, reader.result, dispatch, getState )
+    getState().java.parser( selected.name, selected.name, reader.result, dispatch, getState )
   }
   reader.onerror = () =>
   {
@@ -20,7 +20,7 @@ export const fileSelected = selected => ( dispatch, getState ) =>
   reader.readAsText( selected )
 }
 
-export const fetchModel = ( path ) => ( dispatch, getState ) =>
+export const fetchModel = ( path, id ) => ( dispatch, getState ) =>
 {
   // TODO: I should really deploy my own copy of this proxy on Heroku
   const fetchWithCORS = url => fetch ( url ).catch ( _ => fetch( 'https://cors-anywhere.herokuapp.com/' + url ) )
@@ -36,7 +36,8 @@ export const fetchModel = ( path ) => ( dispatch, getState ) =>
     })
     .then( (text) => {
       const name = path.split( '\\' ).pop().split( '/' ).pop()
-      getState().java.parser( name, text, dispatch, getState )
+      const designId = id || name
+      getState().java.parser( name, designId, text, dispatch, getState )
     })
     .catch( error =>
     {

--- a/client/src/bundles/jsweet.js
+++ b/client/src/bundles/jsweet.js
@@ -545,7 +545,18 @@ export const init = async ( window, store ) =>
     if ( urlParams.has( "url" ) ) {
       url = decodeURI( urlParams.get( "url" ) )
     }
-    store.dispatch( fetchModel( url ) )
+    store.dispatch( fetchModel( url, 'logo' ) )
+
+    const fiveCellDesigns = [
+      { id: 'greenTetra', url: 'https://vzome.com/models/2007/04-Apr/5cell/greenTetra.vZome' },
+      { id: 'A4_18', url: 'https://vzome.com/models/2007/04-Apr/5cell/A4_18.vZome' },
+      { id: 'A4_9', url: 'https://vzome.com/models/2007/04-Apr/5cell/A4_9.vZome' },
+      { id: 'A4_BD', url: 'https://vzome.com/models/2007/04-Apr/5cell/A4_BD.vZome' },
+    ]
+
+    if ( window.location.href.includes( "fivecell" ) ) {
+      fiveCellDesigns.map( ({ id, url }) => store.dispatch( fetchModel( url, id ) ) )
+    }
   }
 }
 
@@ -641,7 +652,7 @@ const assignIds = ( element, id=':' ) => {
   return element
 }
 
-export const createParser = ( createDocument ) => ( name, xmlText, dispatch, getState ) =>
+export const createParser = ( createDocument ) => ( name, id, xmlText, dispatch, getState ) =>
 {
   const extIndex = name.lastIndexOf( '.' )
   if ( extIndex > 0 ) {
@@ -664,7 +675,7 @@ export const createParser = ( createDocument ) => ( name, xmlText, dispatch, get
     // We don't want to dispatch all the edits, which can trigger tons of
     //  overhead and re-rendering.  Instead, we'll build up a design locally
     //  by calling the designReducer manually.
-    let design = designs.initializeDesign( fields[ fieldName ], shaper.shapesName )
+    let design = designs.initializeDesign( fields[ fieldName ], name, shaper.shapesName )
     // Each call to designReducer may create an element in the history
     //  (if it has any changes to the mesh),
     //  so we want to be judicious in when we do it.
@@ -686,13 +697,13 @@ export const createParser = ( createDocument ) => ( name, xmlText, dispatch, get
     design = designs.designReducer( design, parser.sourceLoaded( edits, parseAndPerformEdit, targetEdit ) ) // recorded in history
     design = designs.designReducer( design, ActionCreators.clearHistory() )  // kind of a hack so both histories are in sync, with no past
 
-    dispatch( designs.loadingDesign( name, design ) )
+    dispatch( designs.loadingDesign( id, design ) )
 
     if ( ! getState().dbuggerEnabled ) {
-      dispatch( dbugger.debug( name, 'CONTINUE' ) )
+      dispatch( dbugger.debug( id, 'CONTINUE' ) )
     }
     else {
-      dispatch( designs.loadedDesign( name, design ) )
+      dispatch( designs.loadedDesign( id, design ) )
     }
 
   } catch (error) {

--- a/client/src/components/about.js
+++ b/client/src/components/about.js
@@ -1,11 +1,9 @@
 
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles'
-import Button from '@material-ui/core/Button'
 import Dialog from '@material-ui/core/Dialog'
 import MuiDialogTitle from '@material-ui/core/DialogTitle'
 import MuiDialogContent from '@material-ui/core/DialogContent'
-import MuiDialogActions from '@material-ui/core/DialogActions'
 import IconButton from '@material-ui/core/IconButton'
 import CloseIcon from '@material-ui/icons/Close'
 import Typography from '@material-ui/core/Typography'
@@ -45,13 +43,6 @@ const DialogContent = withStyles((theme) => ({
     padding: theme.spacing(2),
   },
 }))(MuiDialogContent)
-
-const DialogActions = withStyles((theme) => ({
-  root: {
-    margin: 0,
-    padding: theme.spacing(1),
-  },
-}))(MuiDialogActions)
 
 export default function AboutDialog() {
   const [open, setOpen] = React.useState(false);

--- a/client/src/components/appbar.js
+++ b/client/src/components/appbar.js
@@ -25,26 +25,29 @@ const useStyles = makeStyles((theme) => ({
   },
 }))
 
-export default function VZomeAppBar() {
+const VZomeAppBar = ( { article=false } ) =>
+{
   const classes = useStyles()
 
   return (
     <div className={classes.root}>
       <AppBar position="static">
         <Toolbar>
-          {/* <IconButton edge="start" className={classes.menuButton} aria-label="logo"> */}
-            <VZomeLogo/>
-          {/* </IconButton> */}
-
+          <VZomeLogo/>
           <Typography variant="h5" className={classes.title}>
             vZome <Box component="span" fontStyle="oblique">Online</Box>
           </Typography>
-          <UndoRedoButtons/>
-          <DesignsSelect/>
-          <OpenButton className={classes.open}/>
-          <AboutButton/>
+          { article? null :
+            <>
+              <UndoRedoButtons/>
+              <DesignsSelect/>
+              <OpenButton className={classes.open}/>
+            </> }
+            <AboutButton/>
         </Toolbar>
       </AppBar>
     </div>
   )
 }
+
+export default VZomeAppBar

--- a/client/src/components/designs.js
+++ b/client/src/components/designs.js
@@ -53,7 +53,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }))
 
-const DesignsSelect = ( { modelNames, current, doSelectModel } ) =>
+const DesignsSelect = ( { designs, current, doSelectModel } ) =>
 {
   const classes = useStyles()
 
@@ -62,7 +62,7 @@ const DesignsSelect = ( { modelNames, current, doSelectModel } ) =>
     doSelectModel( event.target.value )
   }
 
-  if ( ! modelNames )
+  if ( ! designs )
     return null
 
   return (
@@ -73,8 +73,8 @@ const DesignsSelect = ( { modelNames, current, doSelectModel } ) =>
         label="Design"
         input={<BootstrapInput />}
       >
-        { modelNames.map( modelName =>
-          <MenuItem key={modelName} value={modelName}>{modelName}</MenuItem>
+        { Object.keys( designs ).map( id =>
+          <MenuItem key={id} value={id}>{designs[ id ].name}</MenuItem>
         ) }
       </Select>
     </FormControl>
@@ -86,7 +86,7 @@ const select = ( state ) =>
 {
   const { designs } = state
   return {
-    modelNames: designs && Object.keys( designs.data ),
+    designs: designs && designs.data,
     current: designs && designs.current
   }
 }

--- a/client/src/components/folder.js
+++ b/client/src/components/folder.js
@@ -42,6 +42,12 @@ const models = [
     label: "Orange and Purple Tangle",
     description: "A design by Brian Hall"
   },
+  {
+    key: "truncated5Cell",
+    url: "/models/2007/04-Apr/5cell/A4_3C.vZome",
+    label: "Truncated 5-Cell",
+    description: "Truncated 5-Cell"
+  },
 ]
 
 const DesignsMenu = ( { openDesign, openFile } ) =>
@@ -60,7 +66,8 @@ const DesignsMenu = ( { openDesign, openFile } ) =>
 
   const handleSelectModel = model => {
     setAnchorEl(null)
-    openDesign( `/app/models/${model}.vZome` )
+    const { url, key } = model
+    openDesign( url || `/app/models/${key}.vZome`, key )
   }
 
   const handleClose = () => {
@@ -97,7 +104,7 @@ const DesignsMenu = ( { openDesign, openFile } ) =>
         <MenuItem onClick={handleShowUrlDialog}>Remote vZome URL</MenuItem>
         <Divider />
         { models.map( (model) => (
-          <MenuItem key={model.key} onClick={()=>handleSelectModel(model.key)}>{model.label}</MenuItem>
+          <MenuItem key={model.key} onClick={()=>handleSelectModel(model)}>{model.label}</MenuItem>
         ) ) }
       </Menu>
       <UrlDialog show={showDialog} setShow={setShowDialog} openDesign={openDesign} />

--- a/client/src/components/modelcanvas-three.js
+++ b/client/src/components/modelcanvas-three.js
@@ -1,5 +1,5 @@
 
-import React, { useRef, useMemo } from 'react'
+import React, { useRef, useMemo, useEffect } from 'react'
 import { connect } from 'react-redux'
 import { Canvas, useThree, extend, useFrame } from 'react-three-fiber'
 import * as THREE from 'three'
@@ -64,7 +64,8 @@ TODO:
 //   https://github.com/react-spring/react-three-fiber/discussions/609
 
 const ModelCanvas = ( { lighting, camera, mesh, field, resolver, preResolved, clickable, selectionToggler,
-                        startGridHover, stopGridHover, startBallHover, stopBallHover, shapeClick, bkgdClick, workingPlane } ) => {
+                        startGridHover, stopGridHover, startBallHover, stopBallHover, shapeClick, bkgdClick, workingPlane } ) =>
+{
   const { fov, position, up, lookAt } = camera
   const focus = workingPlane && workingPlane.enabled && workingPlane.buildingStruts && workingPlane.position
   const atFocus = id => focus && ( id === JSON.stringify(focus) )
@@ -102,13 +103,14 @@ const ModelCanvas = ( { lighting, camera, mesh, field, resolver, preResolved, cl
   )
 }
 
-const select = ( state ) =>
+const select = ( state, ownProps ) =>
 {
+  const { design } = ownProps
   const { lighting, workingPlane, java } = state
-  const mesh = state.designs && designs.selectMesh( state )
-  const field = state.designs && designs.selectField( state )
-  const camera = state.camera || designs.selectCamera( state )
-  const resolver = state.designs && designs.selectShaper( state )
+  const mesh = state.designs && designs.selectMesh( state, design )
+  const field = state.designs && designs.selectField( state, design )
+  const camera = state.camera || designs.selectCamera( state, design )
+  const resolver = state.designs && designs.selectShaper( state, design )
   const preResolved = java.shapes && { shapes: java.shapes, instances: java.renderingOn? java.instances : java.previous }
   const shown = mesh && new Map( mesh.shown )
   if ( workingPlane && workingPlane.enabled && workingPlane.endPt ) {
@@ -130,7 +132,7 @@ const select = ( state ) =>
     resolver,
     preResolved,
     mesh: mesh && { ...mesh, shown },
-    clickable: !!state.designs
+    clickable: !!state.designs,
   }
 }
 

--- a/client/src/components/spinner.js
+++ b/client/src/components/spinner.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux'
 
 import Backdrop from '@material-ui/core/Backdrop';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import Typography from '@material-ui/core/Typography'
 import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme) => ({

--- a/client/src/fields/golden.js
+++ b/client/src/fields/golden.js
@@ -122,8 +122,8 @@ function quatnormalize(q)
   return scalarmul( [ q.map( grsign ).reduce( (a, b) => a || b ) || 1 ], q )
 }
 
-const one = [[1],,,], h = [1,,2], blue = [one, [,[1],,], [,,,[1]], [,,[1],]],
-  yellow = [one, [h, h, h, h], [[-1,,2], h, h, h]], red = [one, [[,1,2], h, [-1,1,2],]]
+const one = [[1],[0],[0],[0]], h = [1,0,2], blue = [one, [[0],[1],[0],[0]], [[0],[0],[0],[1]], [[0],[0],[1],[0]]],
+  yellow = [one, [h, h, h, h], [[-1,0,2], h, h, h]], red = [one, [[0,1,2], h, [-1,1,2],]]
 for ( let i = 2; i < 5; i++ )
   red[i] = quatmul( red[i-1], red[1] )
 const vZomeIcosahedralQuaternions = []; let b, r, y

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -2,18 +2,32 @@ import React from 'react';
 import { Provider } from 'react-redux'
 import { render } from 'react-dom'
 import * as serviceWorker from './serviceWorker';
-
+import {
+  BrowserRouter as Router,
+  Switch,
+  Route
+} from "react-router-dom"
 import logger from 'redux-logger'
 import thunk from 'redux-thunk'
 
 import App from './App';
+import Article from './Article';
 import createBundleStore from './bundles'
 
 const store = createBundleStore( [ thunk, logger ] );
 
 render(
   <Provider store={store}>
-    <App />
+    <Router>
+      <Switch>
+        <Route path="/app" exact>
+          <App />
+        </Route>
+        <Route path="/app/fivecell">
+          <Article />
+        </Route>
+      </Switch>
+    </Router>
   </Provider>,
   document.getElementById( 'root' )
 )


### PR DESCRIPTION
This mainly involves decoupling the ModelCanvas from a single, global
current design, allowing it to take a design ID as a prop.

In order to make this well-defined, I had to decouple design IDs from
user-visible design names.

Ideally, each ModelCanvas instance would useEffect() to trigger its own
model load.  However, that caused an infinite loop when I tried it.