### PR TITLE
Removed the CheerpJ and JSweet parts from build-client.bash

### DIFF
--- a/build-client.bash
+++ b/build-client.bash
@@ -12,12 +12,12 @@ banner() {
   echo '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%'
 }
 
-banner 'Transpiling Java sources with JSweet'
-./gradlew core:jsweet -x compileJava && exit $?
+# banner 'Transpiling Java sources with JSweet'
+# ./gradlew core:jsweet -x compileJava && exit $?
 
-pushd client
+# pushd client
 
-source ./cheerpj.bash || exit $?
+# source ./cheerpj.bash || exit $?
 
 banner 'Preparing the distribution folder with NPM'
 npm install || exit $?

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
     "react-redux": "^7.2.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^3.4.1",
-    "react-vzome": "file:vzome-react-vzome-0.9.1.tgz",
+    "react-vzome": "^0.9.1",
     "redux": "^4.0.5",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",

--- a/client/public/natives/com/vzome/cheerpj/RemoteClientShim_native.js
+++ b/client/public/natives/com/vzome/cheerpj/RemoteClientShim_native.js
@@ -1,8 +1,0 @@
-
-function _CHEERPJ_COMPRESS(ZN3com5vzome7cheerpj16RemoteClientShim16sendToJavascriptEN4java4lang6StringEV)(a0,a1,p)
-{
-	/*instance*/
-	const jsString = cjStringJavaToJs( a1 );
-	console.log( jsString );
-	debugger
-}


### PR DESCRIPTION
The JSweet transpile must happen when the react-vzome component is built,
separately from building the app here.