### PR TITLE
Corrected two exceptions in static initializers

### DIFF
--- a/core/src/main/java/com/vzome/core/edits/ColorMappers.java
+++ b/core/src/main/java/com/vzome/core/edits/ColorMappers.java
@@ -18,14 +18,11 @@ public class ColorMappers {
             return false;
         }
 
-        public default String getName() {
-            Class<?> cls = getClass();
-            if(cls.isAnonymousClass()) {
-                throw new IllegalStateException("Anonymous implementations must override "
-                        + ColorMapper.class.getSimpleName()
-                        + ".getName() so that the result is not derived from the class name.");
-            }
-            return cls.getSimpleName();
-        }
+        /**
+         * We had a default implementation here, using reflection, but that gave me problems
+         * when transpiled to JavaScript with JSweet.  Now each class simply implements the method.
+         * @return
+         */
+        public String getName();
     }
 }

--- a/core/src/main/java/com/vzome/core/edits/ManifestationColorMappers.java
+++ b/core/src/main/java/com/vzome/core/edits/ManifestationColorMappers.java
@@ -155,7 +155,14 @@ public class ManifestationColorMappers {
     /**
      * returns current color
      */
-    public static class Identity extends ManifestationColorMapper {
+    public static class Identity extends ManifestationColorMapper
+    {
+        @Override
+        public String getName()
+        {
+            return "Identity";
+        }
+
         @Override
         protected Color applyTo(Manifestation rendered) {
             return rendered.getColor();
@@ -165,7 +172,14 @@ public class ManifestationColorMappers {
     /**
      * returns complementary color
      */
-    public static class ColorComplementor extends ManifestationColorMapper {
+    public static class ColorComplementor extends ManifestationColorMapper
+    {
+        @Override
+        public String getName()
+        {
+            return "ColorComplementor";
+        }
+
         @Override
         protected Color applyTo(Manifestation rendered) {
             return Color.getComplement(super.applyTo(rendered) );
@@ -175,7 +189,14 @@ public class ManifestationColorMappers {
     /**
      * returns inverted color
      */
-    public static class ColorInverter extends ManifestationColorMapper {
+    public static class ColorInverter extends ManifestationColorMapper
+    {
+        @Override
+        public String getName()
+        {
+            return "ColorInverter";
+        }
+
         @Override
         protected Color applyTo(Manifestation rendered) {
             return Color.getInverted( super.applyTo(rendered) );
@@ -185,7 +206,14 @@ public class ManifestationColorMappers {
     /**
      * returns maximized color
      */
-    public static class ColorMaximizer extends ManifestationColorMapper {
+    public static class ColorMaximizer extends ManifestationColorMapper
+    {
+        @Override
+        public String getName()
+        {
+            return "ColorMaximizer";
+        }
+
         @Override
         protected Color applyTo(Manifestation rendered) {
             return Color.getMaximum( super.applyTo(rendered) );
@@ -195,14 +223,28 @@ public class ManifestationColorMappers {
     /**
      * returns pastel of current color
      */
-    public static class ColorSoftener extends ManifestationColorMapper {
+    public static class ColorSoftener extends ManifestationColorMapper
+    {
+        @Override
+        public String getName()
+        {
+            return "ColorSoftener";
+        }
+
         @Override
         protected Color applyTo(Manifestation rendered) {
             return Color.getPastel( super.applyTo(rendered) );
         }
     }
 
-    public static class TransparencyMapper extends ManifestationColorMapper {
+    public static class TransparencyMapper extends ManifestationColorMapper
+    {
+        @Override
+        public String getName()
+        {
+            return "TransparencyMapper";
+        }
+
         private int alpha;
 
         public TransparencyMapper(int alpha) {
@@ -235,7 +277,14 @@ public class ManifestationColorMappers {
         }
     }
 
-    public static class CopyLastSelectedColor extends ManifestationColorMapper {
+    public static class CopyLastSelectedColor extends ManifestationColorMapper
+    {
+        @Override
+        public String getName()
+        {
+            return "CopyLastSelectedColor";
+        }
+
         private Color color;
 
         @Override
@@ -386,7 +435,14 @@ public class ManifestationColorMappers {
      * A position ranging from the origin to the fullScale vector position
      * adjusts the intensity of the current color from darkest to lightest.
      */
-    public static class DarkenNearOrigin extends ManifestationColorMapper {
+    public static class DarkenNearOrigin extends ManifestationColorMapper
+    {
+        @Override
+        public String getName()
+        {
+            return "DarkenNearOrigin";
+        }
+
         protected double offset = 0;
         protected double fullScaleSquared = 0L;
 
@@ -443,7 +499,14 @@ public class ManifestationColorMappers {
      * Same as {@code DarkenNearOrigin} except that
      * the color mapping is reversed from lightest to darkest
      */
-    public static class DarkenWithDistance extends DarkenNearOrigin {
+    public static class DarkenWithDistance extends DarkenNearOrigin
+    {
+        @Override
+        public String getName()
+        {
+            return "DarkenWithDistance";
+        }
+
         @Override
         public void initialize(ManifestationIterator manifestations) throws Failure {
             super.initialize(manifestations);
@@ -462,7 +525,14 @@ public class ManifestationColorMappers {
      *
      * Polarity info IS retained by this mapping.
      */
-    public static class RadialCentroidColorMap extends CentroidColorMapper {
+    public static class RadialCentroidColorMap extends CentroidColorMapper
+    {
+        @Override
+        public String getName()
+        {
+            return "RadialCentroidColorMap";
+        }
+
         @Override
         protected Color applyTo(AlgebraicVector centroid, int alpha) {
             return mapRadially(centroid, alpha);
@@ -473,7 +543,13 @@ public class ManifestationColorMappers {
      * Polarity info is retained by this mapping 
      * so that inverted struts and panels will be mapped to inverted colors.
      */
-    public static class RadialStandardBasisColorMap extends ManifestationSubclassColorMapper {
+    public static class RadialStandardBasisColorMap extends ManifestationSubclassColorMapper
+    {
+        @Override
+        public String getName()
+        {
+            return "RadialStandardBasisColorMap";
+        }
 
         @Override
         protected Color applyToBall(Connector ball, int alpha) {
@@ -499,7 +575,14 @@ public class ManifestationColorMappers {
      * Polarity info is intentionally removed by this mapping for struts and panels, but not balls
      * so that parallel struts and the panels normal to them will be the same color.
      */
-    public static class CanonicalOrientationColorMap extends RadialStandardBasisColorMap {
+    public static class CanonicalOrientationColorMap extends RadialStandardBasisColorMap
+    {
+        @Override
+        public String getName()
+        {
+            return "CanonicalOrientationColorMap";
+        }
+
 
         @Override
         protected Color applyToBall(Connector ball, int alpha) {
@@ -515,7 +598,14 @@ public class ManifestationColorMappers {
     /**
      * Polarity info is the ONLY basis for this mapping 
      */
-    public static class NormalPolarityColorMap extends RadialStandardBasisColorMap {
+    public static class NormalPolarityColorMap extends RadialStandardBasisColorMap
+    {
+        @Override
+        public String getName()
+        {
+            return "NormalPolarityColorMap";
+        }
+
         @Override
         protected Color applyTo(AlgebraicVector vector, int alpha) {
             return mapPolarity(vector, alpha);
@@ -527,7 +617,14 @@ public class ManifestationColorMappers {
      *
      * Polarity info IS retained by this mapping.
      */
-    public static class CentroidByOctantAndDirectionColorMap extends CentroidColorMapper {
+    public static class CentroidByOctantAndDirectionColorMap extends CentroidColorMapper
+    {
+        @Override
+        public String getName()
+        {
+            return "CentroidByOctantAndDirectionColorMap";
+        }
+
         @Override
         protected Color applyTo(AlgebraicVector vector, int alpha) {
             return Color.getMaximum( mapToOctant(vector, alpha, 0x00, 0x7F, 0xFF ) );
@@ -540,7 +637,14 @@ public class ManifestationColorMappers {
      *
      * Polarity info IS NOT retained by this mapping.
      */
-    public static class CoordinatePlaneColorMap extends CentroidColorMapper {
+    public static class CoordinatePlaneColorMap extends CentroidColorMapper
+    {
+        @Override
+        public String getName()
+        {
+            return "CoordinatePlaneColorMap";
+        }
+
         @Override
         protected Color applyTo(AlgebraicVector vector, int alpha) {
             return Color.getInverted( mapToOctant(vector, alpha, 0x00, 0xFF, 0x00) );
@@ -576,7 +680,13 @@ public class ManifestationColorMappers {
     /**
      * Gets standard color mapping from the OrbitSource
      */
-    public static class SystemColorMap extends ManifestationSubclassColorMapper {
+    public static class SystemColorMap extends ManifestationSubclassColorMapper
+    {
+        @Override
+        public String getName()
+        {
+            return "SystemColorMap";
+        }
 
         protected final OrbitSource symmetrySystem;
 
@@ -619,7 +729,13 @@ public class ManifestationColorMappers {
      * Maps standard SymmetrySystem colors 
      * to the Manifestation's Centroid instead of the normal vector
      */
-    public static class SystemCentroidColorMap extends CentroidColorMapper {
+    public static class SystemCentroidColorMap extends CentroidColorMapper
+    {
+        @Override
+        public String getName()
+        {
+            return "SystemCentroidColorMap";
+        }
 
         protected final OrbitSource symmetrySystem;
 
@@ -646,7 +762,14 @@ public class ManifestationColorMappers {
     /**
      * Gets standard color of the nearest special orbit using the standard color basis
      */
-    public static class NearestSpecialOrbitColorMap extends SystemColorMap {
+    public static class NearestSpecialOrbitColorMap extends SystemColorMap
+    {
+        @Override
+        public String getName()
+        {
+            return "NearestSpecialOrbitColorMap";
+        }
+
         protected Set<Direction> specialOrbits = new LinkedHashSet<>(); // maintains insert order.
 
         protected NearestSpecialOrbitColorMap(OrbitSource symm) {
@@ -685,7 +808,13 @@ public class ManifestationColorMappers {
     /**
      * Gets standard color of the nearest special orbit based on the Centroid
      */
-    public static class CentroidNearestSpecialOrbitColorMap extends NearestSpecialOrbitColorMap {
+    public static class CentroidNearestSpecialOrbitColorMap extends NearestSpecialOrbitColorMap
+    {
+        @Override
+        public String getName()
+        {
+            return "CentroidNearestSpecialOrbitColorMap";
+        }
 
         protected CentroidNearestSpecialOrbitColorMap(OrbitSource symm) {
             super(symm);
@@ -710,7 +839,14 @@ public class ManifestationColorMappers {
     /**
      * Gets standard color of the nearest predefined orbit using the symmetry's standard color scheme
      */
-    public static class NearestPredefinedOrbitColorMap extends NearestSpecialOrbitColorMap {
+    public static class NearestPredefinedOrbitColorMap extends NearestSpecialOrbitColorMap
+    {
+        @Override
+        public String getName()
+        {
+            return "NearestPredefinedOrbitColorMap";
+        }
+
         protected NearestPredefinedOrbitColorMap(OrbitSource symm) {
             super(symm);
             // setting specialOrbits to null will use the predefined orbits of the symmetery
@@ -721,7 +857,14 @@ public class ManifestationColorMappers {
     /**
      * Gets standard color of the nearest predefined orbit based on the centroid of each manifestation
      */
-    public static class CentroidNearestPredefinedOrbitColorMap extends CentroidNearestSpecialOrbitColorMap {
+    public static class CentroidNearestPredefinedOrbitColorMap extends CentroidNearestSpecialOrbitColorMap
+    {
+        @Override
+        public String getName()
+        {
+            return "CentroidNearestPredefinedOrbitColorMap";
+        }
+
         protected CentroidNearestPredefinedOrbitColorMap(OrbitSource symm) {
             super(symm);
             // setting specialOrbits to null will use the predefined orbits of the symmetery

--- a/core/src/main/java/com/vzome/core/viewing/ExportedVEFStrutGeometry.java
+++ b/core/src/main/java/com/vzome/core/viewing/ExportedVEFStrutGeometry.java
@@ -15,7 +15,7 @@ import com.vzome.core.parts.StrutGeometry;
 
 public class ExportedVEFStrutGeometry implements StrutGeometry
 {
-    private static final Logger LOGGER = Logger.getLogger( new Throwable().getStackTrace()[0].getClassName() );
+    private static final Logger LOGGER = Logger.getLogger( "com.vzome.core.viewing.ExportedVEFStrutGeometry" );
     
     @JsonProperty( "vertices" )
     public final List<AlgebraicVector> prototypeVertices;  // the polyhedron from which others are derived

--- a/react-library/src/jsweet/bundle.js
+++ b/react-library/src/jsweet/bundle.js
@@ -1,4 +1,3 @@
-
 import { java, javaemul } from './j4ts-2.0.0/bundle'
 
 
@@ -53,8 +52,8 @@ export var com;
                         return this.geometries;
                     }
                     /*private*/ getGeometry(name) {
-                        for (let index1017 = this.geometries.iterator(); index1017.hasNext();) {
-                            let shapes = index1017.next();
+                        for (let index569 = this.geometries.iterator(); index569.hasNext();) {
+                            let shapes = index569.next();
                             {
                                 if ( /* equals */((o1, o2) => { if (o1 && o1.equals) {
                                     return o1.equals(o2);
@@ -333,8 +332,8 @@ export var com;
                     ;
                     addColor(name, color) {
                         this.mColors.put(name, color);
-                        for (let index1018 = this.mListeners.iterator(); index1018.hasNext();) {
-                            let next = index1018.next();
+                        for (let index570 = this.mListeners.iterator(); index570.hasNext();) {
+                            let next = index570.next();
                             {
                                 next.colorAdded(name, color);
                             }
@@ -342,8 +341,8 @@ export var com;
                     }
                     setColor(name, color) {
                         this.mColors.put(name, color);
-                        for (let index1019 = this.mListeners.iterator(); index1019.hasNext();) {
-                            let next = index1019.next();
+                        for (let index571 = this.mListeners.iterator(); index571.hasNext();) {
+                            let next = index571.next();
                             {
                                 next.colorChanged(name, color);
                             }
@@ -621,7 +620,10 @@ export var com;
                         return this.mOrientation;
                     }
                     getLocation() {
-                        return this.getEmbedding().embedInR3(this.location);
+                        if (this.location != null)
+                            return this.getEmbedding().embedInR3(this.location);
+                        else
+                            return new com.vzome.core.math.RealVector(0.0, 0.0, 0.0);
                     }
                     getLocationAV() {
                         return this.location;
@@ -850,8 +852,8 @@ export var com;
                         let poly = new com.vzome.core.math.Polyhedron(panel.getZoneVector().getField());
                         poly.setPanel(true);
                         let arity = 0;
-                        for (let index1020 = panel.iterator(); index1020.hasNext();) {
-                            let gv = index1020.next();
+                        for (let index572 = panel.iterator(); index572.hasNext();) {
+                            let gv = index572.next();
                             {
                                 arity++;
                                 poly.addVertex(gv);
@@ -1104,7 +1106,7 @@ export var com;
                             throw new Error('invalid overload');
                     }
                     static LOGGER_$LI$() { if (ExportedVEFStrutGeometry.LOGGER == null)
-                        ExportedVEFStrutGeometry.LOGGER = java.util.logging.Logger.getLogger(new Error().getStackTrace()[0].getClassName()); return ExportedVEFStrutGeometry.LOGGER; }
+                        ExportedVEFStrutGeometry.LOGGER = java.util.logging.Logger.getLogger("com.vzome.core.viewing.ExportedVEFStrutGeometry"); return ExportedVEFStrutGeometry.LOGGER; }
                     ;
                     /**
                      *
@@ -1138,8 +1140,8 @@ export var com;
                             }
                             ;
                         }
-                        for (let index1021 = this.prototypeFaces.iterator(); index1021.hasNext();) {
-                            let prototypeFace = index1021.next();
+                        for (let index573 = this.prototypeFaces.iterator(); index573.hasNext();) {
+                            let prototypeFace = index573.next();
                             {
                                 let face = result.newFace();
                                 face.addAll(prototypeFace);
@@ -1192,8 +1194,8 @@ export var com;
                     projectImage(source, wFirst) {
                         let result = this.field.origin(this.basis[0].dimension());
                         let pos = wFirst ? 0 : this.basis.length - 1;
-                        for (let index1022 = 0; index1022 < this.basis.length; index1022++) {
-                            let unitVector = this.basis[index1022];
+                        for (let index574 = 0; index574 < this.basis.length; index574++) {
+                            let unitVector = this.basis[index574];
                             {
                                 let scalar = source.getComponent(pos);
                                 result = result.plus(unitVector.scale(scalar));
@@ -1291,15 +1293,15 @@ export var com;
                             ;
                             this.evilTwin.isEvil = true;
                             this.evilTwin.m_vertexList = (new java.util.ArrayList());
-                            for (let index1023 = this.m_vertexList.iterator(); index1023.hasNext();) {
-                                let vertex = index1023.next();
+                            for (let index575 = this.m_vertexList.iterator(); index575.hasNext();) {
+                                let vertex = index575.next();
                                 {
                                     this.evilTwin.addVertex(reflection.timesColumn(vertex));
                                 }
                             }
                             this.evilTwin.m_faces = (new java.util.HashSet());
-                            for (let index1024 = this.m_faces.iterator(); index1024.hasNext();) {
-                                let face = index1024.next();
+                            for (let index576 = this.m_faces.iterator(); index576.hasNext();) {
+                                let face = index576.next();
                                 {
                                     let mirrorFace = ((o) => { if (o.clone != undefined) {
                                         return o.clone();
@@ -1493,8 +1495,8 @@ export var com;
                     }
                     getTriangleFaces() {
                         let result = (new java.util.ArrayList());
-                        for (let index1025 = this.m_faces.iterator(); index1025.hasNext();) {
-                            let face = index1025.next();
+                        for (let index577 = this.m_faces.iterator(); index577.hasNext();) {
+                            let face = index577.next();
                             {
                                 result.addAll(face.getTriangles());
                             }
@@ -1504,11 +1506,11 @@ export var com;
                     getTriangles() {
                         let index = 0;
                         let result = (new java.util.ArrayList());
-                        for (let index1026 = this.m_faces.iterator(); index1026.hasNext();) {
-                            let face = index1026.next();
+                        for (let index578 = this.m_faces.iterator(); index578.hasNext();) {
+                            let face = index578.next();
                             {
-                                for (let index1027 = face.getTriangles().iterator(); index1027.hasNext();) {
-                                    let triangle = index1027.next();
+                                for (let index579 = face.getTriangles().iterator(); index579.hasNext();) {
+                                    let triangle = index579.next();
                                     {
                                         result.add(index++);
                                         result.add(index++);
@@ -1521,14 +1523,14 @@ export var com;
                     }
                     getTriangleVertices() {
                         let result = (new java.util.ArrayList());
-                        for (let index1028 = this.m_faces.iterator(); index1028.hasNext();) {
-                            let face = index1028.next();
+                        for (let index580 = this.m_faces.iterator(); index580.hasNext();) {
+                            let face = index580.next();
                             {
-                                for (let index1029 = face.getTriangles().iterator(); index1029.hasNext();) {
-                                    let triangle = index1029.next();
+                                for (let index581 = face.getTriangles().iterator(); index581.hasNext();) {
+                                    let triangle = index581.next();
                                     {
-                                        for (let index1030 = 0; index1030 < triangle.vertices.length; index1030++) {
-                                            let index = triangle.vertices[index1030];
+                                        for (let index582 = 0; index582 < triangle.vertices.length; index582++) {
+                                            let index = triangle.vertices[index582];
                                             {
                                                 let vertex = this.m_vertexList.get(index);
                                                 result.add(vertex.toRealVector());
@@ -1756,8 +1758,8 @@ export var com;
                             let vertices3d = (s => { let a = []; while (s-- > 0)
                                 a.push(null); return a; })(stack2d.size());
                             let i = 0;
-                            for (let index1031 = stack2d.iterator(); index1031.hasNext();) {
-                                let point2d = index1031.next();
+                            for (let index583 = stack2d.iterator(); index583.hasNext();) {
+                                let point2d = index583.next();
                                 {
                                     let point3d = xyTo3dMap.get(point2d.toString(com.vzome.core.algebra.AlgebraicField.VEF_FORMAT));
                                     vertices3d[i++] = point3d;
@@ -1770,8 +1772,8 @@ export var com;
                             let mapX = (maxAxis + 1) % 3;
                             let mapY = (maxAxis + 2) % 3;
                             let map = (new java.util.HashMap());
-                            for (let index1032 = points3d.iterator(); index1032.hasNext();) {
-                                let point3d = index1032.next();
+                            for (let index584 = points3d.iterator(); index584.hasNext();) {
+                                let point3d = index584.next();
                                 {
                                     let point2d = new com.vzome.core.algebra.AlgebraicVector(point3d.getComponent(mapX), point3d.getComponent(mapY));
                                     keySet.add(point2d);
@@ -1848,8 +1850,8 @@ export var com;
                          */
                         static getLowest2dPoint(points2d) {
                             let lowest = null;
-                            for (let index1033 = points2d.iterator(); index1033.hasNext();) {
-                                let point2d = index1033.next();
+                            for (let index585 = points2d.iterator(); index585.hasNext();) {
+                                let point2d = index585.next();
                                 {
                                     if (lowest == null) {
                                         lowest = point2d;
@@ -2450,8 +2452,8 @@ export var com;
                             }
                         }
                         /*private*/ findHalfEdge(tail, head) {
-                            for (let index1034 = this.faces.iterator(); index1034.hasNext();) {
-                                let face = index1034.next();
+                            for (let index586 = this.faces.iterator(); index586.hasNext();) {
+                                let face = index586.next();
                                 {
                                     let he = face.findEdge(tail, head);
                                     if (he != null) {
@@ -2554,16 +2556,16 @@ export var com;
                          */
                         triangulate() {
                             this.newFaces.clear();
-                            for (let index1035 = this.faces.iterator(); index1035.hasNext();) {
-                                let face = index1035.next();
+                            for (let index587 = this.faces.iterator(); index587.hasNext();) {
+                                let face = index587.next();
                                 {
                                     if (face.mark === com.vzome.core.math.convexhull.Face.VISIBLE) {
                                         face.triangulate(this.newFaces);
                                     }
                                 }
                             }
-                            for (let index1036 = this.newFaces.iterator(); index1036.hasNext();) {
-                                let face = index1036.next();
+                            for (let index588 = this.newFaces.iterator(); index588.hasNext();) {
+                                let face = index588.next();
                                 {
                                     this.faces.add(face);
                                 }
@@ -2853,8 +2855,8 @@ export var com;
                          */
                         getNumEdges() {
                             let count = 0;
-                            for (let index1037 = this.faces.iterator(); index1037.hasNext();) {
-                                let face = index1037.next();
+                            for (let index589 = this.faces.iterator(); index589.hasNext();) {
+                                let face = index589.next();
                                 {
                                     count += face.numVertices();
                                 }
@@ -2876,8 +2878,8 @@ export var com;
                             let allFaces = (s => { let a = []; while (s-- > 0)
                                 a.push(null); return a; })(this.faces.size());
                             let k = 0;
-                            for (let index1038 = this.faces.iterator(); index1038.hasNext();) {
-                                let face = index1038.next();
+                            for (let index590 = this.faces.iterator(); index590.hasNext();) {
+                                let face = index590.next();
                                 {
                                     allFaces[k] = (s => { let a = []; while (s-- > 0)
                                         a.push(0); return a; })(face.numVertices());
@@ -2927,8 +2929,8 @@ export var com;
                                 }
                                 ;
                             }
-                            for (let index1039 = this.faces.iterator(); index1039.hasNext();) {
-                                let face = index1039.next();
+                            for (let index591 = this.faces.iterator(); index591.hasNext();) {
+                                let face = index591.next();
                                 {
                                     let indices = (s => { let a = []; while (s-- > 0)
                                         a.push(0); return a; })(face.numVertices());
@@ -3003,8 +3005,8 @@ export var com;
                                     vtxNext = vtx.next;
                                     let maxDist = 0;
                                     let maxFace = null;
-                                    for (let index1040 = newFaces.iterator(); index1040.hasNext();) {
-                                        let newFace = index1040.next();
+                                    for (let index592 = newFaces.iterator(); index592.hasNext();) {
+                                        let newFace = index592.next();
                                         {
                                             if (newFace.mark === com.vzome.core.math.convexhull.Face.VISIBLE) {
                                                 let dist = newFace.distanceToPlane(vtx.pnt).evaluate();
@@ -3158,8 +3160,8 @@ export var com;
                             newFaces.clear();
                             let hedgeSidePrev = null;
                             let hedgeSideBegin = null;
-                            for (let index1041 = horizon.iterator(); index1041.hasNext();) {
-                                let horizonHe = index1041.next();
+                            for (let index593 = horizon.iterator(); index593.hasNext();) {
+                                let horizonHe = index593.next();
                                 {
                                     let hedgeSide = this.addAdjoiningFace(eyeVtx, horizonHe);
                                     if (this.debug) {
@@ -3209,8 +3211,8 @@ export var com;
                             this.calculateHorizon(eyeVtx.pnt, null, eyeVtx.face, horizon);
                             this.newFaces.clear();
                             this.addNewFaces(this.newFaces, eyeVtx, horizon);
-                            for (let index1042 = this.newFaces.iterator(); index1042.hasNext();) {
-                                let face = index1042.next();
+                            for (let index594 = this.newFaces.iterator(); index594.hasNext();) {
+                                let face = index594.next();
                                 {
                                     if (face.mark === com.vzome.core.math.convexhull.Face.VISIBLE) {
                                         while ((this.doAdjacentMerge(face, QuickHull3D.NONCONVEX_WRT_LARGER_FACE))) { }
@@ -3218,8 +3220,8 @@ export var com;
                                     }
                                 }
                             }
-                            for (let index1043 = this.newFaces.iterator(); index1043.hasNext();) {
-                                let face = index1043.next();
+                            for (let index595 = this.newFaces.iterator(); index595.hasNext();) {
+                                let face = index595.next();
                                 {
                                     if (face.mark === com.vzome.core.math.convexhull.Face.NON_CONVEX) {
                                         face.mark = com.vzome.core.math.convexhull.Face.VISIBLE;
@@ -3325,8 +3327,8 @@ export var com;
                         }
                         checkFaces(ps) {
                             let convex = true;
-                            for (let index1044 = this.faces.iterator(); index1044.hasNext();) {
-                                let face = index1044.next();
+                            for (let index596 = this.faces.iterator(); index596.hasNext();) {
+                                let face = index596.next();
                                 {
                                     if (face.mark === com.vzome.core.math.convexhull.Face.VISIBLE) {
                                         if (!this.checkFaceConvexity(face, ps)) {
@@ -3364,8 +3366,8 @@ export var com;
                             for (let i = 0; i < this.numPoints; i++) {
                                 {
                                     let pnt = this.pointBuffer[i].pnt;
-                                    for (let index1045 = this.faces.iterator(); index1045.hasNext();) {
-                                        let face = index1045.next();
+                                    for (let index597 = this.faces.iterator(); index597.hasNext();) {
+                                        let face = index597.next();
                                         {
                                             if (face.mark === com.vzome.core.math.convexhull.Face.VISIBLE) {
                                                 let dist = face.distanceToPlane(pnt);
@@ -3792,8 +3794,8 @@ export var com;
                     projectImage(source, wFirst) {
                         let result = this.field.origin(this.basis[0].dimension());
                         let pos = wFirst ? 0 : this.basis.length - 1;
-                        for (let index1046 = 0; index1046 < this.basis.length; index1046++) {
-                            let unitVector = this.basis[index1046];
+                        for (let index598 = 0; index598 < this.basis.length; index598++) {
+                            let unitVector = this.basis[index598];
                             {
                                 let scalar = source.getComponent(pos);
                                 result = result.plus(unitVector.scale(scalar));
@@ -5111,8 +5113,8 @@ export var com;
                             }
                             let canonicalOrbit = this.getSpecialOrbit(symmetry.Symmetry.SpecialOrbit.BLACK);
                             if (canonicalOrbit == null)
-                                for (let index1047 = orbits.iterator(); index1047.hasNext();) {
-                                    let dir = index1047.next();
+                                for (let index599 = orbits.iterator(); index599.hasNext();) {
+                                    let dir = index599.next();
                                     {
                                         let candidate = dir.getAxis$com_vzome_core_algebra_AlgebraicVector(vector);
                                         if (candidate != null) {
@@ -5124,8 +5126,8 @@ export var com;
                                 let zone = canonicalOrbit.getAxis$com_vzome_core_math_RealVector(vector.toRealVector());
                                 let orientation = zone.getOrientation();
                                 let sense = zone.getSense();
-                                for (let index1048 = orbits.iterator(); index1048.hasNext();) {
-                                    let orbit = index1048.next();
+                                for (let index600 = orbits.iterator(); index600.hasNext();) {
+                                    let orbit = index600.next();
                                     {
                                         let candidate = orbit.getCanonicalAxis(sense, orientation);
                                         if (com.vzome.core.algebra.AlgebraicVectors.areParallel(candidate.normal(), vector)) {
@@ -5240,8 +5242,8 @@ export var com;
                          */
                         getDirectionNames() {
                             let list = (new java.util.ArrayList());
-                            for (let index1049 = this.mDirectionList.iterator(); index1049.hasNext();) {
-                                let dir = index1049.next();
+                            for (let index601 = this.mDirectionList.iterator(); index601.hasNext();) {
+                                let dir = index601.next();
                                 {
                                     if (!dir.isAutomatic())
                                         list.add(dir.getName());
@@ -5271,8 +5273,8 @@ export var com;
                             while ((!newPerms.isEmpty())) {
                                 {
                                     let perm = newPerms.remove(0);
-                                    for (let index1050 = 0; index1050 < knownPerms.length; index1050++) {
-                                        let knownPerm = knownPerms[index1050];
+                                    for (let index602 = 0; index602 < knownPerms.length; index602++) {
+                                        let knownPerm = knownPerms[index602];
                                         {
                                             if (knownPerm != null) {
                                                 let composition = perm.compose(knownPerm);
@@ -5350,8 +5352,8 @@ export var com;
                          */
                         computeOrbitDots() {
                             this.dotLocator = new com.vzome.core.math.symmetry.OrbitDotLocator(this, this.getOrbitTriangle());
-                            for (let index1051 = this.mDirectionList.iterator(); index1051.hasNext();) {
-                                let orbit = index1051.next();
+                            for (let index603 = this.mDirectionList.iterator(); index603.hasNext();) {
+                                let orbit = index603.next();
                                 {
                                     this.dotLocator.locateOrbitDot(orbit);
                                 }
@@ -5448,8 +5450,8 @@ export var com;
                             return this.symmetry['getAxis$com_vzome_core_math_RealVector$java_util_Set'](vector, this);
                         }
                         getDirection(name) {
-                            for (let index1052 = this.iterator(); index1052.hasNext();) {
-                                let dir = index1052.next();
+                            for (let index604 = this.iterator(); index604.hasNext();) {
+                                let dir = index604.next();
                                 {
                                     if ( /* equals */((o1, o2) => { if (o1 && o1.equals) {
                                         return o1.equals(o2);
@@ -5541,8 +5543,8 @@ export var com;
                             return naming.getAxis(name);
                         }
                         getName(axis) {
-                            for (let index1053 = this.mNamings.values().iterator(); index1053.hasNext();) {
-                                let naming = index1053.next();
+                            for (let index605 = this.mNamings.values().iterator(); index605.hasNext();) {
+                                let naming = index605.next();
                                 {
                                     if (naming.getDirection().equals(axis.getDirection()))
                                         return naming.getName$com_vzome_core_math_symmetry_Axis(axis);
@@ -5790,8 +5792,8 @@ export var com;
                             return this.mName;
                         }
                         getAxis$com_vzome_core_algebra_AlgebraicVector(vector) {
-                            for (let index1054 = this.zoneVectors.values().iterator(); index1054.hasNext();) {
-                                let axis = index1054.next();
+                            for (let index606 = this.zoneVectors.values().iterator(); index606.hasNext();) {
+                                let axis = index606.next();
                                 {
                                     let normal = axis.normal();
                                     if (com.vzome.core.algebra.AlgebraicVectors.areParallel(normal, vector)) {
@@ -5844,8 +5846,8 @@ export var com;
                                         break;
                                     }
                                     let reverseSense = (closestSense + 1) % 2;
-                                    for (let index1055 = 0; index1055 < incidentOrientations.length; index1055++) {
-                                        let i = incidentOrientations[index1055];
+                                    for (let index607 = 0; index607 < incidentOrientations.length; index607++) {
+                                        let i = incidentOrientations[index607];
                                         {
                                             let neighbor = this.getCanonicalAxis(reverseSense, i);
                                             if (checked.contains(neighbor))
@@ -5872,8 +5874,8 @@ export var com;
                         getAxisBruteForce(vector) {
                             let closestAxis = null;
                             let maxCosine = -1.0;
-                            for (let index1056 = this.iterator(); index1056.hasNext();) {
-                                let axis = index1056.next();
+                            for (let index608 = this.iterator(); index608.hasNext();) {
+                                let axis = index608.next();
                                 {
                                     let axisV = axis.normal().toRealVector();
                                     let cosine = vector.dot(axisV) / (vector.length() * axisV.length());
@@ -6976,8 +6978,8 @@ export var com;
                         let panels = (new java.util.ArrayList());
                         let lastBall = null;
                         let lastVertex = null;
-                        for (let index1057 = model.iterator(); index1057.hasNext();) {
-                            let man = index1057.next();
+                        for (let index609 = model.iterator(); index609.hasNext();) {
+                            let man = index609.next();
                             {
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0)) {
                                     lastBall = man.getLocation();
@@ -6989,8 +6991,8 @@ export var com;
                                     vertices.add(man.getEnd());
                                 }
                                 else if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Panel") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Panel") >= 0)) {
-                                    for (let index1058 = man.iterator(); index1058.hasNext();) {
-                                        let vertex = index1058.next();
+                                    for (let index610 = man.iterator(); index610.hasNext();) {
+                                        let vertex = index610.next();
                                         {
                                             lastVertex = vertex;
                                             vertices.add(vertex);
@@ -7003,8 +7005,8 @@ export var com;
                         let sortedVertexList = (new java.util.ArrayList(vertices));
                         vertices = null;
                         let mapper = new com.fasterxml.jackson.databind.ObjectMapper();
-                        for (let index1059 = model.iterator(); index1059.hasNext();) {
-                            let man = index1059.next();
+                        for (let index611 = model.iterator(); index611.hasNext();) {
+                            let man = index611.next();
                             {
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0)) {
                                     let ballJson = mapper.createObjectNode();
@@ -7042,8 +7044,8 @@ export var com;
                         generator.writeFieldName("vertices");
                         generator.writeStartArray();
                         let objectWriter = mapper.writerWithView("com.vzome.core.algebra.AlgebraicNumber.Views.TrailingDivisor");
-                        for (let index1060 = sortedVertexList.iterator(); index1060.hasNext();) {
-                            let algebraicVector = index1060.next();
+                        for (let index612 = sortedVertexList.iterator(); index612.hasNext();) {
+                            let algebraicVector = index612.next();
                             {
                                 algebraicVector = algebraicVector.minus(origin);
                                 generator.writeObject(mapper.readTree(objectWriter.writeValueAsString(algebraicVector)));
@@ -7070,15 +7072,15 @@ export var com;
                         let vertices = (new java.util.ArrayList());
                         {
                             let verticesNode = node.get("vertices");
-                            for (let index1061 = verticesNode.iterator(); index1061.hasNext();) {
-                                let vectorNode = index1061.next();
+                            for (let index613 = verticesNode.iterator(); index613.hasNext();) {
+                                let vectorNode = index613.next();
                                 {
                                     let dimension = vectorNode.size();
                                     let nums = (s => { let a = []; while (s-- > 0)
                                         a.push(null); return a; })(dimension);
                                     let i = 0;
-                                    for (let index1062 = vectorNode.iterator(); index1062.hasNext();) {
-                                        let numberNode = index1062.next();
+                                    for (let index614 = vectorNode.iterator(); index614.hasNext();) {
+                                        let numberNode = index614.next();
                                         {
                                             nums[i++] = (mapper.treeToValue(numberNode, [].constructor));
                                         }
@@ -7102,8 +7104,8 @@ export var com;
                                 })(vertices));
                             }
                             catch (e) {
-                                for (let index1063 = collection.iterator(); index1063.hasNext();) {
-                                    let ballNode = index1063.next();
+                                for (let index615 = collection.iterator(); index615.hasNext();) {
+                                    let ballNode = index615.next();
                                     {
                                         let vertexNode = ballNode.get("vertex");
                                         let i = vertexNode.asInt();
@@ -7117,8 +7119,8 @@ export var com;
                         }
                         collection = node.get("struts");
                         if (collection != null) {
-                            for (let index1064 = collection.iterator(); index1064.hasNext();) {
-                                let strutNode = index1064.next();
+                            for (let index616 = collection.iterator(); index616.hasNext();) {
+                                let strutNode = index616.next();
                                 {
                                     if (strutNode.has("start")) {
                                         let start = (mapper.treeToValue(strutNode.get("start"), Number));
@@ -7141,8 +7143,8 @@ export var com;
                         }
                         collection = node.get("panels");
                         if (collection != null) {
-                            for (let index1065 = collection.iterator(); index1065.hasNext();) {
-                                let panelNode = index1065.next();
+                            for (let index617 = collection.iterator(); index617.hasNext();) {
+                                let panelNode = index617.next();
                                 {
                                     let verticesNode = panelNode.get("vertices");
                                     let indices = (mapper.treeToValue(verticesNode, [].constructor));
@@ -7210,8 +7212,8 @@ export var com;
                         let faceNodes = (new java.util.ArrayList());
                         let lastBall = null;
                         let lastVertex = null;
-                        for (let index1066 = model.iterator(); index1066.hasNext();) {
-                            let man = index1066.next();
+                        for (let index618 = model.iterator(); index618.hasNext();) {
+                            let man = index618.next();
                             {
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0)) {
                                     lastBall = man.getLocation();
@@ -7223,8 +7225,8 @@ export var com;
                                     vertices.add(man.getEnd());
                                 }
                                 else if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Panel") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Panel") >= 0)) {
-                                    for (let index1067 = man.iterator(); index1067.hasNext();) {
-                                        let vertex = index1067.next();
+                                    for (let index619 = man.iterator(); index619.hasNext();) {
+                                        let vertex = index619.next();
                                         {
                                             lastVertex = vertex;
                                             vertices.add(vertex);
@@ -7237,8 +7239,8 @@ export var com;
                         let sortedVertexList = (new java.util.ArrayList(vertices));
                         vertices = null;
                         let mapper = new com.fasterxml.jackson.databind.ObjectMapper();
-                        for (let index1068 = model.iterator(); index1068.hasNext();) {
-                            let man = index1068.next();
+                        for (let index620 = model.iterator(); index620.hasNext();) {
+                            let man = index620.next();
                             {
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0)) {
                                     vertexIndices.add(sortedVertexList.indexOf(man.getLocation()));
@@ -7267,8 +7269,8 @@ export var com;
                         generator.writeFieldName("vertices");
                         generator.writeStartArray();
                         let objectWriter = mapper.writerWithView("com.vzome.core.algebra.AlgebraicNumber.Views.TrailingDivisor");
-                        for (let index1069 = sortedVertexList.iterator(); index1069.hasNext();) {
-                            let algebraicVector = index1069.next();
+                        for (let index621 = sortedVertexList.iterator(); index621.hasNext();) {
+                            let algebraicVector = index621.next();
                             {
                                 algebraicVector = algebraicVector.minus(origin);
                                 generator.writeObject(mapper.readTree(objectWriter.writeValueAsString(algebraicVector)));
@@ -7297,15 +7299,15 @@ export var com;
                         let vertices = (new java.util.ArrayList());
                         {
                             let verticesNode = node.get("vertices");
-                            for (let index1070 = verticesNode.iterator(); index1070.hasNext();) {
-                                let vectorNode = index1070.next();
+                            for (let index622 = verticesNode.iterator(); index622.hasNext();) {
+                                let vectorNode = index622.next();
                                 {
                                     let dimension = vectorNode.size();
                                     let nums = (s => { let a = []; while (s-- > 0)
                                         a.push(null); return a; })(dimension);
                                     let i = 0;
-                                    for (let index1071 = vectorNode.iterator(); index1071.hasNext();) {
-                                        let numberNode = index1071.next();
+                                    for (let index623 = vectorNode.iterator(); index623.hasNext();) {
+                                        let numberNode = index623.next();
                                         {
                                             nums[i++] = (mapper.treeToValue(numberNode, [].constructor));
                                         }
@@ -7321,8 +7323,8 @@ export var com;
                         }
                         ;
                         let collection = node.get("edges");
-                        for (let index1072 = collection.iterator(); index1072.hasNext();) {
-                            let strutNode = index1072.next();
+                        for (let index624 = collection.iterator(); index624.hasNext();) {
+                            let strutNode = index624.next();
                             {
                                 let ends = (mapper.treeToValue(strutNode, [].constructor));
                                 let p1 = new com.vzome.core.construction.FreePoint(vertices.get(ends[0]));
@@ -7333,8 +7335,8 @@ export var com;
                             }
                         }
                         collection = node.get("faces");
-                        for (let index1073 = collection.iterator(); index1073.hasNext();) {
-                            let panelNode = index1073.next();
+                        for (let index625 = collection.iterator(); index625.hasNext();) {
+                            let panelNode = index625.next();
                             {
                                 let indices = (mapper.treeToValue(panelNode, [].constructor));
                                 let points = (java.util.Arrays.stream(indices).mapToObj(((vertices) => {
@@ -8859,8 +8861,8 @@ export var com;
                     getXml(result, attributes) {
                         if (attributes == null)
                             return;
-                        for (let index1074 = attributes.keySet().iterator(); index1074.hasNext();) {
-                            let key = index1074.next();
+                        for (let index626 = attributes.keySet().iterator(); index626.hasNext();) {
+                            let key = index626.next();
                             {
                                 if ( /* equals */((o1, o2) => { if (o1 && o1.equals) {
                                     return o1.equals(o2);
@@ -9272,14 +9274,6 @@ export var com;
                         requiresOrderedSelection() {
                             return false;
                         }
-                        /* Default method injected from com.vzome.core.edits.ColorMappers.ColorMapper */
-                        getName() {
-                            let cls = this.constructor;
-                            if (cls.isAnonymousClass()) {
-                                throw new java.lang.IllegalStateException("Anonymous implementations must override " + /* getSimpleName */ (c => c["__class"] ? c["__class"].substring(c["__class"].lastIndexOf('.') + 1) : c["name"].substring(c["name"].lastIndexOf('.') + 1))("com.vzome.core.edits.ColorMappers.ColorMapper") + ".getName() so that the result is not derived from the class name.");
-                            }
-                            return /* getSimpleName */ (c => c["__class"] ? c["__class"].substring(c["__class"].lastIndexOf('.') + 1) : c["name"].substring(c["name"].lastIndexOf('.') + 1))(cls);
-                        }
                         constructor() {
                         }
                         /**
@@ -9338,6 +9332,13 @@ export var com;
                     class Identity extends ManifestationColorMappers.ManifestationColorMapper {
                         /**
                          *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "Identity";
+                        }
+                        /**
+                         *
                          * @param {*} rendered
                          * @return {com.vzome.core.construction.Color}
                          */
@@ -9357,6 +9358,13 @@ export var com;
                      * @extends com.vzome.core.edits.ManifestationColorMappers.ManifestationColorMapper
                      */
                     class ColorComplementor extends ManifestationColorMappers.ManifestationColorMapper {
+                        /**
+                         *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "ColorComplementor";
+                        }
                         /**
                          *
                          * @param {*} rendered
@@ -9380,6 +9388,13 @@ export var com;
                     class ColorInverter extends ManifestationColorMappers.ManifestationColorMapper {
                         /**
                          *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "ColorInverter";
+                        }
+                        /**
+                         *
                          * @param {*} rendered
                          * @return {com.vzome.core.construction.Color}
                          */
@@ -9399,6 +9414,13 @@ export var com;
                      * @extends com.vzome.core.edits.ManifestationColorMappers.ManifestationColorMapper
                      */
                     class ColorMaximizer extends ManifestationColorMappers.ManifestationColorMapper {
+                        /**
+                         *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "ColorMaximizer";
+                        }
                         /**
                          *
                          * @param {*} rendered
@@ -9422,6 +9444,13 @@ export var com;
                     class ColorSoftener extends ManifestationColorMappers.ManifestationColorMapper {
                         /**
                          *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "ColorSoftener";
+                        }
+                        /**
+                         *
                          * @param {*} rendered
                          * @return {com.vzome.core.construction.Color}
                          */
@@ -9441,6 +9470,13 @@ export var com;
                             if (this.alpha === undefined)
                                 this.alpha = 0;
                             this.setAlpha(alpha);
+                        }
+                        /**
+                         *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "TransparencyMapper";
                         }
                         setAlpha(value) {
                             this.alpha = Math.min(255, Math.max(1, value));
@@ -9481,6 +9517,13 @@ export var com;
                         }
                         /**
                          *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "CopyLastSelectedColor";
+                        }
+                        /**
+                         *
                          * @return {boolean}
                          */
                         requiresOrderedSelection() {
@@ -9493,8 +9536,8 @@ export var com;
                         initialize(selection) {
                             if (this.color == null) {
                                 let last = null;
-                                for (let index1075 = selection.iterator(); index1075.hasNext();) {
-                                    let man = index1075.next();
+                                for (let index627 = selection.iterator(); index627.hasNext();) {
+                                    let man = index627.next();
                                     {
                                         if (man != null && man.isRendered()) {
                                             last = man;
@@ -9591,6 +9634,13 @@ export var com;
                         }
                         /**
                          *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "DarkenNearOrigin";
+                        }
+                        /**
+                         *
                          * @param {com.vzome.core.editor.api.Manifestations.ManifestationIterator} manifestations
                          */
                         initialize(manifestations) {
@@ -9607,8 +9657,8 @@ export var com;
                         }
                         static getMostDistantPoint(manifestations) {
                             let centroids = (new java.util.ArrayList());
-                            for (let index1076 = manifestations.iterator(); index1076.hasNext();) {
-                                let man = index1076.next();
+                            for (let index628 = manifestations.iterator(); index628.hasNext();) {
+                                let man = index628.next();
                                 {
                                     centroids.add(man.getCentroid());
                                 }
@@ -9694,6 +9744,13 @@ export var com;
                      * @extends com.vzome.core.edits.ManifestationColorMappers.CentroidColorMapper
                      */
                     class RadialCentroidColorMap extends ManifestationColorMappers.CentroidColorMapper {
+                        /**
+                         *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "RadialCentroidColorMap";
+                        }
                         applyTo$com_vzome_core_algebra_AlgebraicVector$int(centroid, alpha) {
                             return ManifestationColorMappers.mapRadially(centroid, alpha);
                         }
@@ -9728,6 +9785,13 @@ export var com;
                      * @extends com.vzome.core.edits.ManifestationColorMappers.CentroidColorMapper
                      */
                     class CentroidByOctantAndDirectionColorMap extends ManifestationColorMappers.CentroidColorMapper {
+                        /**
+                         *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "CentroidByOctantAndDirectionColorMap";
+                        }
                         applyTo$com_vzome_core_algebra_AlgebraicVector$int(vector, alpha) {
                             return com.vzome.core.construction.Color.getMaximum(ManifestationColorMappers.mapToOctant(vector, alpha, 0, 127, 255));
                         }
@@ -9763,6 +9827,13 @@ export var com;
                      * @extends com.vzome.core.edits.ManifestationColorMappers.CentroidColorMapper
                      */
                     class CoordinatePlaneColorMap extends ManifestationColorMappers.CentroidColorMapper {
+                        /**
+                         *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "CoordinatePlaneColorMap";
+                        }
                         applyTo$com_vzome_core_algebra_AlgebraicVector$int(vector, alpha) {
                             return com.vzome.core.construction.Color.getInverted(ManifestationColorMappers.mapToOctant(vector, alpha, 0, 255, 0));
                         }
@@ -9801,6 +9872,13 @@ export var com;
                             if (this.symmetrySystem === undefined)
                                 this.symmetrySystem = null;
                             this.symmetrySystem = symmetry;
+                        }
+                        /**
+                         *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "SystemCentroidColorMap";
                         }
                         applyTo$com_vzome_core_algebra_AlgebraicVector$int(centroid, alpha) {
                             return this.symmetrySystem.getVectorColor(centroid);
@@ -9843,6 +9921,13 @@ export var com;
                     class DarkenWithDistance extends ManifestationColorMappers.DarkenNearOrigin {
                         /**
                          *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "DarkenWithDistance";
+                        }
+                        /**
+                         *
                          * @param {com.vzome.core.editor.api.Manifestations.ManifestationIterator} manifestations
                          */
                         initialize(manifestations) {
@@ -9863,6 +9948,13 @@ export var com;
                      * @extends com.vzome.core.edits.ManifestationColorMappers.ManifestationSubclassColorMapper
                      */
                     class RadialStandardBasisColorMap extends ManifestationColorMappers.ManifestationSubclassColorMapper {
+                        /**
+                         *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "RadialStandardBasisColorMap";
+                        }
                         /**
                          *
                          * @param {*} ball
@@ -9921,6 +10013,13 @@ export var com;
                             if (this.symmetrySystem === undefined)
                                 this.symmetrySystem = null;
                             this.symmetrySystem = symmetry;
+                        }
+                        /**
+                         *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "SystemColorMap";
                         }
                         /**
                          *
@@ -9984,6 +10083,13 @@ export var com;
                     class CanonicalOrientationColorMap extends ManifestationColorMappers.RadialStandardBasisColorMap {
                         /**
                          *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "CanonicalOrientationColorMap";
+                        }
+                        /**
+                         *
                          * @param {*} ball
                          * @param {number} alpha
                          * @return {com.vzome.core.construction.Color}
@@ -10023,6 +10129,13 @@ export var com;
                      * @extends com.vzome.core.edits.ManifestationColorMappers.RadialStandardBasisColorMap
                      */
                     class NormalPolarityColorMap extends ManifestationColorMappers.RadialStandardBasisColorMap {
+                        /**
+                         *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "NormalPolarityColorMap";
+                        }
                         applyTo$com_vzome_core_algebra_AlgebraicVector$int(vector, alpha) {
                             return ManifestationColorMappers.mapPolarity(vector, alpha);
                         }
@@ -10061,6 +10174,13 @@ export var com;
                             this.specialOrbits.add(symm.getSymmetry().getSpecialOrbit(com.vzome.core.math.symmetry.Symmetry.SpecialOrbit.BLUE));
                             this.specialOrbits.add(symm.getSymmetry().getSpecialOrbit(com.vzome.core.math.symmetry.Symmetry.SpecialOrbit.YELLOW));
                             this.specialOrbits.add(symm.getSymmetry().getSpecialOrbit(com.vzome.core.math.symmetry.Symmetry.SpecialOrbit.RED));
+                        }
+                        /**
+                         *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "NearestSpecialOrbitColorMap";
                         }
                         /**
                          *
@@ -10122,6 +10242,13 @@ export var com;
                      * @class
                      */
                     class CentroidNearestSpecialOrbitColorMap extends ManifestationColorMappers.NearestSpecialOrbitColorMap {
+                        /**
+                         *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "CentroidNearestSpecialOrbitColorMap";
+                        }
                         constructor(symm) {
                             super(symm);
                         }
@@ -10162,6 +10289,13 @@ export var com;
                      * @class
                      */
                     class NearestPredefinedOrbitColorMap extends ManifestationColorMappers.NearestSpecialOrbitColorMap {
+                        /**
+                         *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "NearestPredefinedOrbitColorMap";
+                        }
                         constructor(symm) {
                             super(symm);
                             this.specialOrbits = null;
@@ -10176,6 +10310,13 @@ export var com;
                      * @class
                      */
                     class CentroidNearestPredefinedOrbitColorMap extends ManifestationColorMappers.CentroidNearestSpecialOrbitColorMap {
+                        /**
+                         *
+                         * @return {string}
+                         */
+                        getName() {
+                            return "CentroidNearestPredefinedOrbitColorMap";
+                        }
                         constructor(symm) {
                             super(symm);
                             this.specialOrbits = null;
@@ -10302,8 +10443,8 @@ export var com;
                     }
                     getXml(doc) {
                         let result = doc.createElement("Tools");
-                        for (let index1077 = this.values().iterator(); index1077.hasNext();) {
-                            let tool = index1077.next();
+                        for (let index629 = this.values().iterator(); index629.hasNext();) {
+                            let tool = index629.next();
                             if (!tool.isPredefined()) {
                                 let toolElem = doc.createElement("Tool");
                                 com.vzome.xml.DomUtils.addAttribute(toolElem, "id", tool.getId());
@@ -10413,8 +10554,8 @@ export var com;
                         }
                         else if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Panel") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Panel") >= 0)) {
                             let vs = (new java.util.ArrayList());
-                            for (let index1078 = man.iterator(); index1078.hasNext();) {
-                                let v = index1078.next();
+                            for (let index630 = man.iterator(); index630.hasNext();) {
+                                let v = index630.next();
                                 {
                                     vs.add(this.getVertex(v));
                                 }
@@ -10459,8 +10600,8 @@ export var com;
                         this.selection = selection;
                     }
                     notifyListeners() {
-                        for (let index1079 = this.listeners.iterator(); index1079.hasNext();) {
-                            let listener = index1079.next();
+                        for (let index631 = this.listeners.iterator(); index631.hasNext();) {
+                            let listener = index631.next();
                             {
                                 listener.selectionChanged(this.selection.size(), this.balls, this.struts, this.panels);
                             }
@@ -10805,8 +10946,8 @@ export var com;
                         let styleName = symmetryPerspective.getDefaultGeometry().getName();
                         this.orbits = new com.vzome.core.math.symmetry.OrbitSet(this.symmetry);
                         if (symmXml == null) {
-                            for (let index1080 = this.symmetry.getOrbitSet().iterator(); index1080.hasNext();) {
-                                let orbit = index1080.next();
+                            for (let index632 = this.symmetry.getOrbitSet().iterator(); index632.hasNext();) {
+                                let orbit = index632.next();
                                 {
                                     if (symmetryPerspective.orbitIsStandard(orbit) || allowNonstandard)
                                         this.orbits.add(orbit);
@@ -10864,8 +11005,8 @@ export var com;
                                 }
                                 ;
                             }
-                            for (let index1081 = this.symmetry.getOrbitSet().iterator(); index1081.hasNext();) {
-                                let orbit = index1081.next();
+                            for (let index633 = this.symmetry.getOrbitSet().iterator(); index633.hasNext();) {
+                                let orbit = index633.next();
                                 {
                                     if (this.orbits.contains(orbit))
                                         continue;
@@ -10886,13 +11027,13 @@ export var com;
                     }
                     createToolFactories(tools) {
                         {
-                            let array1083 = /* Enum.values */ function () { let result = []; for (let val in com.vzome.api.Tool.Kind) {
+                            let array635 = /* Enum.values */ function () { let result = []; for (let val in com.vzome.api.Tool.Kind) {
                                 if (!isNaN(val)) {
                                     result.push(parseInt(val, 10));
                                 }
                             } return result; }();
-                            for (let index1082 = 0; index1082 < array1083.length; index1082++) {
-                                let kind = array1083[index1082];
+                            for (let index634 = 0; index634 < array635.length; index634++) {
+                                let kind = array635[index634];
                                 {
                                     let list = this.symmetryPerspective.createToolFactories(kind, tools);
                                     this.toolFactoryLists.put(kind, list);
@@ -11030,8 +11171,8 @@ export var com;
                         let result = doc.createElement("SymmetrySystem");
                         com.vzome.xml.DomUtils.addAttribute(result, "name", this.getSymmetry().getName());
                         com.vzome.xml.DomUtils.addAttribute(result, "renderingStyle", this.shapes.getName());
-                        for (let index1084 = this.orbits.iterator(); index1084.hasNext();) {
-                            let dir = index1084.next();
+                        for (let index636 = this.orbits.iterator(); index636.hasNext();) {
+                            let dir = index636.next();
                             {
                                 let dirElem = doc.createElement("Direction");
                                 if (dir.isAutomatic())
@@ -11590,8 +11731,8 @@ export var com;
                     hashCode() {
                         let prime = 31;
                         let result = 1;
-                        for (let index1085 = 0; index1085 < this.matrix.length; index1085++) {
-                            let m = this.matrix[index1085];
+                        for (let index637 = 0; index637 < this.matrix.length; index637++) {
+                            let m = this.matrix[index637];
                             {
                                 result = prime * result + java.util.Arrays.hashCode(m);
                             }
@@ -11622,8 +11763,8 @@ export var com;
                      */
                     toString() {
                         let buf = new java.lang.StringBuilder();
-                        for (let index1086 = 0; index1086 < this.matrix.length; index1086++) {
-                            let m = this.matrix[index1086];
+                        for (let index638 = 0; index638 < this.matrix.length; index638++) {
+                            let m = this.matrix[index638];
                             {
                                 buf.append(java.util.Arrays.toString(m));
                                 buf.append(", ");
@@ -11894,8 +12035,8 @@ export var com;
                         let v0 = null;
                         let v1 = null;
                         let normal = null;
-                        for (let index1087 = vectors.iterator(); index1087.hasNext();) {
-                            let vector = index1087.next();
+                        for (let index639 = vectors.iterator(); index639.hasNext();) {
+                            let vector = index639.next();
                             {
                                 if (v0 == null) {
                                     v0 = vector;
@@ -11953,8 +12094,8 @@ export var com;
                             throw new java.lang.IllegalArgumentException("Normal vector cannot be the origin");
                         }
                         let v0 = null;
-                        for (let index1088 = vectors.iterator(); index1088.hasNext();) {
-                            let vector = index1088.next();
+                        for (let index640 = vectors.iterator(); index640.hasNext();) {
+                            let vector = index640.next();
                             {
                                 if (v0 == null) {
                                     v0 = vector;
@@ -12005,8 +12146,8 @@ export var com;
                     static getCentroid(vectors) {
                         let field = vectors[0].getField();
                         let sum = new com.vzome.core.algebra.AlgebraicVector(field, vectors[0].dimension());
-                        for (let index1089 = 0; index1089 < vectors.length; index1089++) {
-                            let vector = vectors[index1089];
+                        for (let index641 = 0; index641 < vectors.length; index641++) {
+                            let vector = vectors[index641];
                             {
                                 sum = sum.plus(vector);
                             }
@@ -12036,8 +12177,8 @@ export var com;
                     static getMostDistantFromOrigin(vectors) {
                         let mostDistant = (new java.util.TreeSet());
                         let maxDistanceSquared = 0.0;
-                        for (let index1090 = vectors.iterator(); index1090.hasNext();) {
-                            let vector = index1090.next();
+                        for (let index642 = vectors.iterator(); index642.hasNext();) {
+                            let vector = index642.next();
                             {
                                 let magnitudeSquared = AlgebraicVectors.getMagnitudeSquared(vector).evaluate();
                                 if (magnitudeSquared >= maxDistanceSquared) {
@@ -12397,8 +12538,8 @@ export var com;
                         return new AlgebraicVector(result);
                     }
                     isOrigin() {
-                        for (let index1091 = 0; index1091 < this.coordinates.length; index1091++) {
-                            let coordinate = this.coordinates[index1091];
+                        for (let index643 = 0; index643 < this.coordinates.length; index643++) {
+                            let coordinate = this.coordinates[index643];
                             {
                                 if (!coordinate.isZero()) {
                                     return false;
@@ -12724,8 +12865,8 @@ export var com;
                         let out = new java.io.StringWriter();
                         let exporter = new VefVectorExporter(out, polyhedron.getField());
                         let vertexList = polyhedron.getVertexList();
-                        for (let index1092 = polyhedron.getFaceSet().iterator(); index1092.hasNext();) {
-                            let face = index1092.next();
+                        for (let index644 = polyhedron.getFaceSet().iterator(); index644.hasNext();) {
+                            let face = index644.next();
                             {
                                 let vertices = (new java.util.ArrayList(face.size()));
                                 for (let i = 0; i < face.size(); i++) {
@@ -12756,8 +12897,8 @@ export var com;
                         this.output.println$java_lang_Object("\n" + this.sortedVertexList.size());
                         {
                             let buf = new java.lang.StringBuffer();
-                            for (let index1093 = this.sortedVertexList.iterator(); index1093.hasNext();) {
-                                let vector = index1093.next();
+                            for (let index645 = this.sortedVertexList.iterator(); index645.hasNext();) {
+                                let vector = index645.next();
                                 {
                                     VefVectorExporter.appendVector(buf, vector, this.scale);
                                     buf.append("\n");
@@ -12768,8 +12909,8 @@ export var com;
                         }
                         ;
                         this.output.println$java_lang_Object("\n" + this.strutEnds.size());
-                        for (let index1094 = this.strutEnds.iterator(); index1094.hasNext();) {
-                            let ends = index1094.next();
+                        for (let index646 = this.strutEnds.iterator(); index646.hasNext();) {
+                            let ends = index646.next();
                             {
                                 this.output.print(this.sortedVertexList.indexOf(ends[0]) + " ");
                                 this.output.println$java_lang_Object(this.sortedVertexList.indexOf(ends[1]));
@@ -12777,12 +12918,12 @@ export var com;
                         }
                         this.output.println$java_lang_Object("\n");
                         this.output.println$java_lang_Object("\n" + this.panelVertices.size());
-                        for (let index1095 = this.panelVertices.iterator(); index1095.hasNext();) {
-                            let corners = index1095.next();
+                        for (let index647 = this.panelVertices.iterator(); index647.hasNext();) {
+                            let corners = index647.next();
                             {
                                 this.output.print(corners.length + "  ");
-                                for (let index1096 = 0; index1096 < corners.length; index1096++) {
-                                    let corner = corners[index1096];
+                                for (let index648 = 0; index648 < corners.length; index648++) {
+                                    let corner = corners[index648];
                                     {
                                         this.output.print(this.sortedVertexList.indexOf(corner) + " ");
                                     }
@@ -12793,8 +12934,8 @@ export var com;
                         this.output.println$java_lang_Object("\n");
                         this.output.println$java_lang_Object("\n" + this.ballLocations.size());
                         let i = 0;
-                        for (let index1097 = this.ballLocations.iterator(); index1097.hasNext();) {
-                            let ball = index1097.next();
+                        for (let index649 = this.ballLocations.iterator(); index649.hasNext();) {
+                            let ball = index649.next();
                             {
                                 this.output.print(this.sortedVertexList.indexOf(ball) + " ");
                                 if (++i % 10 === 0) {
@@ -13480,6 +13621,7 @@ export var com;
         })(api = vzome.api || (vzome.api = {}));
     })(vzome = com.vzome || (com.vzome = {}));
 })(com || (com = {}));
+
 (function (java) {
     var util;
     (function (util) {
@@ -16202,8 +16344,8 @@ export var com;
                             map = (s => { let a = []; while (s-- > 0)
                                 a.push(0); return a; })(ORDER);
                             let starts = [[0, 1, 2], [15, 46, 32], [16, 47, 30], [17, 45, 31]];
-                            for (let index1098 = 0; index1098 < starts.length; index1098++) {
-                                let start = starts[index1098];
+                            for (let index650 = 0; index650 < starts.length; index650++) {
+                                let start = starts[index650];
                                 {
                                     for (let j = 0; j < start.length; j++) {
                                         {
@@ -16222,8 +16364,8 @@ export var com;
                             map = (s => { let a = []; while (s-- > 0)
                                 a.push(0); return a; })(ORDER);
                             let cycles = [[0, 3, 6, 9, 12], [30, 42, 39, 36, 33], [2, 21, 29, 55, 4], [5, 24, 17, 58, 7], [8, 27, 20, 46, 10], [11, 15, 23, 49, 13], [1, 14, 18, 26, 52], [16, 50, 57, 38, 40], [19, 53, 45, 41, 43], [22, 56, 48, 44, 31], [25, 59, 51, 32, 34], [28, 47, 54, 35, 37]];
-                            for (let index1099 = 0; index1099 < cycles.length; index1099++) {
-                                let cycle = cycles[index1099];
+                            for (let index651 = 0; index651 < cycles.length; index651++) {
+                                let cycle = cycles[index651];
                                 {
                                     for (let j = 0; j < cycle.length; j++) {
                                         {
@@ -16446,8 +16588,8 @@ export var com;
                             map = (s => { let a = []; while (s-- > 0)
                                 a.push(0); return a; })(OctahedralSymmetry.ORDER);
                             let cycles = [[0, 4, 8], [1, 11, 17], [2, 16, 22], [3, 21, 5], [6, 20, 14], [7, 13, 9], [10, 12, 18], [19, 15, 23]];
-                            for (let index1100 = 0; index1100 < cycles.length; index1100++) {
-                                let cycle = cycles[index1100];
+                            for (let index652 = 0; index652 < cycles.length; index652++) {
+                                let cycle = cycles[index652];
                                 {
                                     for (let j = 0; j < cycle.length; j++) {
                                         {
@@ -16461,8 +16603,8 @@ export var com;
                             map = (s => { let a = []; while (s-- > 0)
                                 a.push(0); return a; })(OctahedralSymmetry.ORDER);
                             cycles = [[0, 5], [1, 8], [4, 9], [15, 20], [12, 19], [16, 23], [2, 17], [13, 10], [21, 6], [22, 3], [7, 14], [11, 18]];
-                            for (let index1101 = 0; index1101 < cycles.length; index1101++) {
-                                let cycle = cycles[index1101];
+                            for (let index653 = 0; index653 < cycles.length; index653++) {
+                                let cycle = cycles[index653];
                                 {
                                     for (let j = 0; j < cycle.length; j++) {
                                         {
@@ -16702,11 +16844,11 @@ export var com;
                             this.__zones = (new java.util.HashSet());
                             this.delegate = delegate;
                             this.normal = normal;
-                            for (let index1102 = delegate.iterator(); index1102.hasNext();) {
-                                let dir = index1102.next();
+                            for (let index654 = delegate.iterator(); index654.hasNext();) {
+                                let dir = index654.next();
                                 {
-                                    for (let index1103 = dir.iterator(); index1103.hasNext();) {
-                                        let axis = index1103.next();
+                                    for (let index655 = dir.iterator(); index655.hasNext();) {
+                                        let axis = index655.next();
                                         {
                                             if (axis.normal().dot(this.normal).isZero())
                                                 this.__zones.add(axis);
@@ -16729,8 +16871,8 @@ export var com;
                             }
                             let maxCosine = -1.0;
                             let closest = null;
-                            for (let index1104 = this.__zones.iterator(); index1104.hasNext();) {
-                                let axis = index1104.next();
+                            for (let index656 = this.__zones.iterator(); index656.hasNext();) {
+                                let axis = index656.next();
                                 {
                                     let axisV = axis.normal().toRealVector();
                                     let cosine = vector.dot(axisV) / (vector.length() * axisV.length());
@@ -17232,14 +17374,14 @@ export var com;
                         }
                         getConnectorPolyhedron() {
                             let result = new com.vzome.core.math.Polyhedron(this.__parent.mSymmetry.getField());
-                            for (let index1105 = this.vertices.iterator(); index1105.hasNext();) {
-                                let vertex = index1105.next();
+                            for (let index657 = this.vertices.iterator(); index657.hasNext();) {
+                                let vertex = index657.next();
                                 {
                                     result.addVertex(vertex);
                                 }
                             }
-                            for (let index1106 = this.faces.iterator(); index1106.hasNext();) {
-                                let prototypeFace = index1106.next();
+                            for (let index658 = this.faces.iterator(); index658.hasNext();) {
+                                let prototypeFace = index658.next();
                                 {
                                     let face = result.newFace();
                                     face.addAll(prototypeFace);
@@ -17543,8 +17685,8 @@ export var com;
                      */
                     addFace(index, verts) {
                         let face = this.polyhedron.newFace();
-                        for (let index1107 = 0; index1107 < verts.length; index1107++) {
-                            let i = verts[index1107];
+                        for (let index659 = 0; index659 < verts.length; index659++) {
+                            let i = verts[index659];
                             face.add(i);
                         }
                         this.polyhedron.addFace(face);
@@ -17721,8 +17863,8 @@ export var com;
                      */
                     endFile(tokens) {
                         if (this.noBallsSection) {
-                            for (let index1108 = 0; index1108 < this.mVertices.length; index1108++) {
-                                let vertex = this.mVertices[index1108];
+                            for (let index660 = 0; index660 < this.mVertices.length; index660++) {
+                                let vertex = this.mVertices[index660];
                                 {
                                     this.mEffects.constructionAdded(vertex);
                                 }
@@ -17773,8 +17915,8 @@ export var com;
                         return result;
                     }
                     getXml$org_w3c_dom_Element$java_lang_String(result, vertexChildName) {
-                        for (let index1109 = 0; index1109 < this.mVertices.length; index1109++) {
-                            let vertex = this.mVertices[index1109];
+                        for (let index661 = 0; index661 < this.mVertices.length; index661++) {
+                            let vertex = this.mVertices[index661];
                             {
                                 let child = result.getOwnerDocument().createElement(vertexChildName);
                                 com.vzome.xml.DomUtils.addAttribute(child, "at", vertex.getVectorExpression$int(com.vzome.core.algebra.AlgebraicField.ZOMIC_FORMAT));
@@ -17797,8 +17939,8 @@ export var com;
                      * @return {boolean}
                      */
                     is3d() {
-                        for (let index1110 = 0; index1110 < this.mVertices.length; index1110++) {
-                            let algebraicVector = this.mVertices[index1110];
+                        for (let index662 = 0; index662 < this.mVertices.length; index662++) {
+                            let algebraicVector = this.mVertices[index662];
                             {
                                 if (algebraicVector.dimension() !== 3)
                                     return false;
@@ -19703,8 +19845,8 @@ export var com;
                         getDetailXml(doc) {
                             let result = this.getXml(doc);
                             let effects = doc.createElement("effects");
-                            for (let index1111 = this.mItems.iterator(); index1111.hasNext();) {
-                                let se = index1111.next();
+                            for (let index663 = this.mItems.iterator(); index663.hasNext();) {
+                                let se = index663.next();
                                 {
                                     if (se != null) {
                                         let effect = se.getXml(doc);
@@ -19851,8 +19993,8 @@ export var com;
                         if (symmetry != null && symmetry instanceof com.vzome.core.math.symmetry.IcosahedralSymmetry) {
                             if (total !== 2)
                                 return false;
-                            for (let index1112 = selection.iterator(); index1112.hasNext();) {
-                                let man = index1112.next();
+                            for (let index664 = selection.iterator(); index664.hasNext();) {
+                                let man = index664.next();
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0)) {
                                     let zone = symmetry['getAxis$com_vzome_core_algebra_AlgebraicVector'](man.getOffset());
                                     if (zone == null)
@@ -20882,8 +21024,8 @@ export var com;
                          *
                          */
                         endEdges() {
-                            for (let index1113 = this.mUsedPoints.iterator(); index1113.hasNext();) {
-                                let point = index1113.next();
+                            for (let index665 = this.mUsedPoints.iterator(); index665.hasNext();) {
+                                let point = index665.next();
                                 {
                                     this.mEffects.constructionAdded(point);
                                 }
@@ -22027,8 +22169,8 @@ export var com;
                         }
                         let v0 = null;
                         let v1 = null;
-                        for (let index1114 = intersections.iterator(); index1114.hasNext();) {
-                            let v = index1114.next();
+                        for (let index666 = intersections.iterator(); index666.hasNext();) {
+                            let v = index666.next();
                             {
                                 if (v0 == null) {
                                     v0 = v;
@@ -22065,8 +22207,8 @@ export var com;
                         let start = null;
                         let offset = null;
                         let n = 0;
-                        for (let index1115 = projections.iterator(); index1115.hasNext();) {
-                            let v = index1115.next();
+                        for (let index667 = projections.iterator(); index667.hasNext();) {
+                            let v = index667.next();
                             {
                                 if (n === 0) {
                                     start = v;
@@ -22985,8 +23127,8 @@ export var com;
                     transform(params, transform, effects) {
                         let output = new com.vzome.core.construction.ConstructionList();
                         effects.constructionAdded(transform);
-                        for (let index1116 = 0; index1116 < params.length; index1116++) {
-                            let param = params[index1116];
+                        for (let index668 = 0; index668 < params.length; index668++) {
+                            let param = params[index668];
                             {
                                 let result = transform.transform$com_vzome_core_construction_Construction(param);
                                 if (result == null)
@@ -23224,9 +23366,9 @@ export var com;
                     apply(parameters, attrs, effects) {
                         let points = (new java.util.ArrayList());
                         {
-                            let array1118 = parameters.getConstructions();
-                            for (let index1117 = 0; index1117 < array1118.length; index1117++) {
-                                let param = array1118[index1117];
+                            let array670 = parameters.getConstructions();
+                            for (let index669 = 0; index669 < array670.length; index669++) {
+                                let param = array670[index669];
                                 {
                                     if (param != null && param instanceof com.vzome.core.construction.Point) {
                                         points.add(param);
@@ -23245,8 +23387,8 @@ export var com;
                             }
                             else {
                                 let base = null;
-                                for (let index1119 = points.iterator(); index1119.hasNext();) {
-                                    let point = index1119.next();
+                                for (let index671 = points.iterator(); index671.hasNext();) {
+                                    let point = index671.next();
                                     {
                                         if (base == null) {
                                             base = point.getLocation();
@@ -23332,8 +23474,8 @@ export var com;
                             throw new commands.Command.Failure("Select two or more balls to compute their centroid.");
                         let params = parameters.getConstructions();
                         let verticesList = (new java.util.ArrayList());
-                        for (let index1120 = 0; index1120 < params.length; index1120++) {
-                            let param = params[index1120];
+                        for (let index672 = 0; index672 < params.length; index672++) {
+                            let param = params[index672];
                             {
                                 if (param != null && param instanceof com.vzome.core.construction.Point) {
                                     verticesList.add(param);
@@ -23791,8 +23933,8 @@ export var com;
                                 throw new Error('invalid overload');
                         }
                         selectGroup(group) {
-                            for (let index1121 = group.iterator(); index1121.hasNext();) {
-                                let next = index1121.next();
+                            for (let index673 = group.iterator(); index673.hasNext();) {
+                                let next = index673.next();
                                 {
                                     if (next != null && next instanceof com.vzome.core.model.Group)
                                         this.selectGroup(next);
@@ -23802,8 +23944,8 @@ export var com;
                             }
                         }
                         unselectGroup(group) {
-                            for (let index1122 = group.iterator(); index1122.hasNext();) {
-                                let next = index1122.next();
+                            for (let index674 = group.iterator(); index674.hasNext();) {
+                                let next = index674.next();
                                 {
                                     if (next != null && next instanceof com.vzome.core.model.Group)
                                         this.unselectGroup(next);
@@ -23823,8 +23965,8 @@ export var com;
                         }
                         getLastSelectedManifestation() {
                             let last = null;
-                            for (let index1123 = this.mSelection.iterator(); index1123.hasNext();) {
-                                let man = index1123.next();
+                            for (let index675 = this.mSelection.iterator(); index675.hasNext();) {
+                                let man = index675.next();
                                 {
                                     last = man;
                                 }
@@ -23833,8 +23975,8 @@ export var com;
                         }
                         getLastSelectedConnector() {
                             let last = null;
-                            for (let index1124 = this.getSelectedConnectors().iterator(); index1124.hasNext();) {
-                                let connector = index1124.next();
+                            for (let index676 = this.getSelectedConnectors().iterator(); index676.hasNext();) {
+                                let connector = index676.next();
                                 {
                                     last = connector;
                                 }
@@ -23843,8 +23985,8 @@ export var com;
                         }
                         getLastSelectedStrut() {
                             let last = null;
-                            for (let index1125 = this.getSelectedStruts().iterator(); index1125.hasNext();) {
-                                let strut = index1125.next();
+                            for (let index677 = this.getSelectedStruts().iterator(); index677.hasNext();) {
+                                let strut = index677.next();
                                 {
                                     last = strut;
                                 }
@@ -23853,8 +23995,8 @@ export var com;
                         }
                         getLastSelectedPanel() {
                             let last = null;
-                            for (let index1126 = this.getSelectedPanels().iterator(); index1126.hasNext();) {
-                                let panel = index1126.next();
+                            for (let index678 = this.getSelectedPanels().iterator(); index678.hasNext();) {
+                                let panel = index678.next();
                                 {
                                     last = panel;
                                 }
@@ -23863,8 +24005,8 @@ export var com;
                         }
                         unselectAll() {
                             let anySelected = false;
-                            for (let index1127 = this.mSelection.iterator(); index1127.hasNext();) {
-                                let man = index1127.next();
+                            for (let index679 = this.mSelection.iterator(); index679.hasNext();) {
+                                let man = index679.next();
                                 {
                                     anySelected = true;
                                     this.unselect$com_vzome_core_model_Manifestation(man);
@@ -23877,8 +24019,8 @@ export var com;
                         }
                         unselectConnectors() {
                             let anySelected = false;
-                            for (let index1128 = this.getSelectedConnectors().iterator(); index1128.hasNext();) {
-                                let connector = index1128.next();
+                            for (let index680 = this.getSelectedConnectors().iterator(); index680.hasNext();) {
+                                let connector = index680.next();
                                 {
                                     anySelected = true;
                                     this.unselect$com_vzome_core_model_Manifestation(connector);
@@ -23891,8 +24033,8 @@ export var com;
                         }
                         unselectStruts() {
                             let anySelected = false;
-                            for (let index1129 = this.getSelectedStruts().iterator(); index1129.hasNext();) {
-                                let strut = index1129.next();
+                            for (let index681 = this.getSelectedStruts().iterator(); index681.hasNext();) {
+                                let strut = index681.next();
                                 {
                                     anySelected = true;
                                     this.unselect$com_vzome_core_model_Manifestation(strut);
@@ -23905,8 +24047,8 @@ export var com;
                         }
                         unselectPanels() {
                             let anySelected = false;
-                            for (let index1130 = this.getSelectedPanels().iterator(); index1130.hasNext();) {
-                                let panel = index1130.next();
+                            for (let index682 = this.getSelectedPanels().iterator(); index682.hasNext();) {
+                                let panel = index682.next();
                                 {
                                     anySelected = true;
                                     this.unselect$com_vzome_core_model_Manifestation(panel);
@@ -24381,8 +24523,8 @@ export var com;
                         }
                         else {
                             let numSegs = 0;
-                            for (let index1131 = parameters.iterator(); index1131.hasNext();) {
-                                let cons = index1131.next();
+                            for (let index683 = parameters.iterator(); index683.hasNext();) {
+                                let cons = index683.next();
                                 {
                                     if (cons != null && cons instanceof com.vzome.core.construction.Segment) {
                                         let seg = cons;
@@ -24429,11 +24571,11 @@ export var com;
                                 reflections[mirror] = this.symm.reflect(mirror, prototype);
                             ;
                         }
-                        for (let index1132 = 0; index1132 < this.mRoots.length; index1132++) {
-                            let outerRoot = this.mRoots[index1132];
+                        for (let index684 = 0; index684 < this.mRoots.length; index684++) {
+                            let outerRoot = this.mRoots[index684];
                             {
-                                for (let index1133 = 0; index1133 < this.mRoots.length; index1133++) {
-                                    let innerRoot = this.mRoots[index1133];
+                                for (let index685 = 0; index685 < this.mRoots.length; index685++) {
+                                    let innerRoot = this.mRoots[index685];
                                     {
                                         let vertex = outerRoot.rightMultiply(prototype);
                                         vertex = innerRoot.leftMultiply(vertex);
@@ -24749,8 +24891,8 @@ export var com;
                         let center = this.setSymmetry(attributes);
                         let params = parameters.getConstructions();
                         let output = new com.vzome.core.construction.ConstructionList();
-                        for (let index1134 = 0; index1134 < params.length; index1134++) {
-                            let param = params[index1134];
+                        for (let index686 = 0; index686 < params.length; index686++) {
+                            let param = params[index686];
                             {
                                 output.addConstruction(param);
                             }
@@ -24865,20 +25007,20 @@ export var com;
                         let rightRoots = this.mRight.getRoots();
                         let params = parameters.getConstructions();
                         let output = new com.vzome.core.construction.ConstructionList();
-                        for (let index1135 = 0; index1135 < params.length; index1135++) {
-                            let param = params[index1135];
+                        for (let index687 = 0; index687 < params.length; index687++) {
+                            let param = params[index687];
                             {
                                 output.addConstruction(param);
                             }
                         }
-                        for (let index1136 = 0; index1136 < leftRoots.length; index1136++) {
-                            let leftRoot = leftRoots[index1136];
+                        for (let index688 = 0; index688 < leftRoots.length; index688++) {
+                            let leftRoot = leftRoots[index688];
                             {
-                                for (let index1137 = 0; index1137 < rightRoots.length; index1137++) {
-                                    let rightRoot = rightRoots[index1137];
+                                for (let index689 = 0; index689 < rightRoots.length; index689++) {
+                                    let rightRoot = rightRoots[index689];
                                     {
-                                        for (let index1138 = 0; index1138 < params.length; index1138++) {
-                                            let param = params[index1138];
+                                        for (let index690 = 0; index690 < params.length; index690++) {
+                                            let param = params[index690];
                                             {
                                                 let result = null;
                                                 if (param != null && param instanceof com.vzome.core.construction.Point) {
@@ -24986,8 +25128,8 @@ export var com;
                         let output = new com.vzome.core.construction.ConstructionList();
                         let center = attributes.get(com.vzome.core.commands.CommandTransform.SYMMETRY_CENTER_ATTR_NAME);
                         let params = parameters.getConstructions();
-                        for (let index1139 = 0; index1139 < params.length; index1139++) {
-                            let param = params[index1139];
+                        for (let index691 = 0; index691 < params.length; index691++) {
+                            let param = params[index691];
                             {
                                 output.addConstruction(param);
                             }
@@ -25100,8 +25242,8 @@ export var com;
                      *
                      */
                     perform() {
-                        for (let index1140 = this.mManifestations.iterator(); index1140.hasNext();) {
-                            let m = index1140.next();
+                        for (let index692 = this.mManifestations.iterator(); index692.hasNext();) {
+                            let m = index692.next();
                             {
                                 if (m.isRendered()) {
                                     if (this.mSelection.manifestationSelected(m))
@@ -25226,8 +25368,8 @@ export var com;
                      */
                     perform() {
                         if (this.mReplace) {
-                            for (let index1141 = this.mSelection.iterator(); index1141.hasNext();) {
-                                let man = index1141.next();
+                            for (let index693 = this.mSelection.iterator(); index693.hasNext();) {
+                                let man = index693.next();
                                 {
                                     this.unselect$com_vzome_core_model_Manifestation$boolean(man, true);
                                 }
@@ -25367,8 +25509,8 @@ export var com;
                      */
                     perform() {
                         let whichManifestationSet = (this.strutAction === com.vzome.core.editor.api.ActionEnum.SELECT || this.panelAction === com.vzome.core.editor.api.ActionEnum.SELECT) ? this.editor.getRealizedModel() : this.mSelection;
-                        for (let index1142 = whichManifestationSet.iterator(); index1142.hasNext();) {
-                            let man = index1142.next();
+                        for (let index694 = whichManifestationSet.iterator(); index694.hasNext();) {
+                            let man = index694.next();
                             {
                                 if (man.isRendered()) {
                                     if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0)) {
@@ -25516,8 +25658,8 @@ export var com;
                      */
                     perform() {
                         let whichManifestationSet = (this.ballAction === com.vzome.core.editor.api.ActionEnum.SELECT || this.strutAction === com.vzome.core.editor.api.ActionEnum.SELECT || this.panelAction === com.vzome.core.editor.api.ActionEnum.SELECT) ? this.editor.getRealizedModel() : this.mSelection;
-                        for (let index1143 = whichManifestationSet.iterator(); index1143.hasNext();) {
-                            let man = index1143.next();
+                        for (let index695 = whichManifestationSet.iterator(); index695.hasNext();) {
+                            let man = index695.next();
                             {
                                 if (man.isRendered()) {
                                     if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0)) {
@@ -25609,8 +25751,8 @@ export var com;
                      *
                      */
                     perform() {
-                        for (let index1144 = this.realizedModel.iterator(); index1144.hasNext();) {
-                            let m = index1144.next();
+                        for (let index696 = this.realizedModel.iterator(); index696.hasNext();) {
+                            let m = index696.next();
                             {
                                 if (m.isRendered()) {
                                     if (!this.mSelection.manifestationSelected(m))
@@ -25661,8 +25803,8 @@ export var com;
                         let panels = (new java.util.HashSet());
                         let struts = (new java.util.HashSet());
                         let balls = (new java.util.HashSet());
-                        for (let index1145 = this.mSelection.iterator(); index1145.hasNext();) {
-                            let man = index1145.next();
+                        for (let index697 = this.mSelection.iterator(); index697.hasNext();) {
+                            let man = index697.next();
                             {
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0))
                                     struts.add(man);
@@ -25672,12 +25814,12 @@ export var com;
                                     panels.add(man);
                             }
                         }
-                        for (let index1146 = balls.iterator(); index1146.hasNext();) {
-                            let ball = index1146.next();
+                        for (let index698 = balls.iterator(); index698.hasNext();) {
+                            let ball = index698.next();
                             {
                                 let loc = ball.getLocation();
-                                for (let index1147 = model.iterator(); index1147.hasNext();) {
-                                    let man = index1147.next();
+                                for (let index699 = model.iterator(); index699.hasNext();) {
+                                    let man = index699.next();
                                     {
                                         if (!man.isRendered())
                                             continue;
@@ -25688,8 +25830,8 @@ export var com;
                                         }
                                         else if (this.withPanels && (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Panel") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Panel") >= 0)) && !panels.contains(man)) {
                                             let panel = man;
-                                            for (let index1148 = panel.iterator(); index1148.hasNext();) {
-                                                let vertex = index1148.next();
+                                            for (let index700 = panel.iterator(); index700.hasNext();) {
+                                                let vertex = index700.next();
                                                 {
                                                     if (loc.equals(vertex)) {
                                                         this.select$com_vzome_core_model_Manifestation(panel);
@@ -25702,13 +25844,13 @@ export var com;
                                 }
                             }
                         }
-                        for (let index1149 = struts.iterator(); index1149.hasNext();) {
-                            let strut = index1149.next();
+                        for (let index701 = struts.iterator(); index701.hasNext();) {
+                            let strut = index701.next();
                             {
                                 let loc = strut.getLocation();
                                 let end = strut.getEnd();
-                                for (let index1150 = model.iterator(); index1150.hasNext();) {
-                                    let man = index1150.next();
+                                for (let index702 = model.iterator(); index702.hasNext();) {
+                                    let man = index702.next();
                                     {
                                         if (!man.isRendered())
                                             continue;
@@ -25722,14 +25864,14 @@ export var com;
                             }
                         }
                         if (this.withPanels) {
-                            for (let index1151 = panels.iterator(); index1151.hasNext();) {
-                                let panel = index1151.next();
+                            for (let index703 = panels.iterator(); index703.hasNext();) {
+                                let panel = index703.next();
                                 {
-                                    for (let index1152 = panel.iterator(); index1152.hasNext();) {
-                                        let loc = index1152.next();
+                                    for (let index704 = panel.iterator(); index704.hasNext();) {
+                                        let loc = index704.next();
                                         {
-                                            for (let index1153 = model.iterator(); index1153.hasNext();) {
-                                                let man = index1153.next();
+                                            for (let index705 = model.iterator(); index705.hasNext();) {
+                                                let man = index705.next();
                                                 {
                                                     if (man.isRendered()) {
                                                         if ((man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0)) && !balls.contains(man)) {
@@ -25774,8 +25916,8 @@ export var com;
                      *
                      */
                     perform() {
-                        for (let index1154 = this.mSelection.iterator(); index1154.hasNext();) {
-                            let man = index1154.next();
+                        for (let index706 = this.mSelection.iterator(); index706.hasNext();) {
+                            let man = index706.next();
                             {
                                 this.unselect$com_vzome_core_model_Manifestation$boolean(man, true);
                             }
@@ -25877,38 +26019,38 @@ export var com;
                             this.plan(new ChangeManifestations.ColorManifestation(this, m, color));
                         }
                         hideConnectors() {
-                            for (let index1155 = com.vzome.core.editor.api.Manifestations.getVisibleConnectors(this.mManifestations).iterator(); index1155.hasNext();) {
-                                let connector = index1155.next();
+                            for (let index707 = com.vzome.core.editor.api.Manifestations.getVisibleConnectors(this.mManifestations).iterator(); index707.hasNext();) {
+                                let connector = index707.next();
                                 this.hideManifestation(connector);
                             }
                         }
                         showConnectors() {
-                            for (let index1156 = com.vzome.core.editor.api.Manifestations.getHiddenConnectors(this.mManifestations).iterator(); index1156.hasNext();) {
-                                let connector = index1156.next();
+                            for (let index708 = com.vzome.core.editor.api.Manifestations.getHiddenConnectors(this.mManifestations).iterator(); index708.hasNext();) {
+                                let connector = index708.next();
                                 this.showManifestation(connector);
                             }
                         }
                         hideStruts() {
-                            for (let index1157 = com.vzome.core.editor.api.Manifestations.getVisibleStruts(this.mManifestations).iterator(); index1157.hasNext();) {
-                                let strut = index1157.next();
+                            for (let index709 = com.vzome.core.editor.api.Manifestations.getVisibleStruts(this.mManifestations).iterator(); index709.hasNext();) {
+                                let strut = index709.next();
                                 this.hideManifestation(strut);
                             }
                         }
                         showStruts() {
-                            for (let index1158 = com.vzome.core.editor.api.Manifestations.getHiddenStruts(this.mManifestations).iterator(); index1158.hasNext();) {
-                                let strut = index1158.next();
+                            for (let index710 = com.vzome.core.editor.api.Manifestations.getHiddenStruts(this.mManifestations).iterator(); index710.hasNext();) {
+                                let strut = index710.next();
                                 this.showManifestation(strut);
                             }
                         }
                         hidePanels() {
-                            for (let index1159 = com.vzome.core.editor.api.Manifestations.getVisiblePanels(this.mManifestations).iterator(); index1159.hasNext();) {
-                                let panel = index1159.next();
+                            for (let index711 = com.vzome.core.editor.api.Manifestations.getVisiblePanels(this.mManifestations).iterator(); index711.hasNext();) {
+                                let panel = index711.next();
                                 this.hideManifestation(panel);
                             }
                         }
                         showPanels() {
-                            for (let index1160 = com.vzome.core.editor.api.Manifestations.getHiddenPanels(this.mManifestations).iterator(); index1160.hasNext();) {
-                                let panel = index1160.next();
+                            for (let index712 = com.vzome.core.editor.api.Manifestations.getHiddenPanels(this.mManifestations).iterator(); index712.hasNext();) {
+                                let panel = index712.next();
                                 this.showManifestation(panel);
                             }
                         }
@@ -26244,8 +26386,8 @@ export var com;
                         let closure = this.mSymmetry.subgroup(com.vzome.core.math.symmetry.Symmetry.TETRAHEDRAL);
                         let params = parameters.getConstructions();
                         let output = new com.vzome.core.construction.ConstructionList();
-                        for (let index1161 = 0; index1161 < params.length; index1161++) {
-                            let param = params[index1161];
+                        for (let index713 = 0; index713 < params.length; index713++) {
+                            let param = params[index713];
                             {
                                 output.addConstruction(param);
                             }
@@ -26358,8 +26500,8 @@ export var com;
                         let rotate = new com.vzome.core.commands.CommandRotate();
                         for (let i = 1; i < order; i++) {
                             {
-                                for (let index1162 = parameters.iterator(); index1162.hasNext();) {
-                                    let param = index1162.next();
+                                for (let index714 = parameters.iterator(); index714.hasNext();) {
+                                    let param = index714.next();
                                     {
                                         output.addConstruction(param);
                                     }
@@ -26368,8 +26510,8 @@ export var com;
                             }
                             ;
                         }
-                        for (let index1163 = parameters.iterator(); index1163.hasNext();) {
-                            let param = index1163.next();
+                        for (let index715 = parameters.iterator(); index715.hasNext();) {
+                            let param = index715.next();
                             {
                                 output.addConstruction(param);
                             }
@@ -26408,8 +26550,8 @@ export var com;
                         let panel0 = null;
                         let panel1 = null;
                         let nPanels = 0;
-                        for (let index1164 = this.mSelection.iterator(); index1164.hasNext();) {
-                            let man = index1164.next();
+                        for (let index716 = this.mSelection.iterator(); index716.hasNext();) {
+                            let man = index716.next();
                             {
                                 this.unselect$com_vzome_core_model_Manifestation(man);
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Panel") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Panel") >= 0)) {
@@ -26444,12 +26586,12 @@ export var com;
                         if (com.vzome.core.algebra.AlgebraicVectors.areParallel(panel0['getNormal$'](), panel1['getNormal$']())) {
                             let vertices = (new java.util.ArrayList());
                             {
-                                let array1166 = [panel0, panel1];
-                                for (let index1165 = 0; index1165 < array1166.length; index1165++) {
-                                    let panel = array1166[index1165];
+                                let array718 = [panel0, panel1];
+                                for (let index717 = 0; index717 < array718.length; index717++) {
+                                    let panel = array718[index717];
                                     {
-                                        for (let index1167 = panel.iterator(); index1167.hasNext();) {
-                                            let v = index1167.next();
+                                        for (let index719 = panel.iterator(); index719.hasNext();) {
+                                            let v = index719.next();
                                             {
                                                 vertices.add(v);
                                             }
@@ -26470,8 +26612,8 @@ export var com;
                     }
                     /*private*/ static polygonFromPanel(panel) {
                         let vertices = (new java.util.ArrayList(panel.getVertexCount()));
-                        for (let index1168 = panel.iterator(); index1168.hasNext();) {
-                            let vector = index1168.next();
+                        for (let index720 = panel.iterator(); index720.hasNext();) {
+                            let vector = index720.next();
                             {
                                 vertices.add(new com.vzome.core.construction.FreePoint(vector));
                             }
@@ -26560,8 +26702,8 @@ export var com;
                         let inputs = (new java.util.ArrayList());
                         if (this.joinMode !== JoinPoints.JoinModeEnum.ALL_POSSIBLE)
                             this.setOrderedSelection(true);
-                        for (let index1169 = this.mSelection.iterator(); index1169.hasNext();) {
-                            let man = index1169.next();
+                        for (let index721 = this.mSelection.iterator(); index721.hasNext();) {
+                            let man = index721.next();
                             {
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0)) {
                                     inputs.add(man.getFirstConstruction());
@@ -26678,8 +26820,8 @@ export var com;
                         let SCALE_DOWN = this.mManifestations.getField()['createAlgebraicNumber$int$int$int$int'](1, 0, 2, -3);
                         this.unselectConnectors();
                         this.unselectStruts();
-                        for (let index1170 = com.vzome.core.editor.api.Manifestations.getPanels$java_lang_Iterable(this.mSelection).iterator(); index1170.hasNext();) {
-                            let panel = index1170.next();
+                        for (let index722 = com.vzome.core.editor.api.Manifestations.getPanels$java_lang_Iterable(this.mSelection).iterator(); index722.hasNext();) {
+                            let panel = index722.next();
                             {
                                 this.unselect$com_vzome_core_model_Manifestation(panel);
                                 let centroid = panel.getCentroid();
@@ -26980,8 +27122,8 @@ export var com;
                         let s1 = null;
                         let success = false;
                         this.setOrderedSelection(true);
-                        for (let index1171 = this.mSelection.iterator(); index1171.hasNext();) {
-                            let man = index1171.next();
+                        for (let index723 = this.mSelection.iterator(); index723.hasNext();) {
+                            let man = index723.next();
                             {
                                 if (success) {
                                     this.recordSelected(man);
@@ -27047,8 +27189,8 @@ export var com;
                      *
                      */
                     perform() {
-                        for (let index1172 = this.mManifestations.iterator(); index1172.hasNext();) {
-                            let m = index1172.next();
+                        for (let index724 = this.mManifestations.iterator(); index724.hasNext();) {
+                            let m = index724.next();
                             {
                                 if (m.isHidden()) {
                                     this.showManifestation(m);
@@ -27122,8 +27264,8 @@ export var com;
                         let errorMsg = new java.lang.StringBuilder();
                         errorMsg.append("The Polar Zonohedron command requires either of the following selections:\n\n1) Two non-collinear struts with a common end point.\n   The first strut must have more than 2-fold rotational symmetry.\n   The second strut will be rotated around the first.\n\n2) Any three or more struts having a common end point.\n");
                         let struts = (new java.util.ArrayList());
-                        for (let index1173 = this.mSelection.iterator(); index1173.hasNext();) {
-                            let man = index1173.next();
+                        for (let index725 = this.mSelection.iterator(); index725.hasNext();) {
+                            let man = index725.next();
                             {
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0)) {
                                     struts.add(man);
@@ -27303,8 +27445,8 @@ export var com;
                         }
                         this.redo();
                         this.select$com_vzome_core_model_Manifestation(this.manifestConstruction(new com.vzome.core.construction.FreePoint(common)));
-                        for (let index1174 = struts.iterator(); index1174.hasNext();) {
-                            let strut = index1174.next();
+                        for (let index726 = struts.iterator(); index726.hasNext();) {
+                            let strut = index726.next();
                             {
                                 this.select$com_vzome_core_model_Manifestation(strut);
                                 let start = strut.getLocation();
@@ -27345,16 +27487,16 @@ export var com;
                      */
                     perform() {
                         let inputs = (new java.util.ArrayList());
-                        for (let index1175 = this.mSelection.iterator(); index1175.hasNext();) {
-                            let man = index1175.next();
+                        for (let index727 = this.mSelection.iterator(); index727.hasNext();) {
+                            let man = index727.next();
                             {
                                 this.unselect$com_vzome_core_model_Manifestation(man);
                                 inputs.add(man);
                             }
                         }
                         this.redo();
-                        for (let index1176 = inputs.iterator(); index1176.hasNext();) {
-                            let m = index1176.next();
+                        for (let index728 = inputs.iterator(); index728.hasNext();) {
+                            let m = index728.next();
                             {
                                 if (!m.isRendered())
                                     continue;
@@ -27736,8 +27878,8 @@ export var com;
                      *
                      */
                     perform() {
-                        for (let index1177 = this.mSelection.iterator(); index1177.hasNext();) {
-                            let man = index1177.next();
+                        for (let index729 = this.mSelection.iterator(); index729.hasNext();) {
+                            let man = index729.next();
                             {
                                 this.unselect$com_vzome_core_model_Manifestation(man);
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0)) {
@@ -27796,8 +27938,8 @@ export var com;
                         let s0 = null;
                         let s1 = null;
                         let qty = 0;
-                        for (let index1178 = this.mSelection.iterator(); index1178.hasNext();) {
-                            let man = index1178.next();
+                        for (let index730 = this.mSelection.iterator(); index730.hasNext();) {
+                            let man = index730.next();
                             {
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0)) {
                                     switch ((qty)) {
@@ -27877,8 +28019,8 @@ export var com;
                      */
                     perform() {
                         let verticesList = (new java.util.ArrayList());
-                        for (let index1179 = this.mSelection.iterator(); index1179.hasNext();) {
-                            let man = index1179.next();
+                        for (let index731 = this.mSelection.iterator(); index731.hasNext();) {
+                            let man = index731.next();
                             {
                                 this.unselect$com_vzome_core_model_Manifestation(man);
                                 let construction = man.toConstruction();
@@ -27946,8 +28088,8 @@ export var com;
                         let p0 = null;
                         let p1 = null;
                         let p2 = null;
-                        for (let index1180 = this.mSelection.iterator(); index1180.hasNext();) {
-                            let man = index1180.next();
+                        for (let index732 = this.mSelection.iterator(); index732.hasNext();) {
+                            let man = index732.next();
                             {
                                 this.unselect$com_vzome_core_model_Manifestation(man);
                                 if ((man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0)) && (p2 == null)) {
@@ -28041,24 +28183,24 @@ export var com;
                         this.redo();
                     }
                     selectBoundedManifestations() {
-                        for (let index1181 = this.getConnectors().iterator(); index1181.hasNext();) {
-                            let connector = index1181.next();
+                        for (let index733 = this.getConnectors().iterator(); index733.hasNext();) {
+                            let connector = index733.next();
                             {
                                 if (this.boundaryContains$com_vzome_core_model_Connector(connector)) {
                                     this.select$com_vzome_core_model_Manifestation(connector);
                                 }
                             }
                         }
-                        for (let index1182 = this.getStruts().iterator(); index1182.hasNext();) {
-                            let strut = index1182.next();
+                        for (let index734 = this.getStruts().iterator(); index734.hasNext();) {
+                            let strut = index734.next();
                             {
                                 if (this.boundaryContains$com_vzome_core_model_Strut(strut)) {
                                     this.select$com_vzome_core_model_Manifestation(strut);
                                 }
                             }
                         }
-                        for (let index1183 = this.getPanels().iterator(); index1183.hasNext();) {
-                            let panel = index1183.next();
+                        for (let index735 = this.getPanels().iterator(); index735.hasNext();) {
+                            let panel = index735.next();
                             {
                                 if (this.boundaryContains$com_vzome_core_model_Panel(panel)) {
                                     this.select$com_vzome_core_model_Manifestation(panel);
@@ -28089,8 +28231,8 @@ export var com;
                         return this.boundaryContains$com_vzome_core_algebra_AlgebraicVector(strut.getLocation()) && this.boundaryContains$com_vzome_core_algebra_AlgebraicVector(strut.getEnd());
                     }
                     /*private*/ boundaryContains$com_vzome_core_model_Panel(panel) {
-                        for (let index1184 = panel.iterator(); index1184.hasNext();) {
-                            let vertex = index1184.next();
+                        for (let index736 = panel.iterator(); index736.hasNext();) {
+                            let vertex = index736.next();
                             {
                                 if (!this.boundaryContains$com_vzome_core_algebra_AlgebraicVector(vertex)) {
                                     return false;
@@ -28167,8 +28309,8 @@ export var com;
                         this.unselectAll();
                         let opposite = (this.axis.getSense() + 1) % 2;
                         let oppositeAxis = this.orbit.getAxis$int$int(opposite, this.axis.getOrientation());
-                        for (let index1185 = this.getStruts().iterator(); index1185.hasNext();) {
-                            let strut = index1185.next();
+                        for (let index737 = this.getStruts().iterator(); index737.hasNext();) {
+                            let strut = index737.next();
                             {
                                 let strutAxis = this.symmetry.getAxis(strut.getOffset());
                                 if (strutAxis != null && strutAxis.getOrbit().equals(this.orbit)) {
@@ -28229,8 +28371,8 @@ export var com;
                     }
                     getSelectedVertexSet(unselectAll) {
                         let vertexSet = (new java.util.HashSet());
-                        for (let index1186 = this.mSelection.iterator(); index1186.hasNext();) {
-                            let man = index1186.next();
+                        for (let index738 = this.mSelection.iterator(); index738.hasNext();) {
+                            let man = index738.next();
                             {
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0)) {
                                     vertexSet.add(man.getLocation());
@@ -28240,8 +28382,8 @@ export var com;
                                     vertexSet.add(man.getEnd());
                                 }
                                 else if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Panel") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Panel") >= 0)) {
-                                    for (let index1187 = man.iterator(); index1187.hasNext();) {
-                                        let vertex = index1187.next();
+                                    for (let index739 = man.iterator(); index739.hasNext();) {
+                                        let vertex = index739.next();
                                         {
                                             vertexSet.add(vertex);
                                         }
@@ -28276,8 +28418,8 @@ export var com;
                         let errorMsg = "Affine pentagon command requires two selected struts with a common vertex.";
                         let strut1 = null;
                         let strut2 = null;
-                        for (let index1188 = this.mSelection.iterator(); index1188.hasNext();) {
-                            let man = index1188.next();
+                        for (let index740 = this.mSelection.iterator(); index740.hasNext();) {
+                            let man = index740.next();
                             {
                                 this.unselect$com_vzome_core_model_Manifestation(man);
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0)) {
@@ -28338,8 +28480,8 @@ export var com;
                         ;
                         let p1 = null;
                         let p2 = null;
-                        for (let index1189 = this.mManifestations.iterator(); index1189.hasNext();) {
-                            let m = index1189.next();
+                        for (let index741 = this.mManifestations.iterator(); index741.hasNext();) {
+                            let m = index741.next();
                             {
                                 if (m != null && (m["__interfaces"] != null && m["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0 || m.constructor != null && m.constructor["__interfaces"] != null && m.constructor["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0)) {
                                     let loc = m.getLocation();
@@ -28520,8 +28662,8 @@ export var com;
                     perform() {
                         let s1 = null;
                         let s2 = null;
-                        for (let index1190 = this.mSelection.iterator(); index1190.hasNext();) {
-                            let man = index1190.next();
+                        for (let index742 = this.mSelection.iterator(); index742.hasNext();) {
+                            let man = index742.next();
                             {
                                 this.unselect$com_vzome_core_model_Manifestation(man);
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0))
@@ -28651,8 +28793,8 @@ export var com;
                             this.setOrderedSelection(true);
                         }
                         this.colorMapper.initialize(this.getRenderedSelection());
-                        for (let index1191 = this.getRenderedSelection().iterator(); index1191.hasNext();) {
-                            let man = index1191.next();
+                        for (let index743 = this.getRenderedSelection().iterator(); index743.hasNext();) {
+                            let man = index743.next();
                             {
                                 this.plan(new MapToColor.ColorMapManifestation(this, man, this.colorMapper.apply$com_vzome_core_model_Manifestation(man)));
                                 this.unselect$com_vzome_core_model_Manifestation$boolean(man, true);
@@ -28761,8 +28903,8 @@ export var com;
                     }
                     /*private*/ initialize(color) {
                         this.color = color;
-                        for (let index1192 = this.mSelection.iterator(); index1192.hasNext();) {
-                            let m = index1192.next();
+                        for (let index744 = this.mSelection.iterator(); index744.hasNext();) {
+                            let m = index744.next();
                             {
                                 if (m.isRendered())
                                     this.colorManifestation(m, color);
@@ -28942,8 +29084,8 @@ export var com;
                             return;
                         let offset = null;
                         let pointFound = false;
-                        for (let index1193 = this.mSelection.iterator(); index1193.hasNext();) {
-                            let man = index1193.next();
+                        for (let index745 = this.mSelection.iterator(); index745.hasNext();) {
+                            let man = index745.next();
                             {
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0)) {
                                     let nextPoint = man.getFirstConstruction();
@@ -29023,16 +29165,16 @@ export var com;
                      */
                     perform() {
                         let inputs = (new java.util.ArrayList());
-                        for (let index1194 = this.mSelection.iterator(); index1194.hasNext();) {
-                            let man = index1194.next();
+                        for (let index746 = this.mSelection.iterator(); index746.hasNext();) {
+                            let man = index746.next();
                             {
                                 inputs.add(man);
                                 this.unselect$com_vzome_core_model_Manifestation(man);
                             }
                         }
                         this.redo();
-                        for (let index1195 = inputs.iterator(); index1195.hasNext();) {
-                            let man = index1195.next();
+                        for (let index747 = inputs.iterator(); index747.hasNext();) {
+                            let man = index747.next();
                             {
                                 this.deleteManifestation(man);
                             }
@@ -29077,8 +29219,8 @@ export var com;
                         let s1 = null;
                         let s2 = null;
                         let s3 = null;
-                        for (let index1196 = this.mSelection.iterator(); index1196.hasNext();) {
-                            let man = index1196.next();
+                        for (let index748 = this.mSelection.iterator(); index748.hasNext();) {
+                            let man = index748.next();
                             {
                                 this.unselect$com_vzome_core_model_Manifestation(man);
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0)) {
@@ -29095,8 +29237,8 @@ export var com;
                             throw new com.vzome.core.commands.Command.Failure("three struts required");
                         this.redo();
                         let transform = new com.vzome.core.construction.ChangeOfBasis(s1, s2, s3, this.center, true);
-                        for (let index1197 = this.mManifestations.iterator(); index1197.hasNext();) {
-                            let m = index1197.next();
+                        for (let index749 = this.mManifestations.iterator(); index749.hasNext();) {
+                            let m = index749.next();
                             {
                                 if (!m.isRendered())
                                     continue;
@@ -29147,8 +29289,8 @@ export var com;
                         let strut1 = null;
                         let strut2 = null;
                         let strut3 = null;
-                        for (let index1198 = this.mSelection.iterator(); index1198.hasNext();) {
-                            let man = index1198.next();
+                        for (let index750 = this.mSelection.iterator(); index750.hasNext();) {
+                            let man = index750.next();
                             {
                                 this.unselect$com_vzome_core_model_Manifestation(man);
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0)) {
@@ -29301,8 +29443,8 @@ export var com;
                      */
                     perform() {
                         this.unselectAll();
-                        for (let index1199 = this.getVisibleStruts$java_util_function_Predicate((strut) => { return this.isAutomaticStrut(strut); }).iterator(); index1199.hasNext();) {
-                            let strut = index1199.next();
+                        for (let index751 = this.getVisibleStruts$java_util_function_Predicate((strut) => { return this.isAutomaticStrut(strut); }).iterator(); index751.hasNext();) {
+                            let strut = index751.next();
                             {
                                 this.select$com_vzome_core_model_Manifestation(strut);
                             }
@@ -29384,8 +29526,8 @@ export var com;
                                 this.vector2 = lastStrut.getEnd();
                             }
                             else {
-                                for (let index1200 = this.getSelectedConnectors().iterator(); index1200.hasNext();) {
-                                    let ball = index1200.next();
+                                for (let index752 = this.getSelectedConnectors().iterator(); index752.hasNext();) {
+                                    let ball = index752.next();
                                     {
                                         this.vector1 = this.vector2;
                                         this.vector2 = ball.getLocation();
@@ -29398,29 +29540,29 @@ export var com;
                         }
                         this.unselectAll();
                         let balls = (new java.util.TreeSet());
-                        for (let index1201 = this.getVisibleConnectors$java_util_function_Predicate((ball) => { return this.isCollinearWith(ball); }).iterator(); index1201.hasNext();) {
-                            let ball = index1201.next();
+                        for (let index753 = this.getVisibleConnectors$java_util_function_Predicate((ball) => { return this.isCollinearWith(ball); }).iterator(); index753.hasNext();) {
+                            let ball = index753.next();
                             {
                                 balls.add(ball);
                             }
                         }
                         let struts = (new java.util.TreeSet());
-                        for (let index1202 = this.getVisibleStruts$().iterator(); index1202.hasNext();) {
-                            let strut = index1202.next();
+                        for (let index754 = this.getVisibleStruts$().iterator(); index754.hasNext();) {
+                            let strut = index754.next();
                             {
                                 if (this.isCollinearWith$com_vzome_core_model_Strut(strut)) {
                                     struts.add(strut);
                                 }
                             }
                         }
-                        for (let index1203 = struts.iterator(); index1203.hasNext();) {
-                            let strut = index1203.next();
+                        for (let index755 = struts.iterator(); index755.hasNext();) {
+                            let strut = index755.next();
                             {
                                 this.select$com_vzome_core_model_Manifestation(strut);
                             }
                         }
-                        for (let index1204 = balls.iterator(); index1204.hasNext();) {
-                            let ball = index1204.next();
+                        for (let index756 = balls.iterator(); index756.hasNext();) {
+                            let ball = index756.next();
                             {
                                 this.select$com_vzome_core_model_Manifestation(ball);
                             }
@@ -29429,14 +29571,14 @@ export var com;
                         if (com.vzome.core.editor.api.ChangeSelection.logger_$LI$().isLoggable(level)) {
                             let sb = new java.lang.StringBuilder("Selected:\n");
                             let indent = "  ";
-                            for (let index1205 = struts.iterator(); index1205.hasNext();) {
-                                let strut = index1205.next();
+                            for (let index757 = struts.iterator(); index757.hasNext();) {
+                                let strut = index757.next();
                                 {
                                     sb.append(indent).append(strut.toString()).append("\n");
                                 }
                             }
-                            for (let index1206 = balls.iterator(); index1206.hasNext();) {
-                                let ball = index1206.next();
+                            for (let index758 = balls.iterator(); index758.hasNext();) {
+                                let ball = index758.next();
                                 {
                                     sb.append(indent).append(ball.toString()).append("\n");
                                 }
@@ -29572,8 +29714,8 @@ export var com;
                         if (this.mCommand.ordersSelection())
                             this.setOrderedSelection(true);
                         let constrsBefore = new com.vzome.core.construction.ConstructionList();
-                        for (let index1207 = this.mSelection.iterator(); index1207.hasNext();) {
-                            let man = index1207.next();
+                        for (let index759 = this.mSelection.iterator(); index759.hasNext();) {
+                            let man = index759.next();
                             {
                                 if (CommandEdit.logger_$LI$().isLoggable(java.util.logging.Level.FINER)) {
                                     CommandEdit.logger_$LI$().finer("----------- manifestation: " + man.toString());
@@ -29647,14 +29789,14 @@ export var com;
                         }
                         else
                             this.fail("Too many objects in the selection.");
-                        for (let index1208 = news.iterator(); index1208.hasNext();) {
-                            let c = index1208.next();
+                        for (let index760 = news.iterator(); index760.hasNext();) {
+                            let c = index760.next();
                             {
                                 this.manifestConstruction(c);
                             }
                         }
-                        for (let index1209 = selectionAfter.iterator(); index1209.hasNext();) {
-                            let cons = index1209.next();
+                        for (let index761 = selectionAfter.iterator(); index761.hasNext();) {
+                            let cons = index761.next();
                             {
                                 if (cons.failed()) {
                                     CommandEdit.logBugAccommodation("failed construction");
@@ -29775,8 +29917,8 @@ export var com;
                             }
                             if (selectedBefore.size() > (this.mManifestations.size() / 2 | 0)) {
                                 let toUnselect = (new java.util.ArrayList());
-                                for (let index1210 = this.mManifestations.iterator(); index1210.hasNext();) {
-                                    let m = index1210.next();
+                                for (let index762 = this.mManifestations.iterator(); index762.hasNext();) {
+                                    let m = index762.next();
                                     {
                                         if (!selectedBefore.contains(m))
                                             toUnselect.add(m);
@@ -29784,8 +29926,8 @@ export var com;
                                 }
                                 let edit = new com.vzome.core.edits.SelectAll(this.mEditorModel);
                                 context.performAndRecord(edit);
-                                for (let index1211 = toUnselect.iterator(); index1211.hasNext();) {
-                                    let m = index1211.next();
+                                for (let index763 = toUnselect.iterator(); index763.hasNext();) {
+                                    let m = index763.next();
                                     {
                                         edit = new com.vzome.core.edits.SelectManifestation(this.mEditorModel, m);
                                         context.performAndRecord(edit);
@@ -29795,8 +29937,8 @@ export var com;
                             else {
                                 let edit = new com.vzome.core.edits.DeselectAll(this.mEditorModel);
                                 context.performAndRecord(edit);
-                                for (let index1212 = selectedBefore.iterator(); index1212.hasNext();) {
-                                    let m = index1212.next();
+                                for (let index764 = selectedBefore.iterator(); index764.hasNext();) {
+                                    let m = index764.next();
                                     {
                                         edit = new com.vzome.core.edits.SelectManifestation(this.mEditorModel, m);
                                         context.performAndRecord(edit);
@@ -30053,8 +30195,8 @@ export var com;
                      */
                     perform() {
                         let inputs = (new java.util.ArrayList());
-                        for (let index1213 = this.mSelection.iterator(); index1213.hasNext();) {
-                            let man = index1213.next();
+                        for (let index765 = this.mSelection.iterator(); index765.hasNext();) {
+                            let man = index765.next();
                             {
                                 if (this.deleteInputs && this.tool.needsInput()) {
                                     super.unselect$com_vzome_core_model_Manifestation$boolean(man, true);
@@ -30073,8 +30215,8 @@ export var com;
                         this.redo();
                         this.tool.prepare(this);
                         if (this.tool.needsInput()) {
-                            for (let index1214 = inputs.iterator(); index1214.hasNext();) {
-                                let man = index1214.next();
+                            for (let index766 = inputs.iterator(); index766.hasNext();) {
+                                let man = index766.next();
                                 {
                                     let c = man.toConstruction();
                                     c.setColor(man.getColor());
@@ -30083,8 +30225,8 @@ export var com;
                             }
                         }
                         else {
-                            for (let index1215 = this.mManifestations.iterator(); index1215.hasNext();) {
-                                let man = index1215.next();
+                            for (let index767 = this.mManifestations.iterator(); index767.hasNext();) {
+                                let man = index767.next();
                                 {
                                     this.tool.performSelect(man, this);
                                 }
@@ -30235,13 +30377,13 @@ export var com;
                      *
                      */
                     perform() {
-                        for (let index1216 = this.mSelection.iterator(); index1216.hasNext();) {
-                            let man = index1216.next();
+                        for (let index768 = this.mSelection.iterator(); index768.hasNext();) {
+                            let man = index768.next();
                             super.unselect$com_vzome_core_model_Manifestation$boolean(man, true);
                         }
                         this.redo();
-                        for (let index1217 = this.tool.getParameters().iterator(); index1217.hasNext();) {
-                            let con = index1217.next();
+                        for (let index769 = this.tool.getParameters().iterator(); index769.hasNext();) {
+                            let con = index769.next();
                             {
                                 let man = this.manifestConstruction(con);
                                 this.select$com_vzome_core_model_Manifestation(man);
@@ -30328,8 +30470,8 @@ export var com;
                         this.center = null;
                         this.maxRadiusSquared = null;
                         let vectors = (new java.util.ArrayList());
-                        for (let index1218 = this.mSelection.iterator(); index1218.hasNext();) {
-                            let man = index1218.next();
+                        for (let index770 = this.mSelection.iterator(); index770.hasNext();) {
+                            let man = index770.next();
                             {
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0)) {
                                     vectors.add(man.getLocation());
@@ -30430,8 +30572,8 @@ export var com;
                         let p2 = null;
                         let p3 = null;
                         let p4 = null;
-                        for (let index1219 = this.mSelection.iterator(); index1219.hasNext();) {
-                            let man = index1219.next();
+                        for (let index771 = this.mSelection.iterator(); index771.hasNext();) {
+                            let man = index771.next();
                             {
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0)) {
                                     if (p1 == null) {
@@ -30584,8 +30726,8 @@ export var com;
                         this.redo();
                         let vertices = hull3d.getVertices$();
                         let pointMap = (new java.util.HashMap(vertices.length));
-                        for (let index1220 = 0; index1220 < vertices.length; index1220++) {
-                            let vertex = vertices[index1220];
+                        for (let index772 = 0; index772 < vertices.length; index772++) {
+                            let vertex = vertices[index772];
                             {
                                 let point = new com.vzome.core.construction.FreePoint(vertex);
                                 pointMap.put(vertex, point);
@@ -30593,8 +30735,8 @@ export var com;
                             }
                         }
                         let faces = hull3d.getFaces$();
-                        for (let index1221 = 0; index1221 < faces.length; index1221++) {
-                            let face = faces[index1221];
+                        for (let index773 = 0; index773 < faces.length; index773++) {
+                            let face = faces[index773];
                             {
                                 let points = (s => { let a = []; while (s-- > 0)
                                     a.push(null); return a; })(face.length);
@@ -30672,8 +30814,8 @@ export var com;
                             a.push(null); return a; })(hull2d.length);
                         let p = 0;
                         let pointMap = (new java.util.HashMap(hull2d.length));
-                        for (let index1222 = 0; index1222 < hull2d.length; index1222++) {
-                            let vertex = hull2d[index1222];
+                        for (let index774 = 0; index774 < hull2d.length; index774++) {
+                            let vertex = hull2d[index774];
                             {
                                 let point = new com.vzome.core.construction.FreePoint(vertex);
                                 pointMap.put(vertex, point);
@@ -30952,8 +31094,8 @@ export var com;
                      * @param {com.vzome.core.editor.api.ChangeManifestations} applyTool
                      */
                     performEdit(c, applyTool) {
-                        for (let index1223 = 0; index1223 < this.transforms.length; index1223++) {
-                            let transform = this.transforms[index1223];
+                        for (let index775 = 0; index775 < this.transforms.length; index775++) {
+                            let transform = this.transforms[index775];
                             {
                                 let result = transform.transform$com_vzome_core_construction_Construction(c);
                                 if (result == null)
@@ -31042,8 +31184,8 @@ export var com;
                         let p1 = null;
                         let p2 = null;
                         let p3 = null;
-                        for (let index1224 = this.mSelection.iterator(); index1224.hasNext();) {
-                            let man = index1224.next();
+                        for (let index776 = this.mSelection.iterator(); index776.hasNext();) {
+                            let man = index776.next();
                             {
                                 this.unselect$com_vzome_core_model_Manifestation(man);
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0)) {
@@ -31341,8 +31483,8 @@ export var com;
                         if (this.mSelection.size() === 0)
                             this.bookmarkedConstructions.add(new com.vzome.core.construction.FreePoint(this.mManifestations.getField().origin(3)));
                         else
-                            for (let index1225 = this.mSelection.iterator(); index1225.hasNext();) {
-                                let man = index1225.next();
+                            for (let index777 = this.mSelection.iterator(); index777.hasNext();) {
+                                let man = index777.next();
                                 {
                                     let result = duper.duplicateConstruction(man);
                                     this.bookmarkedConstructions.add(result);
@@ -31367,8 +31509,8 @@ export var com;
                             edit.manifestConstruction(new com.vzome.core.construction.FreePoint(this.mManifestations.getField().origin(3)));
                         }
                         else
-                            for (let index1226 = this.bookmarkedConstructions.iterator(); index1226.hasNext();) {
-                                let con = index1226.next();
+                            for (let index778 = this.bookmarkedConstructions.iterator(); index778.hasNext();) {
+                                let con = index778.next();
                                 {
                                     edit.manifestConstruction(con);
                                 }
@@ -31527,8 +31669,8 @@ export var com;
                         let p = c;
                         let loc = p.getLocation();
                         let duper = new com.vzome.core.editor.Duplicator(applyTool, loc);
-                        for (let index1227 = this.bookmarkedSelection.iterator(); index1227.hasNext();) {
-                            let man = index1227.next();
+                        for (let index779 = this.bookmarkedSelection.iterator(); index779.hasNext();) {
+                            let man = index779.next();
                             {
                                 duper.duplicateManifestation(man);
                             }
@@ -31758,8 +31900,8 @@ export var com;
                     checkSelection(prepareTool) {
                         let center = null;
                         if (!this.isAutomatic())
-                            for (let index1228 = this.mSelection.iterator(); index1228.hasNext();) {
-                                let man = index1228.next();
+                            for (let index780 = this.mSelection.iterator(); index780.hasNext();) {
+                                let man = index780.next();
                                 {
                                     if (prepareTool)
                                         this.unselect$com_vzome_core_model_Manifestation(man);
@@ -31839,8 +31981,8 @@ export var com;
                          * @return {boolean}
                          */
                         bindParameters(selection) {
-                            for (let index1229 = selection.iterator(); index1229.hasNext();) {
-                                let man = index1229.next();
+                            for (let index781 = selection.iterator(); index781.hasNext();) {
+                                let man = index781.next();
                                 this.center = man;
                             }
                             return true;
@@ -31889,8 +32031,8 @@ export var com;
                     checkSelection(prepareTool) {
                         let center = null;
                         let axis = null;
-                        for (let index1230 = this.mSelection.iterator(); index1230.hasNext();) {
-                            let man = index1230.next();
+                        for (let index782 = this.mSelection.iterator(); index782.hasNext();) {
+                            let man = index782.next();
                             {
                                 if (prepareTool)
                                     this.unselect$com_vzome_core_model_Manifestation(man);
@@ -32123,8 +32265,8 @@ export var com;
                          */
                         bindParameters(selection) {
                             let symmetry = this.getSymmetry();
-                            for (let index1231 = selection.iterator(); index1231.hasNext();) {
-                                let man = index1231.next();
+                            for (let index783 = selection.iterator(); index783.hasNext();) {
+                                let man = index783.next();
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0)) {
                                     let axisStrut = man;
                                     let vector = axisStrut.getOffset();
@@ -32231,8 +32373,8 @@ export var com;
                         let correct = true;
                         let hasPanels = false;
                         if (!this.isAutomatic())
-                            for (let index1232 = this.mSelection.iterator(); index1232.hasNext();) {
-                                let man = index1232.next();
+                            for (let index784 = this.mSelection.iterator(); index784.hasNext();) {
+                                let man = index784.next();
                                 {
                                     if (prepareTool)
                                         this.unselect$com_vzome_core_model_Manifestation(man);
@@ -32482,8 +32624,8 @@ export var com;
                         let index = 0;
                         let correct = true;
                         let center = null;
-                        for (let index1233 = this.mSelection.iterator(); index1233.hasNext();) {
-                            let man = index1233.next();
+                        for (let index785 = this.mSelection.iterator(); index785.hasNext();) {
+                            let man = index785.next();
                             {
                                 if (prepareTool)
                                     this.unselect$com_vzome_core_model_Manifestation(man);
@@ -32606,8 +32748,8 @@ export var com;
                     perform() {
                         let plane = null;
                         let line = null;
-                        for (let index1234 = this.mSelection.iterator(); index1234.hasNext();) {
-                            let man = index1234.next();
+                        for (let index786 = this.mSelection.iterator(); index786.hasNext();) {
+                            let man = index786.next();
                             {
                                 this.unselect$com_vzome_core_model_Manifestation(man);
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Panel") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Panel") >= 0)) {
@@ -32773,8 +32915,8 @@ export var com;
                             axis = new com.vzome.core.construction.SegmentJoiningPoints(center, p2);
                         }
                         else
-                            for (let index1235 = this.mSelection.iterator(); index1235.hasNext();) {
-                                let man = index1235.next();
+                            for (let index787 = this.mSelection.iterator(); index787.hasNext();) {
+                                let man = index787.next();
                                 {
                                     if (prepareTool)
                                         this.unselect$com_vzome_core_model_Manifestation(man);
@@ -32923,8 +33065,8 @@ export var com;
                         let p2 = null;
                         let correct = true;
                         if (!this.isAutomatic())
-                            for (let index1236 = this.mSelection.iterator(); index1236.hasNext();) {
-                                let man = index1236.next();
+                            for (let index788 = this.mSelection.iterator(); index788.hasNext();) {
+                                let man = index788.next();
                                 {
                                     if (prepareTool)
                                         this.unselect$com_vzome_core_model_Manifestation(man);
@@ -33116,8 +33258,8 @@ export var com;
                         let center = null;
                         let axisStrut = null;
                         let correct = true;
-                        for (let index1237 = this.mSelection.iterator(); index1237.hasNext();) {
-                            let man = index1237.next();
+                        for (let index789 = this.mSelection.iterator(); index789.hasNext();) {
+                            let man = index789.next();
                             {
                                 if (prepareTool)
                                     this.unselect$com_vzome_core_model_Manifestation(man);
@@ -33288,8 +33430,8 @@ export var com;
                          */
                         bindParameters(selection) {
                             let symmetry = this.getSymmetry();
-                            for (let index1238 = selection.iterator(); index1238.hasNext();) {
-                                let man = index1238.next();
+                            for (let index790 = selection.iterator(); index790.hasNext();) {
+                                let man = index790.next();
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0)) {
                                     let axisStrut = man;
                                     let vector = axisStrut.getOffset();
@@ -33369,8 +33511,8 @@ export var com;
                         let center = null;
                         let correct = true;
                         let hasPanels = false;
-                        for (let index1239 = this.mSelection.iterator(); index1239.hasNext();) {
-                            let man = index1239.next();
+                        for (let index791 = this.mSelection.iterator(); index791.hasNext();) {
+                            let man = index791.next();
                             {
                                 if (prepareTool)
                                     this.unselect$com_vzome_core_model_Manifestation(man);
@@ -33493,8 +33635,8 @@ export var com;
                             let symmetry = this.getSymmetry();
                             let offset1 = null;
                             let offset2 = null;
-                            for (let index1240 = selection.iterator(); index1240.hasNext();) {
-                                let man = index1240.next();
+                            for (let index792 = selection.iterator(); index792.hasNext();) {
+                                let man = index792.next();
                                 if (man != null && (man["__interfaces"] != null && man["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0 || man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0)) {
                                     let strut = man;
                                     if (offset1 == null)
@@ -33563,7 +33705,7 @@ export var com;
         })(core = vzome.core || (vzome.core = {}));
     })(vzome = com.vzome || (com.vzome = {}));
 })(com || (com = {}));
-try {
+
 com.vzome.core.editor.CommandEdit.loadAndPerformLgger_$LI$();
 com.vzome.core.editor.CommandEdit.logger_$LI$();
 com.vzome.core.commands.CommandTetrahedralSymmetry.ATTR_SIGNATURE_$LI$();
@@ -33636,7 +33778,3 @@ com.vzome.core.render.Colors.HIGHLIGHT_MAC_$LI$();
 com.vzome.core.render.Colors.HIGHLIGHT_$LI$();
 com.vzome.core.render.Colors.PANEL_$LI$();
 com.vzome.core.render.Colors.BACKGROUND_$LI$();
-    
-} catch (error) {
-    console.log( error )
-}


### PR DESCRIPTION
I removed cls.isAnonymousClass() from ColorMappers interface. This was
causing an error during load for the JSweet-transpiled module.

I also removed a silly idiom for getting a fully-qualified class name
for the ExportedVEFStrutGeometry LOGGER init.  JSweet cannot do
Error.getStackTrace().

This does NOT address Jackpike's problem with setting objects to a black
color.  I suspect that the color value is acting "falsy".