### PR TITLE
Fix a bug in SelectParallelStruts

### DIFF
--- a/core/src/main/java/com/vzome/core/edits/SelectParallelStruts.java
+++ b/core/src/main/java/com/vzome/core/edits/SelectParallelStruts.java
@@ -76,9 +76,16 @@ public class SelectParallelStruts extends ChangeManifestations
         }
         unselectAll();
 
-        int opposite = ( axis .getSense() + 1 ) % 2;
-        Axis oppositeAxis = orbit. getAxis( opposite, axis .getOrientation() );
-
+        // The logic for getting oppositeAxis is copied from Direction.getAxis(AlgebraicVector)
+        // TODO: We should probably have a symmetry method to ensure that we get the opposite axis correctly 
+        // instead of duplicating this code, or worse yet, forgetting to copy it
+        // and not considering the principalReflection when applicable (e.g. any antiprism symmetry). 
+        Axis oppositeAxis = symmetry.getSymmetry().getPrincipalReflection() == null
+            // the traditional way... anti-parallel means just flip the sense
+            ? orbit.getAxis( (( axis .getSense() + 1 ) % 2), axis .getOrientation() )
+            // anti-parallel mean flip inbound to outbound or vice-versa
+            : orbit.getAxis( axis .getSense(), axis .getOrientation(), ! axis .isOutbound() );
+            
         for (Strut strut : getStruts()) {
             Axis strutAxis = symmetry.getAxis(strut .getOffset());
             if (strutAxis != null && strutAxis.getOrbit().equals(orbit)) {

--- a/core/src/main/java/com/vzome/core/math/Polyhedron.java
+++ b/core/src/main/java/com/vzome/core/math/Polyhedron.java
@@ -229,6 +229,7 @@ public class Polyhedron implements Cloneable
 
         public Face createReverse()
         {
+            @SuppressWarnings("unchecked")
             ArrayList<Integer> vertices = (ArrayList<Integer>) this .clone();
             Collections .reverse( vertices );
             Face mirrorFace = new Face();

--- a/core/src/main/java/com/vzome/core/math/symmetry/Axis.java
+++ b/core/src/main/java/com/vzome/core/math/symmetry/Axis.java
@@ -32,7 +32,7 @@ public class Axis
      * relative to mSense==PLUS, but probably a specific reflection.
      * Each zone is oriented, and the inbound and outbound axes DO have opposite normals.
      * 
-     * Typical group, where getZoneInversion() == null:
+     * Typical group, where getPrincipalReflection() == null:
      * 
      *    sense    outbound        normal
      *  --------+------------+------------------


### PR DESCRIPTION
Fix a bug in SelectParallelStruts and suppress one warning as described in the individual unrelated commits. This fix may or may not affect the ability to render any given model depending how that model uses the selected results of this command. The gradle regression command runs clean as do existing unit tests. I did not write a new unit test for this fix, but manually tested it in the model where I discovered it. This fix should probably be run against the full regression suite. Note that it only has the potential to affect models using the SelectParallelStruts command with antiprism symmety in heptagonal or sqrtPhi fields and ultimately may not even affect them in any actual existing models.