### PR TITLE
Finally found a CSS approach for the debugger

### DIFF
--- a/online/src/App.jsx
+++ b/online/src/App.jsx
@@ -19,32 +19,18 @@ const debug = queryParams.get( 'debug' ) === 'true'
 
 const store = createBundleStore( profile, [ thunk ] );
 
-/* CSS GRID DEBUGGING TIP:
-  The DesignEditor (or the r3f Canvas inside it) will lock in an absolute height
-  on initial render.  This means that adjusting CSS layout attributes
-  on the Debugger component within the browser's debug tools may not
-  have the expected result.  For tweaking the Debugger layout, try
-  setting the 2nd Grid item to height:700px, so it won't flex initially.
-*/
-const useStyles = makeStyles((theme) => ({
-  debugDebuggerGrid: {
-    height: '750px',  // uncomment this to debug the Debugger grid layout; see above
-  },
-}))
-
 const App = () =>
 {
-  const classes = useStyles();
   return (
     <Provider store={store}>
         <VZomeAppBar/>
         { debug ?
           <div style={{ flex: '1', height: '100%' }}>
-            <Grid id='debug-main' container spacing={0}>
+            <Grid id='debug-main' container spacing={0} style={{ height: '100%' }}>
               <Grid id='debugger-grid-item' item xs={4}>
                 <Debugger/>
               </Grid>
-              <Grid item xs={8} className={classes.debugDebuggerGrid}>
+              <Grid item xs={8}>
                 <DesignEditor/>
               </Grid>
             </Grid>

--- a/online/src/components/debugger.jsx
+++ b/online/src/components/debugger.jsx
@@ -45,18 +45,6 @@ const StyledTableRow = withStyles((theme) => ({
   },
 }))(TableRow);
 
-const useStyles = makeStyles((theme) => ({
-  debuggerSource: {
-    flex: '1 1 auto',
-    display: 'flex',
-    flexDirection: 'column',
-    maxHeight: '720px'  // This is a horrible hack, but I haven't found anything else to control the expanded tree item height
-  },
-  treeview: {
-    overflow: 'auto',
-  },
-}))
-
 const useTreeItemStyles = makeStyles((theme) => ({
   root: {
     color: theme.palette.text.secondary,
@@ -146,7 +134,6 @@ function StyledTreeItem(props) {
 
 const Debugger = ( { data, current, branches, designName, doDebug } )  =>
 {
-  const classes = useStyles();
   const [ element, setElement ] = useState( null )
 
   const onLabelClick = element => event =>
@@ -174,9 +161,14 @@ const Debugger = ( { data, current, branches, designName, doDebug } )  =>
   if ( !data )
     return null
 
+  // I don't know why this styling works to fill the vertical space, without letting
+  //  the TreeView force everything to overflow, but it works.  I found it in
+  //  this JSFiddle:  https://jsfiddle.net/sgxpqc6b/9/
+  //  from a comment on this post:  https://www.whitebyte.info/programming/css/how-to-make-a-div-take-the-remaining-height
+  //  Note that I had to add an extra div around the TreeView.
   return (
-    <Grid container direction='column'>
-      <Grid item>
+    <Grid container direction='column' style={{ display: 'table', height: '100%' }}>
+      <Grid item style={{ display: 'table-row' }}>
         <Toolbar id="debugger-tools" variant='dense'>
           <Tooltip title="Step in" aria-label="step-in">
             <IconButton color="secondary" aria-label="step-in" onClick={()=>doDebug(designName, vZomeJava.Step.IN)}>
@@ -200,16 +192,19 @@ const Debugger = ( { data, current, branches, designName, doDebug } )  =>
           </Tooltip>
         </Toolbar>
       </Grid>
-      <Grid item id="debugger-source" className={classes.debuggerSource}>
-        <TreeView className={classes.treeview} selected={current} expanded={expanded}
-          defaultCollapseIcon={<ExpandMoreIcon />}
-          defaultExpanded={ expanded }
-          defaultExpandIcon={<ChevronRightIcon />}
-        >
-          {renderTree( data, '' ) }
-        </TreeView>
+      <Grid item id="debugger-source" style={{ display: 'table-row', height: '100%' }}>
+        <div style={{ width: '100%', height: '100%', position: 'relative' }}>
+          <TreeView style={{ overflow: 'auto', position: 'absolute', top: 0, bottom: 0, left: 0, right: 0 }}
+            selected={current} expanded={expanded}
+            defaultCollapseIcon={<ExpandMoreIcon />}
+            defaultExpanded={ expanded }
+            defaultExpandIcon={<ChevronRightIcon />}
+          >
+            {renderTree( data, '' ) }
+          </TreeView>
+        </div>
       </Grid>
-      <Grid item style={{ flex: 0, height: '100px' }}>
+      <Grid item style={{ display: 'table-row' }}>
         <TableContainer component={Paper}>
           <Table size="small" aria-label="command attributes">
             <TableHead>


### PR DESCRIPTION
Now the debugger and the canvas both fill the vertical space, and only
the TreeView gets a scrollbar when needed.

See the comment in debugger.jsx for where I found the solution.