### PR TITLE
Fixed a regression recently introduced.

### DIFF
--- a/react-library/src/components/hooks.js
+++ b/react-library/src/components/hooks.js
@@ -98,7 +98,7 @@ export const useInstanceShaper = ( shown, selected, shaper ) =>
         const instances = []
         const tryToShape = ( instance, selected ) => {
           try {
-            instances.push( { ...shapeInstance( instance ), selected } )
+            instance && instances.push( { ...shapeInstance( instance ), selected } )
           } catch (error) {
             console.log( `Failed to shape instance: ${instance.id}` );
           }

--- a/react-library/src/components/urlviewer.jsx
+++ b/react-library/src/components/urlviewer.jsx
@@ -13,7 +13,7 @@ export const MeshGeometry = ({ shown, selected, shapeRenderer, highlightBall, ha
   const { shapes, instances } = useInstanceShaper( shown, selected, shaper )
   const ref = useRef()
   useEffect( () => {
-    if ( embedding ) {
+    if ( embedding && ref.current && ref.current.matrix ) {
       const m = new Matrix4()
       m.set( ...embedding )
       m.transpose()


### PR DESCRIPTION
The embedding support created a regression, when there is no matrix yet
for the group for an instance.

The defect in hooks.js may not have been a regression; this is probably
still just a symptom of a deeper issue, when the instances array can
accumulate null entries.