### PR TITLE
Removed cast functions from Parallelepiped.java

### DIFF
--- a/core/src/main/java/com/vzome/core/edits/Parallelepiped.java
+++ b/core/src/main/java/com/vzome/core/edits/Parallelepiped.java
@@ -35,11 +35,11 @@ public class Parallelepiped extends ChangeManifestations
             unselect( man );
             if ( man instanceof Strut ) {
                 if ( strut1 == null ) {
-                    strut1 = Strut.class.cast(man);
+                    strut1 = (Strut)(man);
                 } else if ( strut2 == null ) {
-                    strut2 = Strut.class.cast(man);
+                    strut2 = (Strut)(man);
                 } else if ( strut3 == null ) {
-                	strut3 = Strut.class.cast(man);
+                	strut3 = (Strut)(man);
                 } else
                     fail( errorMsg );
             } else
@@ -52,9 +52,9 @@ public class Parallelepiped extends ChangeManifestations
 
         // first, find the offsets and the endpoint vectors: v1, v2, v3
         // Reverse the offset direction(s) if necessary so the two offsets have a common starting point at v0
-        Segment s1 = Segment.class.cast(strut1.getFirstConstruction());
-        Segment s2 = Segment.class.cast(strut2.getFirstConstruction());
-        Segment s3 = Segment.class.cast(strut3.getFirstConstruction());
+        Segment s1 = (Segment)(strut1.getFirstConstruction());
+        Segment s2 = (Segment)(strut2.getFirstConstruction());
+        Segment s3 = (Segment)(strut3.getFirstConstruction());
         AlgebraicVector offset1 = s1 .getOffset();
         AlgebraicVector offset2 = s2 .getOffset();
         AlgebraicVector offset3 = s3 .getOffset();


### PR DESCRIPTION
This removes six transpile errors for JSweet.