### PR TITLE
Unified both JSON import event interfaces into ConstructionChanges

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -486,8 +486,7 @@ jsweet {
         'com/vzome/core/model/Strut.java',
         'com/vzome/core/model/Panel.java',
         'com/vzome/core/model/RealizedModel.java',
-        'com/vzome/core/model/SimpleMeshJson.java',
-        'com/vzome/core/model/ColoredMeshJson.java',
+        'com/vzome/core/model/JsonImportEvents.java',
 
         'com/vzome/core/editor/api/*.java',
 
@@ -550,6 +549,8 @@ jsweet {
 
     //     'com/vzome/core/model/*Impl.java',
 
+        'com/vzome/core/edits/ImportSimpleMeshJson.java',
+        'com/vzome/core/edits/ImportColoredMeshJson.java',
         'com/vzome/core/edits/DodecagonSymmetry.java',
         'com/vzome/core/edits/GhostSymmetry24Cell.java',
         'com/vzome/core/edits/Symmetry4d.java',

--- a/core/src/main/java/com/vzome/core/construction/ConstructionChanges.java
+++ b/core/src/main/java/com/vzome/core/construction/ConstructionChanges.java
@@ -1,11 +1,9 @@
 
-
 package com.vzome.core.construction;
 
-/**
- * @author Scott Vorthmann
- */
 public interface ConstructionChanges
 {
     void constructionAdded( Construction c );
+
+    void constructionAdded( Construction c, Color color );
 }

--- a/core/src/main/java/com/vzome/core/editor/CommandEdit.java
+++ b/core/src/main/java/com/vzome/core/editor/CommandEdit.java
@@ -21,6 +21,7 @@ import com.vzome.core.commands.CommandHide;
 import com.vzome.core.commands.CommandObliquePentagon;
 import com.vzome.core.commands.CommandTransform;
 import com.vzome.core.commands.XmlSaveFormat;
+import com.vzome.core.construction.Color;
 import com.vzome.core.construction.Construction;
 import com.vzome.core.construction.ConstructionChanges;
 import com.vzome.core.construction.ConstructionList;
@@ -360,6 +361,12 @@ public class CommandEdit extends ChangeManifestations
     {
         @Override
         public void constructionAdded( Construction c )
+        {
+            add( c );
+        }
+
+        @Override
+        public void constructionAdded( Construction c, Color color )
         {
             add( c );
         }

--- a/core/src/main/java/com/vzome/core/editor/api/ManifestConstructions.java
+++ b/core/src/main/java/com/vzome/core/editor/api/ManifestConstructions.java
@@ -5,14 +5,12 @@ import java.util.ArrayList;
 import com.vzome.core.construction.Color;
 import com.vzome.core.construction.Construction;
 import com.vzome.core.construction.ConstructionChanges;
-import com.vzome.core.model.ColoredMeshJson;
 import com.vzome.core.model.Manifestation;
-import com.vzome.core.model.SimpleMeshJson;
 
 // TODO use this in CommandEdit as well
 //
 @SuppressWarnings("serial")
-public class ManifestConstructions extends ArrayList<Construction> implements ConstructionChanges, ColoredMeshJson.Events, SimpleMeshJson.Events
+public class ManifestConstructions extends ArrayList<Construction> implements ConstructionChanges
 {
 	private final ChangeManifestations edit;
 

--- a/core/src/main/java/com/vzome/core/model/ColoredMeshJson.java
+++ b/core/src/main/java/com/vzome/core/model/ColoredMeshJson.java
@@ -22,7 +22,7 @@ import com.vzome.core.algebra.AlgebraicField;
 import com.vzome.core.algebra.AlgebraicNumber;
 import com.vzome.core.algebra.AlgebraicVector;
 import com.vzome.core.construction.Color;
-import com.vzome.core.construction.Construction;
+import com.vzome.core.construction.ConstructionChanges;
 import com.vzome.core.construction.FreePoint;
 import com.vzome.core.construction.Point;
 import com.vzome.core.construction.Polygon;
@@ -129,12 +129,7 @@ public class ColoredMeshJson
         generator.close();
     }
     
-    public interface Events
-    {
-        void constructionAdded( Construction c, Color color );
-    }
-
-    public static void parse( String json, AlgebraicVector offset, Projection projection, Events events, AlgebraicField.Registry registry ) throws IOException
+    public static void parse( String json, AlgebraicVector offset, Projection projection, ConstructionChanges events, AlgebraicField.Registry registry ) throws IOException
     {
         ObjectMapper mapper = new ObjectMapper();
         JsonNode node = mapper .readTree( json );

--- a/core/src/main/java/com/vzome/core/model/SimpleMeshJson.java
+++ b/core/src/main/java/com/vzome/core/model/SimpleMeshJson.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.vzome.core.algebra.AlgebraicField;
 import com.vzome.core.algebra.AlgebraicNumber;
 import com.vzome.core.algebra.AlgebraicVector;
-import com.vzome.core.construction.Construction;
+import com.vzome.core.construction.ConstructionChanges;
 import com.vzome.core.construction.FreePoint;
 import com.vzome.core.construction.Point;
 import com.vzome.core.construction.Polygon;
@@ -116,12 +116,7 @@ public class SimpleMeshJson
         generator.close();
     }
     
-    public interface Events
-    {
-        void constructionAdded( Construction c );
-    }
-
-    public static void parse( String json, AlgebraicVector offset, Projection projection, Events events, AlgebraicField.Registry registry ) throws IOException
+    public static void parse( String json, AlgebraicVector offset, Projection projection, ConstructionChanges events, AlgebraicField.Registry registry ) throws IOException
     {
         ObjectMapper mapper = new ObjectMapper();
         JsonNode node = mapper .readTree( json );

--- a/core/src/test/java/com/vzome/core/construction/VefToModelTest.java
+++ b/core/src/test/java/com/vzome/core/construction/VefToModelTest.java
@@ -608,5 +608,11 @@ public class VefToModelTest
         {
             add( c );
         }
+
+        @Override
+        public void constructionAdded( Construction c, Color color )
+        {
+            add( c );
+        }
     }
 }

--- a/core/src/test/java/com/vzome/core/editor/ApplicationTest.java
+++ b/core/src/test/java/com/vzome/core/editor/ApplicationTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import com.vzome.core.algebra.AlgebraicField;
 import com.vzome.core.construction.Color;
 import com.vzome.core.construction.Construction;
+import com.vzome.core.construction.ConstructionChanges;
 import com.vzome.core.math.Projection;
 import com.vzome.core.model.ColoredMeshJson;
 
@@ -77,13 +78,13 @@ public class ApplicationTest {
                 "  } ]\n" + 
                 "}";
         Application application = new Application( false, null, new Properties() );
-        ColoredMeshJson.Events events = new ColoredMeshJson.Events()
+        ConstructionChanges events = new ConstructionChanges()
         {    
             @Override
-            public void constructionAdded( Construction c, Color color )
-            {
-                // TODO Auto-generated method stub
-            }
+            public void constructionAdded( Construction c, Color color ) {}
+
+            @Override
+            public void constructionAdded(Construction c) {}
         };
         try {
             AlgebraicField field = application .getField( "golden" );

--- a/core/src/test/java/com/vzome/core/math/quickhull/TestSimpleExample.java
+++ b/core/src/test/java/com/vzome/core/math/quickhull/TestSimpleExample.java
@@ -8,6 +8,7 @@ import com.vzome.core.algebra.AlgebraicField;
 import com.vzome.core.algebra.AlgebraicVector;
 import com.vzome.core.algebra.PentagonField;
 import com.vzome.core.commands.Command.Failure;
+import com.vzome.core.construction.Color;
 import com.vzome.core.construction.Construction;
 import com.vzome.core.construction.ConstructionChanges;
 import com.vzome.core.construction.Point;
@@ -37,6 +38,12 @@ public class TestSimpleExample {
                     add( polygon.getVertex(i) );
                 }
             }
+        }
+
+        @Override
+        public void constructionAdded( Construction c, Color color )
+        {
+            this.constructionAdded( c );
         }
     }
     


### PR DESCRIPTION
This enabled me to decouple ManifestConstructions from the JSON importers,
so I could remove four classes from the JSweet transpile, and eliminate
52 errors.