### PR TITLE
GitHub sharing now handles spaces in filenames

### DIFF
--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -101,6 +101,7 @@ sourceSets {
             // listed alphabetically
             include '**/*.gif'
             include '**/*.jpg'
+            include '**/*.md'
             include '**/*.pdf'
             include '**/*.png'
             include '**/*.properties'

--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentMenuBar.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentMenuBar.java
@@ -187,7 +187,7 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
         
         menu .addSeparator(); // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-        menu .add( enableIf( canSave, createMenuItem( "Share as Github Gist...", "Share" ) ) );
+        menu .add( enableIf( canSave, createMenuItem( "Share using GitHub...", "Share" ) ) );
 
         menu .addSeparator(); // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/desktop/src/main/java/org/vorthmann/zome/ui/HyperlinkPanel.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/HyperlinkPanel.java
@@ -32,6 +32,11 @@ public class HyperlinkPanel extends JPanel
 
     public HyperlinkPanel( String label, Controller controller )
     {
+        this( label, controller, true );
+    }
+
+    public HyperlinkPanel( String label, Controller controller, boolean showButton )
+    {
         super();
         setLayout( new BorderLayout() );
         JLabel hyperlink = new JLabel( label );
@@ -39,7 +44,13 @@ public class HyperlinkPanel extends JPanel
         hyperlink .setPreferredSize( new Dimension( 250, 30 ) );
         this .add( hyperlink, BorderLayout.CENTER );
         copyButton = new JButton( "Copy URL" );
-        this .add( copyButton, BorderLayout.EAST );
+        if ( showButton )
+            this .add( copyButton, BorderLayout.EAST );
+        else {
+            JPanel spacer = new JPanel();
+            spacer .setMinimumSize( new Dimension( 150, 20 ) );
+            this .add( spacer, BorderLayout.EAST );
+        }
         copyButton .addActionListener( new ActionListener()
         {
             @Override

--- a/desktop/src/main/resources/org/vorthmann/zome/ui/githubReadmeBoilerplate.md
+++ b/desktop/src/main/resources/org/vorthmann/zome/ui/githubReadmeBoilerplate.md
@@ -1,0 +1,57 @@
+## Your vZome design is uploaded
+
+### [Embeddable vZome Online view][embed]
+
+***This is the best link to share***!  The link is *embeddable* because it will render in social media (e.g. Discord, Twitter, FaceBook...) with a proper title and a preview image.
+
+There is just one minor hitch: you must wait a bit because the embeddable link is only 
+ready after GitHub Pages has refreshed and is ready to serve up
+your design file and the thumbnail image.
+That process typically only takes a few seconds, but it may take longer.
+If you use the link too soon, vZome Online will show an error: "Unable to parse XML from...".
+If this happens, just wait a bit and reload the vZome Online page.
+
+---
+
+### [Quick vZome Online view][quick]
+
+Use this link only if you're in a hurry, and you don't care about link embedding with a preview image.  If you can see this page, then the link will work immediately.
+
+---
+
+### [Raw vZome file][raw]
+
+This is just the link to the raw vZome file, and is **not** good for
+sharing on social media.
+It is not good for downloading, either.
+Honestly, you probably don't want this, though it could be used from either
+vZome desktop ("Open URL...") or vZome Online ("Remote vZome URL").
+
+---
+
+### [Download-friendly raw vZome file][rawPages]
+
+This link is slightly better for direct downloading.
+However, like the embeddable vZome Online link, it won't be ready until
+GitHub Pages has refreshed after your upload.
+It will also work in vZome desktop and vZome Online.
+
+---
+
+### [Github source folder][source]
+
+Use this to navigate to the folder in your `vzome-sharing` GitHub repository
+that contains your uploaded vZome file, as well as this README.
+
+---
+
+### [Github Pages version][pages]
+
+This README file will also be served by GitHub Pages (after it refreshes),
+so you can use this link to view the same content there.
+If you want to replace this README with a proper description of your shared model,
+this is how you would share that web page.
+
+---
+
+![Image]


### PR DESCRIPTION
I also added a final "success" screen to the dialog, to give the user a
copy gesture and a simpler interface than the full README page in GitHub.