### PR TITLE
No longer using GitHub Pages

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/ui/ShareDialog.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/ShareDialog.java
@@ -401,27 +401,18 @@ public class ShareDialog extends EscapeDialog
             String baseUrl = "https://raw.githubusercontent.com/" + username + "/" + REPO_NAME + "/" + BRANCH_NAME + "/" + timestampPath;
             String rawUrl = baseUrl + encodedName + "/" + this .fileName;
 
-            String pagesBaseUrl = "https://" + username + ".github.io/" + REPO_NAME + "/" + timestampPath;
-            String pagesRawUrl = pagesBaseUrl + encodedName + "/" + this .fileName;
-
-            // I'm cheating a bit here, not encoding the entire rawUrl and pagesRawUrl, so that the
-            //  quickUrl and slowUrl are not so hideous.  It doesn't seem to matter, as long as
+            // I'm cheating a bit here, not encoding the entire rawUrl, so that the
+            //  embedUrl is not so hideous.  It doesn't seem to matter, as long as
             //  the path and name are encoded (or doubly encoded) correctly.
             String encodedRawTail = URLEncoder.encode( encodedName,    StandardCharsets.UTF_8.toString() )
                             + "/" + URLEncoder.encode( this .fileName, StandardCharsets.UTF_8.toString() );
 
-            String quickUrl = "https://vzome.com/app/?url=" + baseUrl + encodedRawTail;
-            String slowUrl  = "https://vzome.com/app/embed.py?url=" + pagesBaseUrl + encodedRawTail;
+            String embedUrl  = "https://vzome.com/app/embed.py?url=" + baseUrl + encodedRawTail;
             String gitUrl   = "https://github.com/" + username + "/" + REPO_NAME + "/tree/" + BRANCH_NAME + "/" + path;
-            String pagesUrl = "https://" + username + ".github.io/" + REPO_NAME + "/" + path;
             
             String markdown = this.readmeBoilerplate + "(<" + imageFileName + ">)\n\n\n";
-            markdown += "[quick]: <" + quickUrl + ">\n";
-            markdown += "[embed]: <" + slowUrl + ">\n";
-            markdown += "[source]: <" + gitUrl + ">\n";
-            markdown += "[pages]: <" + pagesUrl + ">\n";
+            markdown += "[embed]: <" + embedUrl + ">\n";
             markdown += "[raw]: <" + rawUrl + ">\n";
-            markdown += "[rawPages]: <" + pagesRawUrl + ">\n";
             this .addFile( entries, path + "README.md", markdown, Blob.ENCODING_UTF8 );                
 
             Tree newTree = dataService .createTree( this .repo, entries, (baseTree==null)? null : baseTree.getSha() );
@@ -461,8 +452,8 @@ public class ShareDialog extends EscapeDialog
             reference .setObject( commitResource );
             dataService .editReference( this .repo, reference, true );
             this .gitUrl = gitUrl;
-            this .embedUrl = slowUrl;
-            controller .setProperty( "clipboard", slowUrl );
+            this .embedUrl = embedUrl;
+            controller .setProperty( "clipboard", embedUrl );
         }
         catch (Exception e) {
             e .printStackTrace();

--- a/desktop/src/main/java/org/vorthmann/zome/ui/SymmetryToolbarsPanel.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/SymmetryToolbarsPanel.java
@@ -74,7 +74,7 @@ public class SymmetryToolbarsPanel extends JPanel
             firstToolbar .add( newToolButton( symmController, transformFactory ) );
 		}                
 
-        AbstractButton shareButton = makeEditButton( enabler, "Share", "Share as a Github gist\nfor vZome Online" );
+        AbstractButton shareButton = makeEditButton( enabler, "Share", "Share using Github and vZome Online" );
         topRow .add( shareButton, BorderLayout.EAST );
         controller .addPropertyListener( new PropertyChangeListener()
         {

--- a/desktop/src/main/resources/org/vorthmann/zome/ui/githubReadmeBoilerplate.md
+++ b/desktop/src/main/resources/org/vorthmann/zome/ui/githubReadmeBoilerplate.md
@@ -1,21 +1,8 @@
 ## Your vZome design is uploaded
 
-### [Embeddable vZome Online view][embed]
+### [vZome Online view][embed]
 
 ***This is the best link to share***!  The link is *embeddable* because it will render in social media (e.g. Discord, Twitter, FaceBook...) with a proper title and a preview image.
-
-There is just one minor hitch: you must wait a bit because the embeddable link is only 
-ready after GitHub Pages has refreshed and is ready to serve up
-your design file and the thumbnail image.
-That process typically only takes a few seconds, but it may take longer.
-If you use the link too soon, vZome Online will show an error: "Unable to parse XML from...".
-If this happens, just wait a bit and reload the vZome Online page.
-
----
-
-### [Quick vZome Online view][quick]
-
-Use this link only if you're in a hurry, and you don't care about link embedding with a preview image.  If you can see this page, then the link will work immediately.
 
 ---
 
@@ -23,34 +10,8 @@ Use this link only if you're in a hurry, and you don't care about link embedding
 
 This is just the link to the raw vZome file, and is **not** good for
 sharing on social media.
-It is not good for downloading, either.
 Honestly, you probably don't want this, though it could be used from either
 vZome desktop ("Open URL...") or vZome Online ("Remote vZome URL").
-
----
-
-### [Download-friendly raw vZome file][rawPages]
-
-This link is slightly better for direct downloading.
-However, like the embeddable vZome Online link, it won't be ready until
-GitHub Pages has refreshed after your upload.
-It will also work in vZome desktop and vZome Online.
-
----
-
-### [Github source folder][source]
-
-Use this to navigate to the folder in your `vzome-sharing` GitHub repository
-that contains your uploaded vZome file, as well as this README.
-
----
-
-### [Github Pages version][pages]
-
-This README file will also be served by GitHub Pages (after it refreshes),
-so you can use this link to view the same content there.
-If you want to replace this README with a proper description of your shared model,
-this is how you would share that web page.
 
 ---
 


### PR DESCRIPTION
Nan discovered that embed.py worked fine with the raw content URLs, since
the PNG file still gets served with the correct MIME type.

I have therefore simplified everything, notably the generated README, to
remove the requirement for GitHub Pages at all.