### PR TITLE
Fix VEF Import failing when 3D vectors passed to QuaternionProjection

### DIFF
--- a/core/src/main/java/com/vzome/core/algebra/PentagonField.java
+++ b/core/src/main/java/com/vzome/core/algebra/PentagonField.java
@@ -108,6 +108,7 @@ public final class PentagonField extends AbstractAlgebraicField
         }
     }
 
+    @Override
     public List<Integer> recurrence( List<Integer> input )
     {        
         ArrayList<Integer> output = new ArrayList<>();

--- a/core/src/main/java/com/vzome/core/construction/VefToModel.java
+++ b/core/src/main/java/com/vzome/core/construction/VefToModel.java
@@ -59,6 +59,17 @@ public class VefToModel extends VefParser
             location = location .scale( scale );
             logger .finest( "scaled = " + location .getVectorExpression( AlgebraicField .VEF_FORMAT ) );
         }
+        // Several types of projections expect at least 4D vectors (e.g. quaternion, tetrahedron and perspective) 
+        // but the VEF format now supports vectors with other than 4 dimensions; maybe more, maybe fewer.
+        // so use inflateTo4d() to be safe.
+        if(wFirst() && location.dimension() == 3) {
+            // VEF support for 3 dimensions was introduced well after wFirst became the standard
+            // so this should never be called for legacy files.
+            // inflateTo4d() expects at least 3D inputs so 2D will fail if we try to import 2D VEF. 
+            // That's OK for now, but... 
+            // TODO: inflateTo4d() should be made to work with fewer dimensions if we ever want 2D VEF imports.   
+            location = location.inflateTo4d();
+        }
         location = mProjection .projectImage( location, wFirst() );
         logger .finest( "projected = " + location .getVectorExpression( AlgebraicField .VEF_FORMAT ) );
         if ( offset != null )

--- a/core/src/test/java/com/vzome/core/construction/VefToModelTest.java
+++ b/core/src/test/java/com/vzome/core/construction/VefToModelTest.java
@@ -519,6 +519,39 @@ public class VefToModelTest
             assertEquals( expected, v1 ); 
         } 
     } 
+
+    @Test 
+    public void testQuaternionProjectionOf3DVector() 
+    { 
+        final AlgebraicField field = new RootTwoField(); 
+        final String vefData = "vZome VEF 9 field rootTwo " +
+                "dimension 3 " + 
+                "1 " + 
+                "(1,2) (3,4) (5,6) ";
+        
+        AlgebraicNumber scale = field .one(); 
+        Projection projection = null;
+        while(true) {
+            NewConstructions effects = new NewConstructions(); 
+            VefToModel parser = new VefToModel( projection, effects, scale, null ); 
+            parser .parseVEF( vefData, field ); 
+ 
+            Point p0 = (Point) effects .get( 0 ); 
+            AlgebraicVector v0 = p0 .getLocation(); 
+            if(projection == null) {
+                AlgebraicVector expected = field .createVector( new int[][] {{2,1,1,1}, {4,1,3,1}, {6,1,5,1}} ).scale(scale); 
+                assertEquals( expected, v0 );
+                AlgebraicVector quaternion = field .createVector( new int[][] {{2,1,0,1}, {2,1,1,1}, {2,1,2,1}, {2,1,3,1}} ); 
+                Assert.assertNotEquals(quaternion.inflateTo4d(true), quaternion.inflateTo4d(false)); 
+                projection = new QuaternionProjection(field, null, quaternion ); 
+
+            } else {
+                AlgebraicVector expected = field .createVector( new int[][] {{-2,1,-2,1}, {20,1,14,1}, {6,1,6,1}} ).scale(scale); 
+                assertEquals( expected, v0 );
+                break;
+            }
+        }
+    } 
  
     @Test
     public void testVefParseBigInteger()
@@ -596,7 +629,7 @@ public class VefToModelTest
         }
         assertEquals(fields.length, testsPassed);
     }
-    
+
     private static class NewConstructions extends ArrayList<Construction> implements ConstructionChanges
     {
         private static final long serialVersionUID = 1L;


### PR DESCRIPTION
VEF has supported dimensions other than 4D for a while, but it was only used with higher dimensions. It now supports 3D correctly, but 2D or 1D require a change to inflateTo4d() which  I have not done at this time, although the potential issue with 2D is noted in the newly added comments.