### PR TITLE
Add command to print vZome XML to stdout without saving file.

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
@@ -708,6 +708,10 @@ public class DocumentController extends DefaultController implements Scene.Provi
             }
             break;
             
+            case "show.vZome-xml":   // invoked from custom menu
+                System.out.println(getProperty("vZome-xml"));
+                break;
+                
             default:
                 if ( action.startsWith( "setSymmetry." ) ) {
                     String system = action.substring( "setSymmetry.".length() );


### PR DESCRIPTION
Command "show.vZome-xml" is only to be invoked from custom menu.