### PR TITLE
Optimize VEF strut geometry for automatic directions

### DIFF
--- a/core/src/main/java/com/vzome/core/kinds/SnubCubeFieldApplication.java
+++ b/core/src/main/java/com/vzome/core/kinds/SnubCubeFieldApplication.java
@@ -57,13 +57,13 @@ public class SnubCubeFieldApplication extends DefaultFieldApplication {
         // Add custom default shapes instead of just using the default OctahedralShapes
         final AbstractShapes defaultShapes = (AbstractShapes) symmPerspective.getDefaultGeometry();
         // Be careful not to load the snubDodec versions of the ExportedVEFShapes for zones with shared names
-        String resPath = "snubCube/";
+        String resPath = "snubCube";
         final AbstractShapes snubCubeRhShapes = new ExportedVEFShapes(null, resPath, "snub cube right", null, symm, defaultShapes, false);
         final AbstractShapes snubCubeLhShapes = new ExportedVEFShapes(null, resPath,  "snub cube left",  null, symm, defaultShapes, true);
-        resPath = "snubCube/dual/"; // pentagonal icositetrahedron is the dual of the snub cube
+        resPath = "snubCube/dual"; // pentagonal icositetrahedron is the dual of the snub cube
         final AbstractShapes snubDualRhShapes = new ExportedVEFShapes(null, resPath, "snub cube dual right", null, symm, defaultShapes, false);
         final AbstractShapes snubDualLhShapes = new ExportedVEFShapes(null, resPath,  "snub cube dual left",  null, symm, defaultShapes, true);
-        resPath = "snubCube/disdyakisDodec/";
+        resPath = "snubCube/disdyakisDodec";
         final AbstractShapes disdyakisDodec = new ExportedVEFShapes(null, resPath, "disdyakis dodec", null, symm, defaultShapes, false);
         
         // this is the order they will be shown on the dialog

--- a/core/src/main/java/com/vzome/core/viewing/AbstractShapes.java
+++ b/core/src/main/java/com/vzome/core/viewing/AbstractShapes.java
@@ -44,6 +44,17 @@ public abstract class AbstractShapes implements Shapes
     }
 
     @Override
+    public String toString()
+    {
+        return this.getClass().getSimpleName()
+            + "( Symmetry:" + mSymmetry.getName()
+            + ", PkgName:" + mPkgName
+            + ", Name:" + mName 
+            + ( alias == null ? "" : (", Alias:" + alias) )
+            +" )";
+    }
+
+    @Override
     public Color getColor( Direction dir )
     {
         return null;

--- a/core/src/main/java/com/vzome/core/viewing/ExportedVEFShapes.java
+++ b/core/src/main/java/com/vzome/core/viewing/ExportedVEFShapes.java
@@ -97,34 +97,50 @@ public class ExportedVEFShapes extends AbstractShapes
     }
 
     @Override
-    protected Polyhedron buildConnectorShape( String pkgName )
-    {
-        String vefData = loadVefData( NODE_MODEL );
-        if ( vefData != null ) {
+    protected Polyhedron buildConnectorShape(String pkgName) {
+        String vefData = loadVefData(NODE_MODEL);
+        if (vefData != null) {
             VefToShape parser = new VefToShape();
             parser.invertSnubBall = isSnub;
-            parser .parseVEF( vefData, mSymmetry .getField() );
-            return parser .getConnectorPolyhedron();
+            parser.parseVEF(vefData, mSymmetry.getField());
+            return parser.getConnectorPolyhedron();
         }
-        if ( this .fallback != null )
-            return this .fallback .buildConnectorShape( pkgName );
-        else
-            throw new IllegalStateException( "missing connector shape: " + pkgName );
+        final Level logLevel = Level.FINE;
+        if (LOGGER.isLoggable(logLevel)) {
+            LOGGER.log(logLevel, this.toString() + " has no VEF data for " + NODE_MODEL + " at " + pkgName);
+        }
+        if (this.fallback != null) {
+            if (LOGGER.isLoggable(logLevel)) {
+                LOGGER.log(logLevel, "\t" + NODE_MODEL + " --> fallback to " + fallback.toString());
+            }
+            return this.fallback.buildConnectorShape(pkgName);
+        }
+        throw new IllegalStateException("missing connector shape: " + pkgName);
     }
 
     @Override
-    protected StrutGeometry createStrutGeometry( Direction dir )
-    {
-        String vefData = loadVefData( dir .getName() );
-        if ( vefData != null ) {
-            VefToShape parser = new VefToShape();
-            parser .parseVEF( vefData, mSymmetry .getField() );
-            return parser .getStrutGeometry( dir .getAxis( Symmetry .PLUS, 0 ) .normal() );
+    protected StrutGeometry createStrutGeometry(Direction dir) {
+        // automatic struts don't use VEF so don't waste time trying
+        if (!dir.isAutomatic()) {
+            String vefData = loadVefData(dir.getName());
+            if (vefData != null) {
+                VefToShape parser = new VefToShape();
+                parser.parseVEF(vefData, mSymmetry.getField());
+                return parser.getStrutGeometry(dir.getAxis(Symmetry.PLUS, 0).normal());
+            }
+            // strut uses finer logging level than connector since strut fallback is more common.
+            final Level logLevel = Level.FINER;
+            if (LOGGER.isLoggable(logLevel)) {
+                LOGGER.log(logLevel, this.toString() + " has no VEF data for strut: " + dir.getName());
+            }
+            if (fallback != null) {
+                if (LOGGER.isLoggable(logLevel)) {
+                    LOGGER.log(logLevel, "\t" + dir.getName() + " strut --> fallback to " + fallback.toString());
+                }
+                return this.fallback.createStrutGeometry(dir);
+            }
         }
-        else  if ( this .fallback != null )
-            return this .fallback .createStrutGeometry( dir );
-        else
-            return super .createStrutGeometry( dir );
+        return super.createStrutGeometry(dir);
     }
 
     protected String loadVefData( String name )


### PR DESCRIPTION
Skip the unnecessary overhead of trying to load VEF and retry with fallback for automatic directions. Go straight to default struts since we know VEF or other fallbacks won't render auto struts. This should speed up the rendering of automatic struts, even if only a little bit.

Also added logging for missing VEF resources in ExportedVEFShapes to help track down why balls are not being loaded by the SnubCubeField in the gradle builds but they are in the Eclipse builds.

Eventually, we could make a test case to use this logging to track down missing strut geometries.