### PR TITLE
Remove type parameter from ParameterizedField

### DIFF
--- a/core/src/main/java/com/vzome/core/algebra/EdPeggField.java
+++ b/core/src/main/java/com/vzome/core/algebra/EdPeggField.java
@@ -1,7 +1,7 @@
 package com.vzome.core.algebra;
 
 // This field is based on a suggestion by Ed Pegg
-public class EdPeggField extends ParameterizedField<Integer> {
+public class EdPeggField extends ParameterizedField {
     public static final String FIELD_NAME = "edPegg";
     
     /**
@@ -32,12 +32,10 @@ public class EdPeggField extends ParameterizedField<Integer> {
     }
     
     public EdPeggField( AlgebraicNumberFactory factory ) {
-        super( FIELD_NAME, 3, 0, factory );
+        super( FIELD_NAME, 3, factory );
+        initialize();
     }
 
-    @Override
-    protected void validate() {}
-    
     @Override
     protected void initializeCoefficients() {
         double[] temp = getCoefficients();

--- a/core/src/main/java/com/vzome/core/algebra/ParameterizedField.java
+++ b/core/src/main/java/com/vzome/core/algebra/ParameterizedField.java
@@ -5,23 +5,21 @@ import java.util.function.BiConsumer;
 /**
  * @author David Hall
  */
-public abstract class ParameterizedField<T extends Object> extends AbstractAlgebraicField {
+public abstract class ParameterizedField extends AbstractAlgebraicField {
 
-    protected final T operand;
     protected final double[] coefficients;
     protected short[][][] multiplicationTensor;
     protected String[][] irrationalLabels;
     
-    public ParameterizedField( String name, int order, T operand, AlgebraicNumberFactory factory ) {
+    public ParameterizedField( String name, int order, AlgebraicNumberFactory factory ) {
         super( name, order, factory );
-        this.operand = operand;
         // These arrays are allocated here, but all non-zero values will be initialized in the derived classes.
         coefficients = new double[order];
         multiplicationTensor = new short[order][order][order];
         irrationalLabels = new String[order][2];
         irrationalLabels[0] = new String[] {" ", " "}; // units use a space character
-        // overridable methods intentionally called from c'tor. Be sure all member variables are initialized first.
-        initialize();
+        // overridable methods should not be called from c'tor since not all member variables may be initialized.
+        // derived classes should call initialize() in their c'tor.
     }
 
     /**
@@ -49,14 +47,11 @@ public abstract class ParameterizedField<T extends Object> extends AbstractAlgeb
         // In some cases, the coefficients may eventually be determined
         // simply by evaluating the only possible solutions to the multiplicationTensor.
         // The labels are initialized last because they could possibly utilize the other values.
-        validate();
         initializeNormalizer();
         initializeMultiplicationTensor();
         initializeCoefficients();
         initializeLabels();
     }
-
-    protected abstract void validate();
 
     protected void initializeNormalizer() 
     {

--- a/core/src/main/java/com/vzome/core/algebra/PlasticNumberField.java
+++ b/core/src/main/java/com/vzome/core/algebra/PlasticNumberField.java
@@ -3,7 +3,7 @@ package com.vzome.core.algebra;
 /**
  * @author David Hall
  */
-public class PlasticNumberField  extends ParameterizedField<Integer> {
+public class PlasticNumberField  extends ParameterizedField {
     public static final String FIELD_NAME = "plasticNumber";
     
     /**
@@ -34,12 +34,10 @@ public class PlasticNumberField  extends ParameterizedField<Integer> {
     }
     
     public PlasticNumberField( AlgebraicNumberFactory factory ) {
-        super( FIELD_NAME, 3, 0, factory );
+        super( FIELD_NAME, 3, factory );
+        initialize();
     }
 
-    @Override
-    protected void validate() {}
-    
     @Override
     protected void initializeCoefficients() {
         double[] temp = getCoefficients();

--- a/core/src/main/java/com/vzome/core/algebra/PlasticPhiField.java
+++ b/core/src/main/java/com/vzome/core/algebra/PlasticPhiField.java
@@ -1,6 +1,6 @@
 package com.vzome.core.algebra;
 
-public class PlasticPhiField extends ParameterizedField<Integer> {
+public class PlasticPhiField extends ParameterizedField {
         public static final String FIELD_NAME = "plasticPhi";
         
         /**
@@ -35,12 +35,10 @@ public class PlasticPhiField extends ParameterizedField<Integer> {
         }
         
         public PlasticPhiField( AlgebraicNumberFactory factory ) {
-            super( FIELD_NAME, 6, 0, factory );
+            super( FIELD_NAME, 6, factory );
+            initialize();
         }
 
-        @Override
-        protected void validate() {}
-        
         @Override
         protected void initializeCoefficients() {
             double[] temp = getCoefficients();

--- a/core/src/main/java/com/vzome/core/algebra/PolygonField.java
+++ b/core/src/main/java/com/vzome/core/algebra/PolygonField.java
@@ -8,7 +8,7 @@ import java.util.List;
 /**
  * @author David Hall
  */
-public class PolygonField extends ParameterizedField<Integer>
+public class PolygonField extends ParameterizedField
 {
     private static final double PI = 3.14159265358979323846; // JSweet doesn't know Math.PI
     /**
@@ -348,6 +348,8 @@ public class PolygonField extends ParameterizedField<Integer>
      * so I'm going to leave them as public static methods.
      */
 
+    private final int polygonSides;
+    
     public PolygonField( int polygonSides, AlgebraicNumberFactory factory ) {
         this( FIELD_PREFIX + polygonSides, polygonSides, factory );
     }
@@ -355,7 +357,10 @@ public class PolygonField extends ParameterizedField<Integer>
     // this protected c'tor is intended to allow PentagonField and HeptagonField classes to be refactored
     // so they are derived from PolygonField and still maintain their original legacy names
     protected PolygonField(String name, int polygonSides, AlgebraicNumberFactory factory ) {
-        super( name, getOrder(polygonSides), polygonSides, factory );
+        super( name, getOrder(polygonSides), factory );
+        this.polygonSides = polygonSides;
+        validate();
+        initialize();
         isEven = polygonSides % 2 == 0;
         final boolean isGolden = polygonSides % 5 == 0;
         if (isGolden) {
@@ -406,7 +411,6 @@ public class PolygonField extends ParameterizedField<Integer>
         return getUnitDiagonal( 2 ); // be sure to use getUnitDiagonal() instead of getUnitTerm()
     }
 
-    @Override
     protected void validate() {
         if (polygonSides() < MIN_SIDES) {
             String msg = "polygon sides = " + polygonSides() + ". It must be at least " + MIN_SIDES + ".";
@@ -553,7 +557,7 @@ public class PolygonField extends ParameterizedField<Integer>
     }
 
     public Integer polygonSides() {
-        return operand;
+        return polygonSides;
     }
 
     public final boolean isEven() {

--- a/core/src/main/java/com/vzome/core/algebra/SnubCubeField.java
+++ b/core/src/main/java/com/vzome/core/algebra/SnubCubeField.java
@@ -3,7 +3,7 @@ package com.vzome.core.algebra;
 /**
  * @author David Hall
  */
-public class SnubCubeField  extends ParameterizedField<Integer> {
+public class SnubCubeField  extends ParameterizedField {
     public static final String FIELD_NAME = "snubCube";
     
     /**
@@ -33,12 +33,10 @@ public class SnubCubeField  extends ParameterizedField<Integer> {
     }
     
     public SnubCubeField( AlgebraicNumberFactory factory ) {
-        super( FIELD_NAME, 3, 0, factory );
+        super( FIELD_NAME, 3, factory );
+        initialize();
     }
 
-    @Override
-    protected void validate() {}
-    
     @Override
     protected void initializeCoefficients() {
         double[] temp = getCoefficients();

--- a/core/src/main/java/com/vzome/core/algebra/SuperGoldenField.java
+++ b/core/src/main/java/com/vzome/core/algebra/SuperGoldenField.java
@@ -4,7 +4,7 @@ package com.vzome.core.algebra;
 // See https://community.wolfram.com/groups/-/m/t/1286708
 // The Narayana's cows sequence constant is also known as 
 // the Super Golden Ratio at https://en.wikipedia.org/wiki/Supergolden_ratio
-public class SuperGoldenField extends ParameterizedField<Integer> {
+public class SuperGoldenField extends ParameterizedField {
     public static final String FIELD_NAME = "superGolden";
     
     /**
@@ -36,12 +36,10 @@ public class SuperGoldenField extends ParameterizedField<Integer> {
     }
     
     public SuperGoldenField( AlgebraicNumberFactory factory ) {
-        super( FIELD_NAME, 3, 0, factory );
+        super( FIELD_NAME, 3, factory );
+        initialize();
     }
 
-    @Override
-    protected void validate() {}
-    
     @Override
     protected void initializeCoefficients() {
         double[] temp = getCoefficients();

--- a/core/src/main/java/com/vzome/fields/sqrtphi/SqrtPhiField.java
+++ b/core/src/main/java/com/vzome/fields/sqrtphi/SqrtPhiField.java
@@ -7,7 +7,7 @@ import com.vzome.core.algebra.ParameterizedField;
 /**
  * @author David Hall
  */
-public class SqrtPhiField  extends ParameterizedField<Integer>
+public class SqrtPhiField  extends ParameterizedField
 {
     public static final String FIELD_NAME = "sqrtPhi";
     public static final double PHI_VALUE = ( 1.0 + Math.sqrt( 5.0 ) ) / 2.0;
@@ -48,11 +48,9 @@ public class SqrtPhiField  extends ParameterizedField<Integer>
     }
     
     public SqrtPhiField( AlgebraicNumberFactory factory ) {
-        super( FIELD_NAME, 4, 0, factory );
+        super( FIELD_NAME, 4, factory );
+        initialize();
     }
-
-    @Override
-    protected void validate() {}
 
     @Override
     protected void initializeCoefficients() {

--- a/core/src/test/java/com/vzome/core/algebra/ParameterizedFieldTest.java
+++ b/core/src/test/java/com/vzome/core/algebra/ParameterizedFieldTest.java
@@ -103,8 +103,8 @@ public class ParameterizedFieldTest {
     public void printMultiplicationTensors() {
         System.out.println(new Throwable().getStackTrace()[0].getMethodName() + " " + Utilities.thisSourceCodeLine());
         for(AlgebraicField field : TEST_FIELDS) {
-            if(field instanceof ParameterizedField<?>) {
-                ParameterizedFields.printMultiplicationTensor( (ParameterizedField<?>)field );    
+            if(field instanceof ParameterizedField) {
+                ParameterizedFields.printMultiplicationTensor( (ParameterizedField)field );    
             }
         }
     }

--- a/core/src/test/java/com/vzome/core/algebra/ParameterizedFields.java
+++ b/core/src/test/java/com/vzome/core/algebra/ParameterizedFields.java
@@ -177,7 +177,7 @@ public class ParameterizedFields {
         }
     }
     
-	public static String multiplicationTensorToString(ParameterizedField<?> field) {
+	public static String multiplicationTensorToString(ParameterizedField field) {
 		StringBuffer buf = new StringBuffer();
 		buf.append("{\n");
 		for (short[][] outer : field.multiplicationTensor) {
@@ -222,7 +222,7 @@ public class ParameterizedFields {
         System.out.println();
     }
 
-    public static void printMultiplicationTensor(ParameterizedField<?> field) {
+    public static void printMultiplicationTensor(ParameterizedField field) {
         String name = "( " + field.toString() + " ) = \n";
         System.out.println("Multiplication Tensor" + name + multiplicationTensorToString(field));
     }


### PR DESCRIPTION
Remove the unnecessary 'operand' member variable.
Move call to initialize() out of the base class.
Each derived class now calls initialize() in their c'tor after calling the base class c'tor.
Remove validate() from base class and only use it in PolygonField which actually has something to validate.
