### PR TITLE
Fix #419

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
@@ -104,7 +104,6 @@ public class DocumentController extends DefaultController implements Scene.Provi
     private Lights sceneLighting;
     private MouseTool modelModeMainTrackball;
     private Component modelCanvas;
-    private Dimension canvasSize = new Dimension( 700, 700 );
     private boolean drawNormals = false;
     private boolean drawOutlines = false;
     private boolean showFrameLabels = false;
@@ -408,7 +407,6 @@ public class DocumentController extends DefaultController implements Scene.Provi
     {
     		// This is called on a UI thread!
         this .modelCanvas = canvas;
-        this .canvasSize = canvas .getSize();
         this .imageCaptureViewer = viewer;
         
         // clicks become select or deselect all
@@ -852,7 +850,6 @@ public class DocumentController extends DefaultController implements Scene.Provi
             if ( "capture-animation" .equals( command ) )
             {
                 File dir = file .isDirectory()? file : file .getParentFile();
-                Dimension size = this .canvasSize;
                 String html = readResource( "org/vorthmann/zome/app/animation.html" );
                 File htmlFile = new File( dir, "index.html" );
                 writeFile( html, htmlFile );
@@ -870,7 +867,7 @@ public class DocumentController extends DefaultController implements Scene.Provi
             }
             if ( command.startsWith( "export2d." ) )
             {
-                Dimension size = this .canvasSize;
+                Dimension size = this .modelCanvas .getSize();
                 String format = command .substring( "export2d." .length() ) .toLowerCase();
                 Java2dSnapshot snapshot = documentModel .capture2d( currentSnapshot, size.height, size.width, cameraController .getView(), sceneLighting, false, true );
                 documentModel .export2d( snapshot, format, file, this .drawOutlines, false );
@@ -879,7 +876,7 @@ public class DocumentController extends DefaultController implements Scene.Provi
             }
             if ( command.startsWith( "export." ) )
             {
-                Dimension size = this .canvasSize;
+                Dimension size = this .modelCanvas .getSize();
                 Writer out = null;
                 try {
                     out = new FileWriter( file );


### PR DESCRIPTION
PDF and SVG un-customized exports now work.  This reverts a change made
in 7742ddbb5c58286759d4961ade6fc55096768e99 to get DAE export to work
with CheerpJ in vZome Online.

Since that commit also claimed that POV export was broken, I tested that, too.