### PR TITLE
Saving shapes.json as part of GitHub shares

### DIFF
--- a/core/src/main/java/com/vzome/core/exporters/Exporter3d.java
+++ b/core/src/main/java/com/vzome/core/exporters/Exporter3d.java
@@ -75,9 +75,11 @@ public abstract class Exporter3d
     {
         mScene = doc .getCamera();
         mModel = doc .getRenderedModel();
+        mLights = doc .getSceneLighting();
         this .doExport( file, writer, height, width );
         mScene = null;
         mModel = null;
+        mLights = null;
     }
 }
 

--- a/core/src/main/java/com/vzome/core/exporters/ShapesJsonExporter.java
+++ b/core/src/main/java/com/vzome/core/exporters/ShapesJsonExporter.java
@@ -48,6 +48,8 @@ public class ShapesJsonExporter extends Exporter3d
         generator .setCodec( mapper .getObjectMapper() );
 
         generator .writeStartObject();
+        generator .writeObjectField( "lights", this .mLights );
+        generator .writeObjectField( "camera", this .mScene );
         generator .writeObjectField( "shapes", shapes );
         generator .writeObjectField( "instances", instances );
         generator .writeEndObject();

--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
@@ -1197,6 +1197,9 @@ public class DocumentController extends DefaultController implements Scene.Provi
         case "field.name":
             return this .documentModel .getField() .getName();
 
+        case "shapes-json":
+            return this .documentModel .copyRenderedModel( "shapes" );
+                    
         case "vZome-xml":
             try ( ByteArrayOutputStream out = new ByteArrayOutputStream() ) {
                 documentModel .serialize( out, properties );

--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
@@ -236,7 +236,8 @@ public class DocumentFrame extends JFrame implements PropertyChangeListener, Con
                     Path filePath = new File( windowName ) .toPath();
                     String xml = mController .getProperty( "vZome-xml" );
                     String pngEncoded = mController .getProperty( "png-base64" );
-                    shareDialog .startUpload( filePath .getFileName() .toString(), xml, pngEncoded );
+                    String shapesJson = mController .getProperty( "shapes-json" );
+                    shareDialog .startUpload( filePath .getFileName() .toString(), xml, pngEncoded, shapesJson );
                     break;
 
                 case "saveDefault":

--- a/desktop/src/main/java/org/vorthmann/zome/ui/ShareDialog.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/ShareDialog.java
@@ -82,7 +82,7 @@ public class ShareDialog extends EscapeDialog
     private transient String gitUrl, error; // marks success or failure state
     
     // Inputs
-    private transient String fileName, png, xml;
+    private transient String fileName, png, xml, shapesJson;
     
     // Outputs
     private transient String embedUrl;
@@ -274,11 +274,12 @@ public class ShareDialog extends EscapeDialog
         }
     }
 
-    public void startUpload( String fileName, String xml, String png )
+    public void startUpload( String fileName, String xml, String png, String shapesJson )
     {
         this.fileName = fileName;
         this.xml = xml;
         this.png = png;
+        this.shapesJson = shapesJson;
         
         // Initialize the transient, file-specific state
         this.error = null;
@@ -397,6 +398,9 @@ public class ShareDialog extends EscapeDialog
             
             String imageFileName = designName + ".png";
             this .addFile( entries, path + imageFileName, png, Blob.ENCODING_BASE64 );
+
+            String shapesFileName = designName + ".shapes.json";
+            this .addFile( entries, path + shapesFileName, shapesJson, Blob.ENCODING_UTF8 );
 
             String baseUrl = "https://raw.githubusercontent.com/" + username + "/" + REPO_NAME + "/" + BRANCH_NAME + "/" + timestampPath;
             String rawUrl = baseUrl + encodedName + "/" + this .fileName;


### PR DESCRIPTION
This will allow vZome Online (or even other tools) to do a "3d preview",
or even just a read-only view, without any need to load or execute the
legacy vZome code.  This immediately sidesteps all issues relating to
interpretation errors in the transpiled code, until full editing is
available.

I've also updated the Shapes JSON exporter to include camera and lighting.