### PR TITLE
Rendering shapes preview when available

### DIFF
--- a/core/src/main/java/com/vzome/core/exporters/ShapesJsonExporter.java
+++ b/core/src/main/java/com/vzome/core/exporters/ShapesJsonExporter.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.vzome.core.math.RealVector;
+import com.vzome.core.math.symmetry.Embedding;
 import com.vzome.core.render.JsonMapper;
 import com.vzome.core.render.RenderedManifestation;
 
@@ -41,6 +43,16 @@ public class ShapesJsonExporter extends Exporter3d
                 instances .add( instanceNode );
             }
         }
+        
+        // First, turn the embedding into a set of real column vectors.
+        Embedding embedding = this .mModel .getEmbedding();
+        float[] embeddingRows = new float[]{ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 };
+        for ( int i = 0; i < 3; i++ ) {
+            RealVector column = embedding .embedInR3( this .mModel .getField() .basisVector( 3, i ) );
+            embeddingRows[ 0 + i ] = column.x;
+            embeddingRows[ 4 + i ] = column.y;
+            embeddingRows[ 8 + i ] = column.z;
+        }
 
         JsonFactory factory = new JsonFactory() .disable( JsonGenerator.Feature.AUTO_CLOSE_TARGET );
         JsonGenerator generator = factory.createGenerator( writer );
@@ -50,6 +62,7 @@ public class ShapesJsonExporter extends Exporter3d
         generator .writeStartObject();
         generator .writeObjectField( "lights", this .mLights );
         generator .writeObjectField( "camera", this .mScene );
+        generator .writeObjectField( "embedding", embeddingRows );
         generator .writeObjectField( "shapes", shapes );
         generator .writeObjectField( "instances", instances );
         generator .writeEndObject();

--- a/core/src/main/java/com/vzome/core/render/JsonMapper.java
+++ b/core/src/main/java/com/vzome/core/render/JsonMapper.java
@@ -109,6 +109,9 @@ public class JsonMapper
 
                 ObjectNode quaternion = getQuaternionNode( rm .getOrientation() );
                 node .set( "rotation", quaternion );
+                
+                ArrayNode matrix = getMatrix( rm .getOrientation() );
+                node .set( "rotationMatrix", matrix );
 
                 return node;
             }
@@ -160,7 +163,10 @@ public class JsonMapper
     
     private ObjectNode getLocation( RenderedManifestation rm )
     {
-        return getVectorNode( rm .getLocation() );
+        AlgebraicVector location = rm .getLocationAV();
+        if ( location == null )
+            location = rm .getShape() .getField() .origin( 3 );
+        return getVectorNode( location .toRealVector() ); // DON'T embed!
     }
 
     @Deprecated
@@ -178,6 +184,22 @@ public class JsonMapper
             e .printStackTrace();
             return objectMapper .createObjectNode();
         }
+    }
+
+    public ArrayNode getMatrix( AlgebraicMatrix orientation )
+    {
+        ArrayNode arrayNode = this .objectMapper .createArrayNode();
+        for ( int i = 0; i < 3; i++) {
+            for ( int j = 0; j < 3; j++) {
+                arrayNode .add( (float) orientation .getElement( i, j ) .evaluate() );
+            }
+            arrayNode .add( 0f );
+        }
+        arrayNode .add( 0f );
+        arrayNode .add( 0f );
+        arrayNode .add( 0f );
+        arrayNode .add( 1f );
+        return arrayNode;
     }
 
     public ObjectNode getQuaternionNode( AlgebraicMatrix orientation )

--- a/core/src/main/java/com/vzome/core/viewing/Camera.java
+++ b/core/src/main/java/com/vzome/core/viewing/Camera.java
@@ -248,6 +248,11 @@ public class Camera
         return eyePoint;
     }
     
+    public Vector3f getLookDirection()
+    {
+        return this .mLookDirection;
+    }
+    
     public Point3f getLookAtPoint()
     {
         return mLookAtPoint;

--- a/online/src/App.jsx
+++ b/online/src/App.jsx
@@ -7,6 +7,7 @@ import Grid from '@material-ui/core/Grid'
 import './App.css'
 
 import DesignEditor from './components/designeditor.jsx'
+import ShapesViewer from './components/shapesviewer.jsx'
 // import EditMenu from './components/editmenu.jsx'
 import ErrorAlert from './components/alert.jsx'
 import VZomeAppBar from './components/appbar.jsx'
@@ -14,6 +15,7 @@ import Debugger from './components/debugger.jsx'
 import createBundleStore from './bundles/index.js'
 
 const queryParams = new URLSearchParams( window.location.search );
+const editor = queryParams.get( 'editor' ) === 'true'
 const profile = queryParams.get( "profile" ) || queryParams.get( "editMode" )
 const debug = queryParams.get( 'debug' ) === 'true'
 
@@ -35,7 +37,7 @@ const App = () =>
               </Grid>
             </Grid>
           </div>
-        : <DesignEditor/>}
+        : <DesignEditor/> }
         <ErrorAlert/> 
         {/* <EditMenu/>  */}
         {/* <Spinner/> */}

--- a/online/src/bundles/camera.js
+++ b/online/src/bundles/camera.js
@@ -3,7 +3,7 @@
 const CAMERA_DEFINED = 'CAMERA_DEFINED'
 
 const aspectRatio = window.innerWidth / window.innerHeight  // TODO fix this hardwiring
-const convertFOV = (fovX) => ( fovX / aspectRatio ) * 180 / Math.PI  // converting radians to degrees
+export const convertFOV = (fovX) => ( fovX / aspectRatio ) * 180 / Math.PI  // converting radians to degrees
 
 export const initialState = {
   fov: convertFOV( 0.75 ), // 0.44 in vZome

--- a/online/src/components/designeditor.jsx
+++ b/online/src/components/designeditor.jsx
@@ -5,14 +5,16 @@ import { connect } from 'react-redux'
 import { selectionToggled } from '../bundles/mesh.js'
 import * as planes from '../bundles/planes.js'
 import * as designs from '../bundles/designs.js'
-import { DesignCanvas, BuildPlane, MeshGeometry, getDefaultRenderer } from '@vzome/react-vzome'
+import { DesignCanvas, ShapedGeometry, BuildPlane, MeshGeometry, getDefaultRenderer } from '@vzome/react-vzome'
 
 const select = ( state ) =>
 {
-  const { lighting } = state
-  const mesh = state.designs && designs.selectMesh( state )
+  const lighting = ( state.designs && designs.selectLighting( state ) ) || state.lighting
   const camera = ( state.designs && designs.selectCamera( state ) ) || state.camera
+  const preview = ( state.designs && designs.selectPreview( state ) )
+  const mesh = state.designs && designs.selectMesh( state )
   const renderer = state.designs && designs.selectRenderer( state )
+  const embedding = state.designs && designs.selectEmbedding( state )
   const field = state.designs && designs.selectField( state )
   // const shown = mesh && new Map( mesh.shown )
   // if ( workingPlane && workingPlane.enabled && workingPlane.endPt ) {
@@ -29,6 +31,8 @@ const select = ( state ) =>
   return {
     camera,
     lighting,
+    embedding,
+    preview,
     renderer,
     mesh,
     field,
@@ -60,7 +64,8 @@ const DesignEditor = ( props ) =>
 {
   const { startGridHover, stopGridHover, workingPlane } = props
   const [ defaultRenderers ] = useState( {} )
-  let { mesh, renderer, field } = props
+  let { mesh, renderer, field, embedding, preview } = props
+  const { shapes={}, instances=[] } = preview
   if ( !renderer ) {
     renderer = defaultRenderers[ field.name ]
   }
@@ -95,8 +100,8 @@ const DesignEditor = ( props ) =>
 
   return (
     <DesignCanvas {...props} >
-      { mesh && <MeshGeometry {...{ shown: mesh.shown, selected: mesh.selected, renderer }} /> }
-
+      { preview? <ShapedGeometry {...{ shapes, instances, embedding }} />
+        : ( mesh && <MeshGeometry {...{ shown: mesh.shown, selected: mesh.selected, renderer }} /> ) }
       { workingPlane && workingPlane.enabled &&
           <BuildPlane config={workingPlane} {...{ startGridHover, stopGridHover }} /> }
     </DesignCanvas>

--- a/online/src/components/shapesviewer.jsx
+++ b/online/src/components/shapesviewer.jsx
@@ -1,0 +1,33 @@
+
+import React from 'react'
+import { connect } from 'react-redux'
+
+import * as designs from '../bundles/designs.js'
+import { DesignCanvas, ShapedGeometry } from '@vzome/react-vzome'
+
+const select = ( state ) =>
+{
+  const lighting = ( state.designs && designs.selectLighting( state ) ) || state.lighting
+  const camera = ( state.designs && designs.selectCamera( state ) ) || state.camera
+  const preview = ( state.designs && designs.selectPreview( state ) ) || {}
+
+  return {
+    camera,
+    lighting,
+    preview,
+  }
+}
+
+const ShapesViewer = ( props ) =>
+{
+  let { preview={} } = props
+  const { shapes={}, instances=[] } = preview
+
+  return (
+    <DesignCanvas {...props} >
+      { preview && <ShapedGeometry {...{ shapes, instances }} /> }
+    </DesignCanvas>
+  )
+}
+
+export default connect( select )( ShapesViewer )

--- a/react-library/src/components/geometry.jsx
+++ b/react-library/src/components/geometry.jsx
@@ -1,5 +1,6 @@
 import { BufferGeometry, Vector3, Float32BufferAttribute, Matrix4 } from 'three'
 import React, { useMemo, useRef, useLayoutEffect } from 'react'
+import { useInstanceSorter, useEmbedding } from './hooks.js'
 
 const createGeometry = ( { vertices, faces } ) =>
 {
@@ -27,6 +28,7 @@ const createGeometry = ( { vertices, faces } ) =>
 
 const Instance = ( { id, vectors, position, rotation, geometry, color, selected, highlightBall=()=>{}, onClick, onHover } ) =>
 {
+  // debugger
   const ref = useRef()
   useLayoutEffect( () => {
     const m = new Matrix4()
@@ -63,6 +65,7 @@ const Instance = ( { id, vectors, position, rotation, geometry, color, selected,
 
 const InstancedShape = ( { instances, shape, onClick, onHover, highlightBall } ) =>
 {
+  // debugger
   const geometry = useMemo( () => createGeometry( shape ), [ shape ] )
   return (
     <>
@@ -83,17 +86,13 @@ export const SortedGeometry = ( { sortedInstances, highlightBall, handleClick, o
   )
 }
 
-export const ShapedGeometry = ( { shapes, instances, highlightBall, handleClick, onHover } ) =>
+export const ShapedGeometry = ( { shapes, instances, embedding, highlightBall, handleClick, onHover } ) =>
 {
   const sortedInstances = useInstanceSorter( shapes, instances )
-  return (
-    <SortedGeometry {...{ sortedInstances, highlightBall, handleClick, onHover }} />
-  )
-}
-
-const useInstanceSorter = ( shapes, instances ) =>
-{
-  const filterInstances = ( shape, instances ) => instances.filter( instance => instance.shapeId === shape.id )
-  const sortByShape = () => Object.values( shapes ).map( shape => ( { shape, instances: filterInstances( shape, instances ) } ) )
-  return useMemo( sortByShape, [ shapes, instances ] )
+  const ref = useEmbedding( embedding )
+  return ( sortedInstances &&
+    <group matrixAutoUpdate={false} ref={ref}>
+      <SortedGeometry {...{ sortedInstances, highlightBall, handleClick, onHover }} />
+    </group>
+  ) || null
 }

--- a/react-library/src/components/hooks.js
+++ b/react-library/src/components/hooks.js
@@ -1,4 +1,5 @@
-import { useMemo, useState, useEffect } from 'react'
+import { useMemo, useState, useEffect, useRef } from 'react'
+import { Matrix4 } from 'three'
 import { createInstance } from '../core/adapter.js'
 import { parse, interpret, Step } from '../core/api.js'
 
@@ -113,4 +114,28 @@ export const useInstanceShaper = ( shown, selected, shaper ) =>
       return {}
   }
   return useMemo( shapeInstances, [ shown, selected, shaper ] )
+}
+
+export const useInstanceSorter = ( shapes, instances ) =>
+{
+  const filterInstances = ( shape, instances ) => instances.filter( instance => instance.shapeId === shape.id )
+  const sortByShape = () => Object.values( shapes ).map( shape => ( { shape, instances: filterInstances( shape, instances ) } ) )
+  return useMemo( sortByShape, [ shapes, instances ] )
+}
+
+export const useEmbedding = embedding =>
+{
+  const ref = useRef()
+  useEffect( () => {
+    if ( embedding && ref.current && ref.current.matrix ) {
+      const m = new Matrix4()
+      m.set( ...embedding )
+      m.transpose()
+      ref.current.matrix.identity()  // Required, or applyMatrix4() changes will accumulate
+      // This imperative approach is required because I was unable to decompose the
+      //   embedding matrix (a shear) into a scale and rotation.
+      ref.current.applyMatrix4( m )
+    }
+  }, [embedding] )
+  return ref
 }

--- a/react-library/src/components/urlviewer.jsx
+++ b/react-library/src/components/urlviewer.jsx
@@ -1,6 +1,5 @@
 
-import React, { useRef, useEffect } from 'react'
-import { Matrix4 } from 'three'
+import React from 'react'
 import { ShapedGeometry } from './geometry.jsx'
 import DesignCanvas from './designcanvas.jsx'
 import { useInstanceShaper, useVZomeUrl } from './hooks.js'
@@ -11,22 +10,8 @@ export const MeshGeometry = ({ shown, selected, renderer, highlightBall, handleC
 {
   const { shaper, embedding } = renderer || {}
   const { shapes, instances } = useInstanceShaper( shown, selected, shaper )
-  const ref = useRef()
-  useEffect( () => {
-    if ( embedding && ref.current && ref.current.matrix ) {
-      const m = new Matrix4()
-      m.set( ...embedding )
-      m.transpose()
-      ref.current.matrix.identity()  // Required, or applyMatrix4() changes will accumulate
-      // This imperative approach is required because I was unable to decompose the
-      //   embedding matrix (a shear) into a scale and rotation.
-      ref.current.applyMatrix4( m )
-    }
-  }, [embedding] )
   return ( instances &&
-    <group matrixAutoUpdate={false} ref={ref}>
-      <ShapedGeometry {...{ shapes, instances, highlightBall, handleClick, onHover }} />
-    </group>
+    <ShapedGeometry {...{ shapes, instances, embedding, highlightBall, handleClick, onHover }} />
   ) || null
 }
 


### PR DESCRIPTION
I can successfully render a .shapes.json file that is found next to a
.vZome file.

Camera and lighting details are carried over successfully, though Online
does not yet have a perspective | orthogonal switch.

Older shares (with no preview .shapes.json) still render successfully.

Also, legacy vZome files now render with their original background color.