### PR TITLE
Rendering shapes preview when available

### DIFF
--- a/core/src/main/java/com/vzome/core/algebra/AlgebraicMatrix.java
+++ b/core/src/main/java/com/vzome/core/algebra/AlgebraicMatrix.java
@@ -36,7 +36,18 @@ public class AlgebraicMatrix
     {
         return this .matrix;
     }
-
+    
+    public float[] getRowMajorRealElements()
+    {
+        float[] result = new float[]{ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 };
+        for ( int i = 0; i < 3; i++) {
+            for ( int j = 0; j < 3; j++) {
+                result[ i*4 + j ] = (float) this .getElement( i, j ) .evaluate();
+            }
+        }
+        return result;
+    }
+    
     /**
      * Create a new nXn identity matrix.
      * @param field

--- a/core/src/main/java/com/vzome/core/editor/api/OrbitSource.java
+++ b/core/src/main/java/com/vzome/core/editor/api/OrbitSource.java
@@ -47,14 +47,18 @@ public interface OrbitSource
         return embedding;
     }
 
-    default float[][] getOrientations()
+    default float[][] getOrientations( boolean rowMajor )
     {
         Symmetry symmetry = this .getSymmetry();
         AlgebraicField field = symmetry .getField();
         int order = symmetry .getChiralOrder();
-        float[][] orientations = new float[order][];
+        float[][] orientations = new float[order][];        
         for ( int orientation = 0; orientation < order; orientation++ )
         {
+            if ( rowMajor ) {
+                orientations[ orientation ] = symmetry .getMatrix( orientation ) .getRowMajorRealElements();
+                continue;
+            }
             float[] asFloats = new float[ 16 ];
             AlgebraicMatrix transform = symmetry .getMatrix( orientation );
             for ( int i = 0; i < 3; i++ )
@@ -74,5 +78,10 @@ public interface OrbitSource
             orientations[ orientation ] = asFloats;
         }
         return orientations;
+    }
+
+    default float[][] getOrientations()
+    {
+        return getOrientations( false );
     }
 }

--- a/core/src/main/java/com/vzome/core/viewing/Camera.java
+++ b/core/src/main/java/com/vzome/core/viewing/Camera.java
@@ -248,6 +248,11 @@ public class Camera
         return eyePoint;
     }
     
+    public Vector3f getLookDirection()
+    {
+        return this .mLookDirection;
+    }
+    
     public Point3f getLookAtPoint()
     {
         return mLookAtPoint;

--- a/core/src/main/java/com/vzome/unity/Renderer.java
+++ b/core/src/main/java/com/vzome/unity/Renderer.java
@@ -38,7 +38,7 @@ class Renderer implements RenderingChanges
     @Override
     public void manifestationAdded( RenderedManifestation rm )
     {
-        ObjectNode node = this .mapper .getObjectNode( rm );
+        ObjectNode node = this .mapper .getObjectNode( rm, false );
         if ( node != null ) {
             Polyhedron shape = rm .getShape();
             ObjectNode shapeNode = this .mapper .getShapeNode( shape );

--- a/desktop/src/main/java/com/vzome/desktop/controller/JsonClientRendering.java
+++ b/desktop/src/main/java/com/vzome/desktop/controller/JsonClientRendering.java
@@ -44,7 +44,7 @@ public class JsonClientRendering implements RenderingChanges
         if ( ! this .instanceStreamEnabled )
             return;
 
-        ObjectNode node = this .mapper .getObjectNode( rm );
+        ObjectNode node = this .mapper .getObjectNode( rm, false );
         if ( node != null ) {
             node .put( "id", rm .getGuid() .toString() );
             if ( this .instanceStreamEnabled )

--- a/online/src/App.jsx
+++ b/online/src/App.jsx
@@ -14,6 +14,7 @@ import Debugger from './components/debugger.jsx'
 import createBundleStore from './bundles/index.js'
 
 const queryParams = new URLSearchParams( window.location.search );
+const editor = queryParams.get( 'editor' ) === 'true'
 const profile = queryParams.get( "profile" ) || queryParams.get( "editMode" )
 const debug = queryParams.get( 'debug' ) === 'true'
 
@@ -35,7 +36,7 @@ const App = () =>
               </Grid>
             </Grid>
           </div>
-        : <DesignEditor/>}
+        : <DesignEditor/> }
         <ErrorAlert/> 
         {/* <EditMenu/>  */}
         {/* <Spinner/> */}

--- a/online/src/bundles/camera.js
+++ b/online/src/bundles/camera.js
@@ -3,7 +3,7 @@
 const CAMERA_DEFINED = 'CAMERA_DEFINED'
 
 const aspectRatio = window.innerWidth / window.innerHeight  // TODO fix this hardwiring
-const convertFOV = (fovX) => ( fovX / aspectRatio ) * 180 / Math.PI  // converting radians to degrees
+export const convertFOV = (fovX) => ( fovX / aspectRatio ) * 180 / Math.PI  // converting radians to degrees
 
 export const initialState = {
   fov: convertFOV( 0.75 ), // 0.44 in vZome

--- a/online/src/bundles/designs.js
+++ b/online/src/bundles/designs.js
@@ -8,16 +8,24 @@ import { reducer as cameraReducer, initialState as cameraDefault, cameraDefined 
 import * as dbugger from './dbugger.js'
 import * as renderers from './renderers.js'
 import { showAlert } from './alerts.js'
+import { fetchUrlText } from '../bundles/files.js'
+import { convertFOV } from './camera.js'
+
+const identityReducer = ( state="", action ) => state
 
 export const designReducer = combineReducers( {
   mesh: undoable( mesh.reducer ),
   dbugger: undoable( dbugger.reducer ),
   camera: cameraReducer,
-  name: ( state="", action ) => state, // name cannot be changed (YET), so a constant reducer is fine
-  text: ( state="", action ) => state, // text cannot be changed (YET), so a constant reducer is fine
-  success: ( state="", action ) => state, // success cannot be changed, so a constant reducer is fine
-  field: ( state="", action ) => state, // field cannot be changed, so a constant reducer is fine
-  rendererName: ( state="", action ) => state, // rendererName cannot be changed (YET!), so a constant reducer is fine
+  // These cannot be changed (YET), so a constant reducer is fine
+  lighting: identityReducer, 
+  embedding: identityReducer, 
+  name: identityReducer,
+  text: identityReducer,
+  success: identityReducer,
+  field: identityReducer,
+  rendererName: identityReducer,
+  preview: identityReducer,
 })
 
 export const initializeDesign = ( field, name, rendererName, text ) => ({
@@ -69,6 +77,8 @@ export const selectDesignName = ( state, id ) => selectDesign( state, id ).name
 
 export const selectText = ( state, id ) => selectDesign( state, id ).text
 
+export const selectPreview = ( state, id ) => selectDesign( state, id ).preview
+
 export const selectMesh = ( state, id ) => selectDesign( state, id ).mesh.present
 
 export const selectDebugger = ( state, id ) => {
@@ -77,6 +87,10 @@ export const selectDebugger = ( state, id ) => {
 }
 
 export const selectCamera = ( state, id ) => selectDesign( state, id ).camera
+
+export const selectLighting = ( state, id ) => selectDesign( state, id ).lighting
+
+export const selectEmbedding = ( state, id ) => selectDesign( state, id ).embedding
 
 export const selectSource = ( state, id ) => selectDebugger( state, id ).source
 
@@ -162,9 +176,59 @@ export const reducer = ( state = addNewModel( emptyState, goldenField ), action 
   }
 }
 
+const IDENTITY_MATRIX = [1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]
+
+const q2m = ({ x, y, z, w }) =>
+{
+  const q = [ w, x, y, z ]
+  const q01 = q[0]*q[1], q02 = q[0]*q[2], q03 = q[0]*q[3]
+  const q11 = q[1]*q[1], q12 = q[1]*q[2], q13 = q[1]*q[3]
+  const q21 = q12, q22 = q[2]*q[2], q23 = q[2]*q[3]
+  const q31 = q13, q32 = q23, q33 = q[3]*q[3]
+  
+  return [1-2*(q22+q33), 2*(q12-q03), 2*(q13+q02), 0,
+          2*(q21+q03), 1-2*(q33+q11), 2*(q23-q01), 0,
+          2*(q31-q02), 2*(q32+q01), 1-2*(q11+q22), 0,
+          0, 0, 0, 1 ]
+};
+
+const convertPreview = preview =>
+{
+  let i = 0
+  let { lights, camera, shapes, instances, embedding, orientations } = preview
+  instances = instances.map( ({ position, orientation, color, shape }) => {
+    const id = "id_" + i++
+    const { x, y, z } = position
+    const rotation = orientations[ orientation ] || IDENTITY_MATRIX
+    return { id, position: [ x, y, z ], rotation, color, shapeId: shape }
+  })
+  const dlights = lights.directionalLights.map( ({ direction, color }) => {
+    const { x, y, z } = direction
+    return { direction: [ x, y, z ], color }
+  })
+  const { lookAtPoint, upDirection, lookDirection, viewDistance, fieldOfView, near, far } = camera
+  const lookAt = [ ...Object.values( lookAtPoint ) ]
+  const up = [ ...Object.values( upDirection ) ]
+  const lookDir = [ ...Object.values( lookDirection ) ]
+  camera = {
+    near, far, up, lookAt,
+    fov: convertFOV( fieldOfView ),
+    position: lookAt.map( (e,i) => e - viewDistance * lookDir[ i ] ),
+  }
+  return { lighting: { ...lights, directionalLights: dlights }, camera, shapes, instances, embedding }
+}
+
 export const openDesign = ( textPromise, url ) => async ( dispatch, getState ) =>
 {
   try {
+    const name = decodeURI( url.split( '\\' ).pop().split( '/' ).pop() )
+    if ( ! name.endsWith( ".vZome" ) ) {
+      const message = `Unrecognized file name: ${url}`
+      console.log( message )
+      dispatch( showAlert( message ) )
+      return
+    }
+
     const text = await textPromise
     if ( !text ) {
       const message = `Unable to retrieve XML from ${url}`
@@ -173,7 +237,19 @@ export const openDesign = ( textPromise, url ) => async ( dispatch, getState ) =
       return
     }
 
-    const name = decodeURI( url.split( '\\' ).pop().split( '/' ).pop() )
+    const previewUrl = url.substring( 0, url.length-6 ).concat( ".shapes.json" )
+    const previewText = await fetchUrlText( previewUrl )
+    if ( previewText ) {
+      let design = initializeDesign( null, name, null, text )
+      design.preview = convertPreview( JSON.parse( previewText ) )
+      design.camera = design.preview.camera
+      design.lighting = design.preview.lighting
+      design.embedding = design.preview.embedding
+      dispatch( loadingDesign( name, design ) )
+      dispatch( loadedDesign( name, design ) )
+      return
+    }
+
     const failure = message => {
       console.log( message )
       let design = initializeDesign( null, name, null, text )
@@ -182,7 +258,7 @@ export const openDesign = ( textPromise, url ) => async ( dispatch, getState ) =
       dispatch( showAlert( message + ' Use the download button to save this file, then try opening it with desktop vZome.' ) )
     }
 
-    const { firstEdit, camera, field, targetEdit, renderer } = await parse( text ) || {}
+    const { firstEdit, camera, field, targetEdit, renderer, lighting } = await parse( text ) || {}
 
     if ( field.unknown ) {
       failure( `Field "${field.name}" is not implemented.` )
@@ -199,6 +275,8 @@ export const openDesign = ( textPromise, url ) => async ( dispatch, getState ) =
     //  overhead and re-rendering.  Instead, we'll build up a design locally
     //  by calling the designReducer manually.
     let design = initializeDesign( field, name, renderer.name, text )
+    design.lighting = lighting
+    design.embedding = renderer.embedding
     // Each call to designReducer may create an element in the history
     //  (if it has any changes to the mesh),
     //  so we want to be judicious in when we do it.

--- a/online/src/components/designeditor.jsx
+++ b/online/src/components/designeditor.jsx
@@ -5,14 +5,16 @@ import { connect } from 'react-redux'
 import { selectionToggled } from '../bundles/mesh.js'
 import * as planes from '../bundles/planes.js'
 import * as designs from '../bundles/designs.js'
-import { DesignCanvas, BuildPlane, MeshGeometry, getDefaultRenderer } from '@vzome/react-vzome'
+import { DesignCanvas, ShapedGeometry, BuildPlane, MeshGeometry, getDefaultRenderer } from '@vzome/react-vzome'
 
 const select = ( state ) =>
 {
-  const { lighting } = state
-  const mesh = state.designs && designs.selectMesh( state )
+  const lighting = ( state.designs && designs.selectLighting( state ) ) || state.lighting
   const camera = ( state.designs && designs.selectCamera( state ) ) || state.camera
+  const preview = ( state.designs && designs.selectPreview( state ) )
+  const mesh = state.designs && designs.selectMesh( state )
   const renderer = state.designs && designs.selectRenderer( state )
+  const embedding = state.designs && designs.selectEmbedding( state )
   const field = state.designs && designs.selectField( state )
   // const shown = mesh && new Map( mesh.shown )
   // if ( workingPlane && workingPlane.enabled && workingPlane.endPt ) {
@@ -29,6 +31,8 @@ const select = ( state ) =>
   return {
     camera,
     lighting,
+    embedding,
+    preview,
     renderer,
     mesh,
     field,
@@ -60,7 +64,8 @@ const DesignEditor = ( props ) =>
 {
   const { startGridHover, stopGridHover, workingPlane } = props
   const [ defaultRenderers ] = useState( {} )
-  let { mesh, renderer, field } = props
+  let { mesh, renderer, field, embedding, preview } = props
+  const { shapes={}, instances=[] } = preview
   if ( !renderer ) {
     renderer = defaultRenderers[ field.name ]
   }
@@ -95,8 +100,8 @@ const DesignEditor = ( props ) =>
 
   return (
     <DesignCanvas {...props} >
-      { mesh && <MeshGeometry {...{ shown: mesh.shown, selected: mesh.selected, renderer }} /> }
-
+      { preview? <ShapedGeometry {...{ shapes, instances, embedding }} />
+        : ( mesh && <MeshGeometry {...{ shown: mesh.shown, selected: mesh.selected, renderer }} /> ) }
       { workingPlane && workingPlane.enabled &&
           <BuildPlane config={workingPlane} {...{ startGridHover, stopGridHover }} /> }
     </DesignCanvas>

--- a/react-library/src/components/geometry.jsx
+++ b/react-library/src/components/geometry.jsx
@@ -1,5 +1,6 @@
 import { BufferGeometry, Vector3, Float32BufferAttribute, Matrix4 } from 'three'
 import React, { useMemo, useRef, useLayoutEffect } from 'react'
+import { useInstanceSorter, useEmbedding } from './hooks.js'
 
 const createGeometry = ( { vertices, faces } ) =>
 {
@@ -27,6 +28,7 @@ const createGeometry = ( { vertices, faces } ) =>
 
 const Instance = ( { id, vectors, position, rotation, geometry, color, selected, highlightBall=()=>{}, onClick, onHover } ) =>
 {
+  // debugger
   const ref = useRef()
   useLayoutEffect( () => {
     const m = new Matrix4()
@@ -63,6 +65,7 @@ const Instance = ( { id, vectors, position, rotation, geometry, color, selected,
 
 const InstancedShape = ( { instances, shape, onClick, onHover, highlightBall } ) =>
 {
+  // debugger
   const geometry = useMemo( () => createGeometry( shape ), [ shape ] )
   return (
     <>
@@ -83,17 +86,13 @@ export const SortedGeometry = ( { sortedInstances, highlightBall, handleClick, o
   )
 }
 
-export const ShapedGeometry = ( { shapes, instances, highlightBall, handleClick, onHover } ) =>
+export const ShapedGeometry = ( { shapes, instances, embedding, highlightBall, handleClick, onHover } ) =>
 {
   const sortedInstances = useInstanceSorter( shapes, instances )
-  return (
-    <SortedGeometry {...{ sortedInstances, highlightBall, handleClick, onHover }} />
-  )
-}
-
-const useInstanceSorter = ( shapes, instances ) =>
-{
-  const filterInstances = ( shape, instances ) => instances.filter( instance => instance.shapeId === shape.id )
-  const sortByShape = () => Object.values( shapes ).map( shape => ( { shape, instances: filterInstances( shape, instances ) } ) )
-  return useMemo( sortByShape, [ shapes, instances ] )
+  const ref = useEmbedding( embedding )
+  return ( sortedInstances &&
+    <group matrixAutoUpdate={false} ref={ref}>
+      <SortedGeometry {...{ sortedInstances, highlightBall, handleClick, onHover }} />
+    </group>
+  ) || null
 }

--- a/react-library/src/components/hooks.js
+++ b/react-library/src/components/hooks.js
@@ -1,4 +1,5 @@
-import { useMemo, useState, useEffect } from 'react'
+import { useMemo, useState, useEffect, useRef } from 'react'
+import { Matrix4 } from 'three'
 import { createInstance } from '../core/adapter.js'
 import { parse, interpret, Step } from '../core/api.js'
 
@@ -113,4 +114,28 @@ export const useInstanceShaper = ( shown, selected, shaper ) =>
       return {}
   }
   return useMemo( shapeInstances, [ shown, selected, shaper ] )
+}
+
+export const useInstanceSorter = ( shapes, instances ) =>
+{
+  const filterInstances = ( shape, instances ) => instances.filter( instance => instance.shapeId === shape.id )
+  const sortByShape = () => Object.values( shapes ).map( shape => ( { shape, instances: filterInstances( shape, instances ) } ) )
+  return useMemo( sortByShape, [ shapes, instances ] )
+}
+
+export const useEmbedding = embedding =>
+{
+  const ref = useRef()
+  useEffect( () => {
+    if ( embedding && ref.current && ref.current.matrix ) {
+      const m = new Matrix4()
+      m.set( ...embedding )
+      m.transpose()
+      ref.current.matrix.identity()  // Required, or applyMatrix4() changes will accumulate
+      // This imperative approach is required because I was unable to decompose the
+      //   embedding matrix (a shear) into a scale and rotation.
+      ref.current.applyMatrix4( m )
+    }
+  }, [embedding] )
+  return ref
 }

--- a/react-library/src/components/urlviewer.jsx
+++ b/react-library/src/components/urlviewer.jsx
@@ -1,6 +1,5 @@
 
-import React, { useRef, useEffect } from 'react'
-import { Matrix4 } from 'three'
+import React from 'react'
 import { ShapedGeometry } from './geometry.jsx'
 import DesignCanvas from './designcanvas.jsx'
 import { useInstanceShaper, useVZomeUrl } from './hooks.js'
@@ -11,22 +10,8 @@ export const MeshGeometry = ({ shown, selected, renderer, highlightBall, handleC
 {
   const { shaper, embedding } = renderer || {}
   const { shapes, instances } = useInstanceShaper( shown, selected, shaper )
-  const ref = useRef()
-  useEffect( () => {
-    if ( embedding && ref.current && ref.current.matrix ) {
-      const m = new Matrix4()
-      m.set( ...embedding )
-      m.transpose()
-      ref.current.matrix.identity()  // Required, or applyMatrix4() changes will accumulate
-      // This imperative approach is required because I was unable to decompose the
-      //   embedding matrix (a shear) into a scale and rotation.
-      ref.current.applyMatrix4( m )
-    }
-  }, [embedding] )
   return ( instances &&
-    <group matrixAutoUpdate={false} ref={ref}>
-      <ShapedGeometry {...{ shapes, instances, highlightBall, handleClick, onHover }} />
-    </group>
+    <ShapedGeometry {...{ shapes, instances, embedding, highlightBall, handleClick, onHover }} />
   ) || null
 }
 


### PR DESCRIPTION
I can successfully render a .shapes.json file that is found next to a
.vZome file.

Camera and lighting details are carried over successfully, though Online
does not yet have a perspective | orthogonal switch.

Older shares (with no preview .shapes.json) still render successfully.

Also, legacy vZome files now render with their original background color.