### PR TITLE
POV-Ray exporter now uses real numbers

### DIFF
--- a/core/src/main/java/com/vzome/core/algebra/AlgebraicField.java
+++ b/core/src/main/java/com/vzome/core/algebra/AlgebraicField.java
@@ -10,8 +10,6 @@ public interface AlgebraicField
         AlgebraicField getField( String name );
     }
     
-    void defineMultiplier( StringBuffer instances, int w );
-
     int getOrder();
 
     int getNumIrrationals();

--- a/core/src/main/java/com/vzome/core/algebra/HeptagonField.java
+++ b/core/src/main/java/com/vzome/core/algebra/HeptagonField.java
@@ -46,21 +46,6 @@ public class HeptagonField extends AbstractAlgebraicField
         return new BigRational[]{ ones, rhos, sigmas };
     }
 
-    @Override
-    public void defineMultiplier( StringBuffer buf, int i )
-    {
-        if ( i == B )
-        {
-            buf .append( "rho = " );
-            buf .append( RHO_VALUE );
-        }
-        if ( i == C )
-        {
-            buf .append( "sigma = " );
-            buf .append( SIGMA_VALUE );
-        }
-    }
-    
     /**
      * scalar for an affine heptagon
      * @return 

--- a/core/src/main/java/com/vzome/core/algebra/ParameterizedField.java
+++ b/core/src/main/java/com/vzome/core/algebra/ParameterizedField.java
@@ -69,31 +69,7 @@ public abstract class ParameterizedField extends AbstractAlgebraicField {
     protected abstract void initializeCoefficients();
     
     protected abstract void initializeLabels();
-    
-    @Override
-    public void defineMultiplier(StringBuffer buf, int i) {
-        if(i > getNumMultipliers()) {
-            buf .append( "" );
-        } else {
-            String varName = getIrrational(i, AlgebraicField.EXPRESSION_FORMAT);
-            // This method used used by the POVRayExporter
-            // to define a set of named constants.
-            // I suspect that POVRay prefers alphanumeric variable names,
-            // so for the common case where our EXPRESSION_FORMAT looks like "sqrt(phi)",
-            // we'll try to make the variable name alphanumeric.
-            // Derived class can override this method to handle other odd cases.
-            if(varName.matches("sqrt\\(.+\\)") ) {
-                varName = varName.replace("sqrt(", "sqrt").replace(")", "");
-            }
-            if(varName.contains("^") ) {
-                System.err.println("WARNING: " + getName() + ".getNumMultipliers() should probably be returning less than " + i);
-            }
-            buf .append( varName );
-            buf .append( " = " );
-            buf .append( getCoefficient(i) );
-        }
-    }
-    
+        
     @Override
     protected BigRational[] multiply( BigRational[] v1, BigRational[] v2 )
     {

--- a/core/src/main/java/com/vzome/core/algebra/PentagonField.java
+++ b/core/src/main/java/com/vzome/core/algebra/PentagonField.java
@@ -72,12 +72,6 @@ public final class PentagonField extends AbstractAlgebraicField
         return new BigRational[]{ ones, phis };
     }
 
-    @Override
-    public void defineMultiplier( StringBuffer buf, int which )
-    {
-        buf.append( "phi = ( 1 + sqrt(5) ) / 2" );
-    }
-
     /**
      * scalar for an affine pentagon
      * @return 

--- a/core/src/main/java/com/vzome/core/algebra/PolygonField.java
+++ b/core/src/main/java/com/vzome/core/algebra/PolygonField.java
@@ -525,18 +525,6 @@ public class PolygonField extends ParameterizedField
     }
 
     @Override
-    public void defineMultiplier(StringBuffer buf, int i) {
-        // This is used by the POVRayExporter. 
-        if(i > 0 && i < coefficients.length) {
-            String name = getIrrational(i, EXPRESSION_FORMAT);
-            // reformat generated irrational names like d[1] to look like d_1
-            buf.append( name.replace( "[", "_" ).replace( "]", "" ) )
-            .append(" = ")
-            .append(coefficients[i]);
-        }
-    }
-
-    @Override
     protected void initializeCoefficients() {
         double[] temp = getCoefficients();
         for(int i = 0; i < coefficients.length; i++) {

--- a/core/src/main/java/com/vzome/core/algebra/RootThreeField.java
+++ b/core/src/main/java/com/vzome/core/algebra/RootThreeField.java
@@ -28,12 +28,6 @@ public class RootThreeField extends AbstractAlgebraicField
     {
         super( FIELD_NAME, 2, AlgebraicNumberImpl.FACTORY );
     };
-    
-    @Override
-    public void defineMultiplier( StringBuffer buf, int i )
-    {
-        buf .append( "" );
-    }
 
     @Override
     public final BigRational[] multiply( BigRational[] first, BigRational[]  second )

--- a/core/src/main/java/com/vzome/core/algebra/RootTwoField.java
+++ b/core/src/main/java/com/vzome/core/algebra/RootTwoField.java
@@ -30,12 +30,6 @@ public class RootTwoField extends AbstractAlgebraicField
     {
         return true;
     }
-
-    @Override
-    public void defineMultiplier( StringBuffer buf, int which )
-    {
-        buf .append( "" );
-    }
     
     public static final double ROOT_2 = Math.sqrt( 2d );
     

--- a/core/src/main/java/com/vzome/core/algebra/SnubDodecField.java
+++ b/core/src/main/java/com/vzome/core/algebra/SnubDodecField.java
@@ -184,24 +184,6 @@ public class SnubDodecField extends AbstractAlgebraicField
         return 2; // only two primitive elements, phi and xi
     }
 
-    @Override
-    public void defineMultiplier( StringBuffer buf, int i )
-    {
-        switch (i) {
-            case B:
-                buf .append( "phi = " );
-                buf .append( PHI_VALUE );
-                break;
-            case C:
-                buf .append( "xi = " );
-                buf .append( XI_VALUE );
-                break;
-            default:
-                buf .append( "" );
-                break;
-        }
-    }
-
     /**
      * scalar for an affine pentagon
      * @return 

--- a/core/src/main/java/com/vzome/core/exporters/POVRayExporter.java
+++ b/core/src/main/java/com/vzome/core/exporters/POVRayExporter.java
@@ -9,6 +9,7 @@ import java.io.PrintWriter;
 import java.io.Writer;
 import java.text.NumberFormat;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -131,19 +132,11 @@ public class POVRayExporter extends Exporter3d
         output .println( " }" );
         output .println();
 		
-		FORMAT .setMaximumFractionDigits( 3 );
+//		FORMAT .setMaximumFractionDigits( 3 );
 
 		StringBuffer instances = new StringBuffer();
 
         AlgebraicField field = mModel .getField();
-        for ( int o = 1; o <= field .getNumMultipliers(); o++ )
-        {
-            instances .append( "#declare " );
-            field .defineMultiplier( instances, o );
-            instances .append( ";\n" );
-        }
-        output .print( instances );
-        instances = new StringBuffer();
         
         Embedding embedding = mModel .getEmbedding();
         String embeddingTransform = " ";
@@ -166,17 +159,15 @@ public class POVRayExporter extends Exporter3d
             output .flush();
         }
         
-		int numShapes = 0, numTransforms = 0;
-		HashMap<Polyhedron, String> shapes = new HashMap<>();
+		int numTransforms = 0;
+		HashSet<String> shapes = new HashSet<>();
 		Map<AlgebraicMatrix, String> transforms = new HashMap<>();
 		Map<Color, String> colors = new HashMap<>();
         for (RenderedManifestation rm : mModel) {
-            Polyhedron shape = rm .getShape();
-            String shapeName = shapes .get( shape );
-            if ( shapeName == null ) {
-                shapeName = "shape" + numShapes++;
-                shapes .put( shape, shapeName );
-                exportShape( shapeName, shape );
+            String shapeName = "S" + rm .getShapeId() .toString() .replaceAll( "-", "" );
+            if ( ! shapes .contains( shapeName ) ) {
+                shapes .add( shapeName );
+                exportShape( shapeName, rm .getShape() );
             }
             AlgebraicMatrix transform = rm .getOrientation();
             String transformName = transforms .get( transform );
@@ -279,33 +270,28 @@ public class POVRayExporter extends Exporter3d
      */
 	protected void appendVector( AlgebraicVector loc, StringBuffer buf )
 	{
-        loc .getComponent( 0 ) .getNumberExpression( buf, AlgebraicField.EXPRESSION_FORMAT );
+	    RealVector vector = loc .toRealVector();
+        buf .append( FORMAT.format(vector.x) );
         buf .append( ", " );
-        loc .getComponent( 1 ) .getNumberExpression( buf, AlgebraicField.EXPRESSION_FORMAT );
+        buf .append( FORMAT.format(vector.y) );
         buf .append( ", " );
-        loc .getComponent( 2 ) .getNumberExpression( buf, AlgebraicField.EXPRESSION_FORMAT );
+        buf .append( FORMAT.format(vector.z) );
 	}
 
     private void exportShape( String shapeName, Polyhedron poly )
     {
         output .print( "#declare " + shapeName + " = " );
         List<AlgebraicVector> vertices = poly .getVertexList();
-        output .println( "union {" );
-        for (Polyhedron.Face face : poly .getFaceSet()) {
-            int arity = face .size();
-            int num = face .size() + 1;
-            output .print( "polygon {" );
-            output .print( num + ", " );
-            
-            for ( int j = 0; j <= arity; j++ ){
-                // POV-Ray requires that you explicitly repeat the first vertex to close the polygon
-                int m = j % arity;
-                int index = face .get( m );
+        output .println( "mesh {" );
+        poly .getTriangleFaces();
+        for (Polyhedron.Face.Triangle face : poly .getTriangleFaces()) {
+            output .print( "triangle {" );
+            for ( int index : face.vertices ) {
                 AlgebraicVector loc = vertices .get( index );
                 StringBuffer buf = new StringBuffer();
-                buf .append( "(<" );
+                buf .append( "<" );
                 appendVector( loc, buf );
-                buf .append( ">)" );
+                buf .append( ">" );
                 output .print( buf.toString() );
             }
             output .println( "}" );

--- a/core/src/main/java/com/vzome/fields/sqrtphi/SqrtPhiField.java
+++ b/core/src/main/java/com/vzome/fields/sqrtphi/SqrtPhiField.java
@@ -35,13 +35,6 @@ public class SqrtPhiField  extends ParameterizedField
     }
 
     @Override
-    public void defineMultiplier( StringBuffer buf, int w )
-    {
-        buf .append( "sqrtphi = " ); // note that phi is not the first irrational in this field
-        buf .append( SQRT_PHI_VALUE );
-    }
-
-    @Override
     public double[] getCoefficients() {
         return getFieldCoefficients();
     }

--- a/core/src/test/java/com/vzome/core/algebra/AlgebraicFieldTest.java
+++ b/core/src/test/java/com/vzome/core/algebra/AlgebraicFieldTest.java
@@ -143,51 +143,6 @@ public class AlgebraicFieldTest {
 		}
 	}
 	
-	@Test
-	public void testDefineMultiplier() {
-	    System.out.println(new Throwable().getStackTrace()[0].getMethodName() + " " + Utilities.thisSourceCodeLine());
-	    int pass = 0;
-	    for(AlgebraicField field : fields) {
-            System.out.println(field.getName());
-            final int mults = field.getNumMultipliers();
-            final int irrats = field.getNumIrrationals();
-            assertTrue(mults <= irrats);
-            for(int i = 1; i <= mults; i++) {
-                StringBuffer buf = new StringBuffer();
-                field.defineMultiplier(buf, i);
-                final String declaration = buf.toString();
-                
-                switch(field.getName()) {
-                case "golden":
-                    assertEquals(declaration, "phi = ( 1 + sqrt(5) ) / 2");
-                    break;
-                    
-                case "rootTwo":
-                case "rootThree":
-                    assertTrue(declaration.isEmpty());
-                    break;
-                    
-                default:
-                    assertFalse(declaration.isEmpty());
-                    break;                        
-                }
-                if(!declaration.isEmpty()) {
-                    // allow uppercase names too for PlasticNumberField
-                    if(!declaration.matches("[A-Za-z]+ = .*")) {
-                        String msg = "Expected alphanumeric variable name but found: " + declaration + ". " 
-                                + field.getName() 
-                                + ".getNumMultipliers() should probably be returning less than " + i;
-                        fail(msg);
-                    }
-                }
-                System.out.println("\t" + declaration);
-            }
-	        pass++;
-	    }
-	    assertTrue("Did we test any?", pass > 0);
-        assertEquals(fields.size(), pass);
-	}
-
     @Test
     public void testGaussJordanReduction()
     {


### PR DESCRIPTION
There was no real value to using the algebraic expressions for ANs, and
this means we can get rid of AF.defineMultiplier(), which I have done.

I had to do quite a bit of debugging to get panels to work, and I finally
switched from "union { polygon { ..." to "mesh { triangle { ...".  This
way there is no problem with planarity of polygon vertices.