### PR TITLE
Create a ProjectionTool from a ball and strut

### DIFF
--- a/core/src/regression/files/2021/08-Aug/03-David-ProjectionTool-from-ball-and-strut/ProjectionTool-from-ball-and-strut.vZome
+++ b/core/src/regression/files/2021/08-Aug/03-David-ProjectionTool-from-ball-and-strut/ProjectionTool-from-ball-and-strut.vZome
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<vzome:vZome xmlns:vzome="http://xml.vzome.com/vZome/4.0.0/" buildNumber="DEV" coreVersion="7.0" edition="vZome" field="golden" version="7.0">
+  <EditHistory editNumber="100" lastStickyEdit="4">
+    <StrutCreation anchor="0 0 0 0 0 0" dir="yellow" index="9" len="1 1"/>
+    <SelectManifestation point="1 2 1 2 1 2"/>
+    <ApplyTool name="icosahedral.builtin/icosahedral around origin" selectInputs="true"/>
+    <Branch>
+      <BeginBlock/>
+      <DeselectAll/>
+      <SelectManifestation endSegment="1 2 1 2 1 2" startSegment="0 0 0 0 0 0"/>
+      <SelectManifestation point="0 0 0 0 0 0"/>
+      <EndBlock/>
+      <ProjectionTool name="tool-0"/>
+    </Branch>
+    <BeginBlock/>
+    <DeselectAll/>
+    <SelectManifestation point="1 2 1 2 1 2"/>
+    <SelectManifestation point="0 0 1 1 2 3"/>
+    <EndBlock/>
+    <JoinPoints closedLoop="false"/>
+    <ApplyTool name="icosahedral.builtin/icosahedral around origin" selectInputs="true"/>
+    <SelectAll/>
+    <ApplyTool name="tool-0"/>
+    <BeginBlock/>
+    <DeselectAll/>
+    <SelectManifestation point="-4/3 -8/3 2/3 4/3 2/3 4/3"/>
+    <SelectManifestation point="-1 -2 1 2 1 2"/>
+    <SelectManifestation point="-1 -1 2 3 0 0"/>
+    <SelectManifestation point="-4/3 -5/3 5/3 7/3 -1/3 -2/3"/>
+    <EndBlock/>
+    <Polygon/>
+    <BeginBlock/>
+    <SelectManifestation point="-1 -2 1 2 -1 -2"/>
+    <SelectManifestation point="-2/3 -4/3 4/3 8/3 -2/3 -4/3"/>
+    <SelectManifestation point="1/3 2/3 4/3 5/3 -5/3 -7/3"/>
+    <SelectManifestation point="0 0 1 1 -2 -3"/>
+    <EndBlock/>
+    <Polygon/>
+    <BeginBlock/>
+    <SelectManifestation point="2/3 4/3 2/3 4/3 -4/3 -8/3"/>
+    <SelectManifestation point="1 2 1 2 -1 -2"/>
+    <SelectManifestation point="2 3 0 0 -1 -1"/>
+    <SelectManifestation point="5/3 7/3 -1/3 -2/3 -4/3 -5/3"/>
+    <EndBlock/>
+    <Polygon/>
+    <BeginBlock/>
+    <SelectManifestation point="4/3 8/3 -2/3 -4/3 -2/3 -4/3"/>
+    <SelectManifestation point="1 2 -1 -2 -1 -2"/>
+    <SelectManifestation point="1 1 -2 -3 0 0"/>
+    <SelectManifestation point="4/3 5/3 -5/3 -7/3 1/3 2/3"/>
+    <EndBlock/>
+    <Polygon/>
+    <BeginBlock/>
+    <SelectManifestation point="2/3 4/3 -4/3 -8/3 2/3 4/3"/>
+    <SelectManifestation point="1 2 -1 -2 1 2"/>
+    <SelectManifestation point="0 0 -1 -1 2 3"/>
+    <SelectManifestation point="-1/3 -2/3 -4/3 -5/3 5/3 7/3"/>
+    <EndBlock/>
+    <Polygon/>
+    <BeginBlock/>
+    <SelectManifestation point="-1 -2 -1 -2 1 2"/>
+    <SelectManifestation point="-2/3 -4/3 -2/3 -4/3 4/3 8/3"/>
+    <SelectManifestation point="-5/3 -7/3 1/3 2/3 4/3 5/3"/>
+    <SelectManifestation point="-2 -3 0 0 1 1"/>
+    <EndBlock/>
+    <Polygon/>
+    <BeginBlock/>
+    <SelectManifestation point="0 0 0 0 0 0"/>
+    <SelectManifestation point="-1 -2 -1 -2 -1 -2"/>
+    <EndBlock/>
+    <JoinPoints closedLoop="false"/>
+    <BeginBlock/>
+    <DeselectAll/>
+    <SelectManifestation point="-1 -5/3 1 4/3 0 1/3"/>
+    <SelectManifestation point="1 4/3 0 1/3 -1 -5/3"/>
+    <SelectManifestation point="0 0 -1 -1 -2 -3"/>
+    <SelectManifestation point="-2 -3 0 0 -1 -1"/>
+    <EndBlock/>
+    <Polygon/>
+    <BeginBlock/>
+    <DeselectAll/>
+    <SelectManifestation point="0 1/3 -1 -5/3 1 4/3"/>
+    <SelectManifestation point="-1 -1 -2 -3 0 0"/>
+    <SelectManifestation point="-2 -3 0 0 -1 -1"/>
+    <SelectManifestation point="-1 -5/3 1 4/3 0 1/3"/>
+    <EndBlock/>
+    <Polygon/>
+    <BeginBlock/>
+    <SelectManifestation point="-1 -1 -2 -3 0 0"/>
+    <SelectManifestation point="0 0 -1 -1 -2 -3"/>
+    <SelectManifestation point="1 4/3 0 1/3 -1 -5/3"/>
+    <SelectManifestation point="0 1/3 -1 -5/3 1 4/3"/>
+    <EndBlock/>
+    <Polygon/>
+    <BeginBlock/>
+    <SelectManifestation>
+      <polygonVertex at="0 1/3 -1 -5/3 1 4/3"/>
+      <polygonVertex at="-1 -1 -2 -3 0 0"/>
+      <polygonVertex at="-2 -3 0 0 -1 -1"/>
+      <polygonVertex at="-1 -5/3 1 4/3 0 1/3"/>
+    </SelectManifestation>
+    <SelectManifestation>
+      <polygonVertex at="-1 -5/3 1 4/3 0 1/3"/>
+      <polygonVertex at="1 4/3 0 1/3 -1 -5/3"/>
+      <polygonVertex at="0 0 -1 -1 -2 -3"/>
+      <polygonVertex at="-2 -3 0 0 -1 -1"/>
+    </SelectManifestation>
+    <EndBlock/>
+    <CentralSymmetry/>
+    <BeginBlock/>
+    <DeselectAll/>
+    <AdjustSelectionByClass balls="SELECT" panels="IGNORE" struts="IGNORE"/>
+    <AdjustSelectionByClass balls="IGNORE" panels="IGNORE" struts="SELECT"/>
+    <DeselectAll/>
+    <EndBlock/>
+    <SelectToolParameters name="tool-0"/>
+    <SelectManifestation point="0 0 0 0 0 0"/>
+    <Hide/>
+    <SelectManifestation endSegment="-1 -2 -1 -2 -1 -2" startSegment="0 0 0 0 0 0"/>
+    <Hide/>
+  </EditHistory>
+  <notes/>
+  <sceneModel ambientLight="41,41,41" background="175,200,220">
+    <directionalLight color="235,235,228" x="1.0" y="-1.0" z="-1.0"/>
+    <directionalLight color="228,228,235" x="-1.0" y="0.0" z="0.0"/>
+    <directionalLight color="30,30,30" x="0.0" y="0.0" z="-1.0"/>
+  </sceneModel>
+  <Viewing>
+    <ViewModel distance="108.73126983642578" far="217.46253967285156" near="0.27182817459106445" parallel="false" stereoAngle="0.0" width="48.92906951904297">
+      <LookAtPoint x="0.0" y="0.0" z="0.0"/>
+      <UpDirection x="-0.5572799444198608" y="-0.3584202527999878" z="-0.7489851117134094"/>
+      <LookDirection x="0.24320638179779053" y="-0.9329349398612976" z="0.265487402677536"/>
+    </ViewModel>
+  </Viewing>
+  <SymmetrySystem name="icosahedral" renderingStyle="solid connectors">
+    <Direction color="0,118,149" name="blue"/>
+    <Direction color="0,141,54" name="green"/>
+    <Direction color="154,117,74" name="sand"/>
+    <Direction color="18,73,48" name="spruce"/>
+    <Direction color="175,0,0" name="red"/>
+    <Direction color="255,126,106" name="coral"/>
+    <Direction color="30,30,30" name="black"/>
+    <Direction color="117,0,50" name="maroon"/>
+    <Direction color="240,160,0" name="yellow"/>
+    <Direction color="230,245,62" name="sulfur"/>
+    <Direction color="255,51,143" name="rose"/>
+    <Direction color="18,205,148" name="turquoise"/>
+    <Direction color="116,195,0" name="apple"/>
+    <Direction color="136,37,0" name="cinnamon"/>
+    <Direction color="108,0,198" name="purple"/>
+    <Direction color="220,76,0" name="orange"/>
+    <Direction color="0,0,153" name="navy"/>
+    <Direction color="107,53,26" name="brown"/>
+    <Direction color="175,135,255" name="lavender"/>
+    <Direction color="100,113,0" name="olive"/>
+  </SymmetrySystem>
+  <OtherSymmetries>
+    <SymmetrySystem name="octahedral" renderingStyle="trapezoids">
+      <Direction color="0,118,149" name="blue"/>
+      <Direction color="175,135,255" name="lavender"/>
+      <Direction color="18,205,148" name="turquoise"/>
+      <Direction color="30,30,30" name="black"/>
+      <Direction color="0,141,54" name="green"/>
+      <Direction color="100,113,0" name="olive"/>
+      <Direction color="117,0,50" name="maroon"/>
+      <Direction color="107,53,26" name="brown"/>
+      <Direction color="240,160,0" name="yellow"/>
+      <Direction color="175,0,0" name="red"/>
+      <Direction color="108,0,198" name="purple"/>
+    </SymmetrySystem>
+  </OtherSymmetries>
+  <Tools>
+    <Tool id="tool-0" label="projection 0"/>
+  </Tools>
+</vzome:vZome>

--- a/core/src/regression/files/sniff-test.vZome-files
+++ b/core/src/regression/files/sniff-test.vZome-files
@@ -158,3 +158,6 @@ format-2.1.0-models.vZome-files
 
 # storing auto orbits from *all* symmetries
 2020/11-Nov/21-Scott-regression
+
+# ProjectionTool can now be generated from a ball and strut, not just a panel
+2021/08-Aug/03-David-ProjectionTool-from-ball-and-strut/ProjectionTool-from-ball-and-strut.vZome


### PR DESCRIPTION
A ProjectionTool can now be created from a strut that's normal to the projection plane and a ball on the plane.
The original way of creating a ProjectionTool from a panel and an optional strut still works the same as before.
A regression file is included which uses this new capability.