### PR TITLE
Version info always saved

### DIFF
--- a/core/src/main/java/com/vzome/core/editor/DocumentModel.java
+++ b/core/src/main/java/com/vzome/core/editor/DocumentModel.java
@@ -742,7 +742,6 @@ public class DocumentModel implements Snapshot .Recorder, Context
         value = editorProps .getProperty( "buildNumber" );
         if ( value != null )
             vZomeRoot .setAttribute( "buildNumber", value );
-        vZomeRoot .setAttribute( "coreVersion", this .coreVersion );
         vZomeRoot .setAttribute( "field", field.getName() );
 
         Element childElement;

--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/ApplicationController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/ApplicationController.java
@@ -265,10 +265,6 @@ public class ApplicationController extends DefaultController
                     DocumentModel document = modelApp .createDocument( fieldName );
                     String title = "Untitled " + ++lastUntitled;
                     docProps .setProperty( "window.title", title );
-                    docProps .setProperty( "edition", this .properties .getProperty( "edition" ) );
-                    docProps .setProperty( "version", this .properties .getProperty( "version" ) );
-                    docProps .setProperty( "buildNumber", this .properties .getProperty( "buildNumber" ) );
-                    docProps .setProperty( "gitCommit", this .properties .getProperty( "gitCommit" ) );
                     newDocumentController( title, document, docProps );
                 }
             }
@@ -542,6 +538,11 @@ public class ApplicationController extends DefaultController
         props .setProperty( "githubClientId", this .properties .getProperty( "githubClientId" ) );
         props .setProperty( "githubClientSecret", this .properties .getProperty( "githubClientSecret" ) );
         
+//        props .setProperty( "edition", this .properties .getProperty( "edition" ) );
+        props .setProperty( "version", this .properties .getProperty( "version" ) );
+        props .setProperty( "buildNumber", this .properties .getProperty( "buildNumber" ) );
+        props .setProperty( "gitCommit", this .properties .getProperty( "gitCommit" ) );
+
         DocumentController newest = new DocumentController( document, this, props );
         this .registerDocumentController( name, newest );
         // trigger window creation in the UI


### PR DESCRIPTION
Until now, only new documents correctly saved the version info.

I also removed the irrelevant "coreVersion" and "edition" attributes.