### PR TITLE
Fixed 2d export background defect

### DIFF
--- a/core/src/main/java/com/vzome/core/editor/DocumentModel.java
+++ b/core/src/main/java/com/vzome/core/editor/DocumentModel.java
@@ -973,12 +973,12 @@ public class DocumentModel implements Snapshot .Recorder, Context
         return snapshot;
     }
 
-    public void export2d( Java2dSnapshot snapshot, String format, File file, boolean doOutlines, boolean monochrome ) throws Exception
+    public void export2d( Java2dSnapshot snapshot, String format, File file, boolean doOutlines, boolean monochrome, boolean showBackground ) throws Exception
     {
         SnapshotExporter exporter = this .app .getSnapshotExporter( format );
         // A try-with-resources block closes the resource even if an exception occurs
         try ( Writer out = new FileWriter( file ) ) {
-            exporter .export( snapshot, out, doOutlines, monochrome );
+            exporter .export( snapshot, out, doOutlines, monochrome, showBackground );
         }
     }
 

--- a/core/src/main/java/com/vzome/core/exporters2d/SnapshotExporter.java
+++ b/core/src/main/java/com/vzome/core/exporters2d/SnapshotExporter.java
@@ -77,7 +77,7 @@ public abstract class SnapshotExporter {
 		}
 	}
 	
-	public void export( Java2dSnapshot snapshot, Writer writer, boolean doOutlines, boolean monochrome )
+	public void export( Java2dSnapshot snapshot, Writer writer, boolean doOutlines, boolean monochrome, boolean showBackground )
 	{
         XY_FORMAT .setGroupingUsed( false );
         XY_FORMAT .setMaximumFractionDigits( 2 );
@@ -96,7 +96,7 @@ public abstract class SnapshotExporter {
 		outputPrologue( snapshot .getRect(), strokeWidth );
 		
 		Color bgColor = snapshot .getBackgroundColor();
-		if ( bgColor != null )
+		if ( bgColor != null && showBackground )
 			outputBackground( bgColor );
 		
         if ( ! lines .isEmpty() )

--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
@@ -870,7 +870,7 @@ public class DocumentController extends DefaultController implements Scene.Provi
                 Dimension size = this .modelCanvas .getSize();
                 String format = command .substring( "export2d." .length() ) .toLowerCase();
                 Java2dSnapshot snapshot = documentModel .capture2d( currentSnapshot, size.height, size.width, cameraController .getView(), sceneLighting, false, true );
-                documentModel .export2d( snapshot, format, file, this .drawOutlines, false );
+                documentModel .export2d( snapshot, format, file, this .drawOutlines, false, true );
                 this .openApplication( file );
                 return;
             }

--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/Java2dSnapshotController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/Java2dSnapshotController.java
@@ -150,7 +150,7 @@ public class Java2dSnapshotController extends DefaultController
     {
         try {
             String format = command .substring( "export2d." .length() ) .toLowerCase();
-            this .document .export2d( snapshot, format, file, this .outlinePanels, this .monochrome );
+            this .document .export2d( snapshot, format, file, this .outlinePanels, this .monochrome, this .showBackground );
             openApplication( file );
         } catch ( Exception e ) {
             mErrors .reportError( UNKNOWN_ERROR_CODE, new Object[]{ e } );


### PR DESCRIPTION
The "show background" checkbox was not respected when exporting, so the
background was always rendered.  The defect was only for export; the on-screen
rendering was correct.