### PR TITLE
Fixed the NPE when pasting golden JSON into sqrtPhi

### DIFF
--- a/core/src/jsweet/java/com/vzome/jsweet/JsAlgebraicField.java
+++ b/core/src/jsweet/java/com/vzome/jsweet/JsAlgebraicField.java
@@ -473,17 +473,6 @@ public class JsAlgebraicField implements AlgebraicField
         return createAlgebraicNumber( ones, phis, div, 0 );
     }
 
-    @Override
-    public AlgebraicVector createIntegerVectorFromTDs(int[][] nums)
-    {
-        final int dims = nums.length;
-        AlgebraicVector result = origin( dims );
-        for (int dim = 0; dim < dims; dim++) {
-            result .setComponent( dim, createAlgebraicNumberFromTD( nums[dim] ) );
-        }
-        return result;
-    }
-
     
     
     

--- a/core/src/main/java/com/vzome/core/algebra/AlgebraicField.java
+++ b/core/src/main/java/com/vzome/core/algebra/AlgebraicField.java
@@ -173,15 +173,6 @@ public interface AlgebraicField
     AlgebraicVector createIntegerVector( int[][] nums );
     
     /**
-     * Generates an AlgebraicVector with all AlgebraicNumber terms in "trailing divisor" int array form.
-     * @param nums is a 2 dimensional integer array. The length of nums becomes the number of dimensions in the resulting AlgebraicVector.
-     * For example, {@code (new PentagonField()).createIntegerVectorFromTDs( new int[][]{ {0,-1,1}, {2,3,2}, {4,5,2} } ); } 
-     * generates the 3 dimensional vector (-φ, 1 +3φ/2, 2 +5φ/2). 
-     * @return an AlgebraicVector
-     */
-    AlgebraicVector createIntegerVectorFromTDs( int[][] nums );
-
-    /**
      * Create a 3x3 square matrix from integer data.
      * TODO: Generalize this method to create a matrix with dimensions matching the dimensions of the data array
      * Sample input data for an order-4 field:
@@ -217,4 +208,21 @@ public interface AlgebraicField
     boolean scale4dRoots();
     
     boolean doubleFrameVectors();
+
+    default boolean supportsSubfield( String fieldName )
+    {
+        // most common, so check this first
+        if ( fieldName.equals( this .getName()) )
+            return true;
+        
+        //  I'm disabling this as unimportant, and very hard to work around.
+//        if (AlgebraicFields.haveSameInitialCoefficients(field, fieldName) )
+//            return true;
+
+        // any field that returns a non-null goldenRatio is expected to be able 
+        // to map a pair of golden field terms to the corresponding terms in that field
+        // by overriding AbstractAlgebraicField.convertGoldenNumberPairs().
+        // See SqrtPhiField.prepareAlgebraicNumberTerms() for an example.
+        return fieldName .equals( "golden" ) && this.getGoldenRatio() != null;
+    }
 }

--- a/core/src/main/java/com/vzome/core/algebra/SnubDodecField.java
+++ b/core/src/main/java/com/vzome/core/algebra/SnubDodecField.java
@@ -200,6 +200,8 @@ public class SnubDodecField extends AbstractAlgebraicField
         return getUnitTerm(1);
     }
     
+    // No need to override convertGoldenNumberPairs() as long as phi is the first irrational
+
     @Override
     public String getIrrational( int which, int format )
     {

--- a/core/src/main/java/com/vzome/core/edits/ImportMesh.java
+++ b/core/src/main/java/com/vzome/core/edits/ImportMesh.java
@@ -183,10 +183,11 @@ public abstract class ImportMesh extends ChangeManifestations
             @Override
             public AlgebraicField getField( String name )
             {
-                if ( field .getName() .equals( name ) )
+                if ( field .supportsSubfield( name ) )
                     return field;
-                else
+                else {
                     return null;
+                }
             }
         };
         
@@ -196,7 +197,7 @@ public abstract class ImportMesh extends ChangeManifestations
         try {
             this .parseMeshData( offset, events, registry );
         } catch ( IOException e ) {
-            throw new Failure( "The selected file has incorrect content for this import.\n" + e .getMessage() );
+            throw new Failure( "Incorrect content for this import:\n" + e .getMessage() );
         }
 
         redo();

--- a/core/src/main/java/com/vzome/core/math/VefParser.java
+++ b/core/src/main/java/com/vzome/core/math/VefParser.java
@@ -93,22 +93,6 @@ public abstract class VefParser
         return mVersion >= VERSION_W_FIRST;
     }
     
-    public static boolean fieldsAreCompatible(final AlgebraicField field, String fieldName) {
-        // most common, so check this first
-        if (fieldName.equals(field .getName()) )
-            return true;
-        
-        //  I'm disabling this as unimportant, and very hard to work around.
-//        if (AlgebraicFields.haveSameInitialCoefficients(field, fieldName) )
-//            return true;
-
-        // any field that returns a non-null goldenRatio is expected to be able 
-        // to map a pair of golden field terms to the coresponding terms in that field
-        // by overriding prepareAlgebraicNumberTerms().
-        // See SqrtPhiField.prepareAlgebraicNumberTerms() for an example.
-        return fieldName.equals("golden") && field.getGoldenRatio() != null;
-    }
-
     public void parseVEF( String vefData, final AlgebraicField field )
     {
         this.field = field;
@@ -155,7 +139,7 @@ public abstract class VefParser
                 isRational = true;
                 token = field .getName();
             }
-            if(! fieldsAreCompatible(field, token) ) {
+            if(! field.supportsSubfield( token) ) {
                 throw new IllegalStateException( "VEF field mismatch error: VEF field name (\"" + token + "\") does not match current model field name (\"" + field .getName() + "\")." );
             }
             token = tokens .nextToken();

--- a/core/src/main/java/com/vzome/core/model/ColoredMeshJson.java
+++ b/core/src/main/java/com/vzome/core/model/ColoredMeshJson.java
@@ -136,7 +136,9 @@ public class ColoredMeshJson
         
         String fieldName = ( node .has( "field") )? node .get( "field" ) .asText() : "golden";
         AlgebraicField field = registry .getField( fieldName );
-        // TODO: fail if field is null
+        if ( field == null ) {
+            throw new IOException( "This document cannot import mesh data from field \"" + fieldName + "\"" );
+        }
         
         if ( ! node .has( "vertices" ) ) {
             throw new IOException( "There is no 'vertices' list in the JSON" );
@@ -155,7 +157,7 @@ public class ColoredMeshJson
                 for ( JsonNode numberNode : vectorNode ) {
                     nums[ i++ ] = mapper .treeToValue( numberNode, new int[]{}.getClass() ); // JSweet compiler confused by int[].class
                 }
-                AlgebraicVector vertex = field .createIntegerVectorFromTDs( nums );
+                AlgebraicVector vertex = field .createVectorFromTDs( nums );
                 if ( vertex .dimension() > 3 )
                     vertex = projection .projectImage( vertex, false );
                 if ( offset != null )

--- a/core/src/main/java/com/vzome/core/model/SimpleMeshJson.java
+++ b/core/src/main/java/com/vzome/core/model/SimpleMeshJson.java
@@ -123,7 +123,9 @@ public class SimpleMeshJson
         
         String fieldName = ( node .has( "field") )? node .get( "field" ) .asText() : "golden";
         AlgebraicField field = registry .getField( fieldName );
-        // TODO: fail if field is null
+        if ( field == null ) {
+            throw new IOException( "This document cannot import mesh data from field \"" + fieldName + "\"" );
+        }
         
         if ( ! node .has( "vertices" ) ) {
             throw new IOException( "There is no 'vertices' list in the JSON" );
@@ -145,7 +147,7 @@ public class SimpleMeshJson
                 for ( JsonNode numberNode : vectorNode ) {
                     nums[ i++ ] = mapper .treeToValue( numberNode, new int[]{}.getClass() ); // JSweet compiler confused by int[].class
                 }
-                AlgebraicVector vertex = field .createIntegerVectorFromTDs( nums );
+                AlgebraicVector vertex = field .createVectorFromTDs( nums );
                 if ( vertex .dimension() > 3 )
                     vertex = projection .projectImage( vertex, false );
                 if ( offset != null )

--- a/core/src/test/java/com/vzome/core/algebra/AlgebraicFieldTest.java
+++ b/core/src/test/java/com/vzome/core/algebra/AlgebraicFieldTest.java
@@ -186,6 +186,21 @@ public class AlgebraicFieldTest {
 
             num = field.parseVefNumber("(1,2)", false);
             assertEquals(msg, golden2, num);
+            
+            num = field .createAlgebraicNumberFromTD( new int[]{ 0, 0, 1 } );
+            assertTrue( msg, num.isZero() );
+            
+            num = field .createAlgebraicNumberFromTD( new int[]{ 1, 0, 1 } );
+            assertTrue( msg, num.isOne() );
+            
+            num = field .createAlgebraicNumberFromTD( new int[]{ 0, 1, 1 } );
+            assertEquals( msg, golden, num );
+            
+            num = field .createAlgebraicNumberFromTD( new int[]{ 1, 1, 1 } );
+            assertEquals( msg, golden1, num );
+            
+            num = field .createAlgebraicNumberFromTD( new int[]{ 2, 1, 1 } );
+            assertEquals( msg, golden2, num );
         }
     }
         


### PR DESCRIPTION
I moved the VefParser.fieldsAreCompatible() static method into AF as a
default method, so now it is called from the AF.Registry in ImportMesh.

ColoredMeshJson.parse() and SimpleMeshJson.parse() now test for a null
field, corresponding to incompatible fields.

I improved the error message in ImportMesh, for any exception.

The AAF.convertGoldenNumberPairs() base implementation now handles simple
extension of the array size to match the field order.

Most importantly, AAF.createAlgebraicNumberFromTD() now calls
convertGoldenNumberPairs() when appropriate.  To do this, it has to
convert from trailing divisors to pairs, and back again.

I also removed AF.createIntegerVectorFromTDs(), after I realized that
the JSON mesh imports could use AF.createVectorFromTDs, and it makes no
sense to create an "integer" vector from trailing divisor forms.