### PR TITLE
Set the canvas pixel ratio to match the device.

### DIFF
--- a/pwa/src/App.js
+++ b/pwa/src/App.js
@@ -26,7 +26,7 @@ function App( {structure, workingPlane, doMoveWorkingPlane, doToggleStrutMode, d
     doMoveWorkingPlane( end )
   }
   return (
-    <Canvas camera={{ fov: 50 }} resize={{polyfill}}>
+    <Canvas camera={{ fov: 50 }} resize={{polyfill}} dpr={window.devicePixelRatio}>
       <Controls staticMoving='true' rotateSpeed={6} zoomSpeed={3} panSpeed={1} />
       <Scene points={structure.points} segments={structure.segments}
         buildEdge={buildNodeOrEdge}

--- a/react-library/src/components/designcanvas.jsx
+++ b/react-library/src/components/designcanvas.jsx
@@ -71,7 +71,7 @@ const DesignCanvas = ( { lighting, camera, children, handleBackgroundClick=()=>{
 {
   const { fov, position, up, lookAt } = camera || defaultInitialCamera
   return(
-    <Canvas gl={{ antialias: true, alpha: false }} onPointerMissed={handleBackgroundClick} >
+    <Canvas dpr={ window.devicePixelRatio } gl={{ antialias: true, alpha: false }} onPointerMissed={handleBackgroundClick} >
       <PerspectiveCamera makeDefault {...{fov, position, up}}>
         <Lighting {...(lighting || defaultLighting)} />
       </PerspectiveCamera>


### PR DESCRIPTION
This makes for a nice crisp display on Retina screens, and performance still looks good!

`window.devicePixelRatio` is very widely available: https://caniuse.com/?search=devicePixelRatio

See it in action at https://garron.net/temp/vzome-viewer/ (using a hack).