### PR TITLE
Fixed the download button for vzome-viewer

### DIFF
--- a/online/src/wc/urlviewer.jsx
+++ b/online/src/wc/urlviewer.jsx
@@ -3,8 +3,6 @@ import React from 'react'
 import { ShapedGeometry } from './components/geometry.jsx'
 import { DesignCanvas } from './components/designcanvas.jsx'
 import { useVZomeUrl } from './components/hooks.js'
-import Fab from '@material-ui/core/Fab'
-import GetAppRoundedIcon from '@material-ui/icons/GetAppRounded'
 
 // from https://www.bitdegree.org/learn/javascript-download
 export const download = ( url, xml ) =>
@@ -21,6 +19,7 @@ export const download = ( url, xml ) =>
   document.body.removeChild( element )
 }
 
+
 export const UrlViewer = props =>
 {
   const { text, scene } = useVZomeUrl( props.url, props.camera )
@@ -30,11 +29,13 @@ export const UrlViewer = props =>
         { (scene && scene.shapes)? <ShapedGeometry {...scene} /> : null }
       </DesignCanvas>
       { text &&
-        <Fab color="primary" size="small" aria-label="download"
-            style={ { position: 'absolute' } }
-            onClick={() => download( props.url, text ) } >
-          <GetAppRoundedIcon fontSize='small'/>
-        </Fab> }
+        <button className='muiButton' onClick={ () => download( props.url, text ) }>
+          {/* Material-UI was not building correctly, leaving the styles behind when using esbuild,
+              so I have simply hand-coded this, copying their styles and SVG.  See vzome-viewer.css.ts. */}
+          <svg focusable="false" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M16.59 9H15V4c0-.55-.45-1-1-1h-4c-.55 0-1 .45-1 1v5H7.41c-.89 0-1.34 1.08-.71 1.71l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.63-.63.19-1.71-.7-1.71zM5 19c0 .55.45 1 1 1h12c.55 0 1-.45 1-1s-.45-1-1-1H6c-.55 0-1 .45-1 1z"></path>
+          </svg>
+        </button> }
     </div>
   )
 }

--- a/online/src/wc/vzome-viewer.css.ts
+++ b/online/src/wc/vzome-viewer.css.ts
@@ -4,6 +4,7 @@ export const vZomeViewerCSS: string = `
   width: 384px;
   height: 256px;
   overflow: hidden;
+  position: relative;
 }
 
 :host > div {
@@ -29,4 +30,37 @@ export const vZomeViewerCSS: string = `
   place-content: center;
 }
 
+.muiButton:hover {
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.muiButton {
+  flex: 0 0 auto;
+  color: inherit;
+  padding: 12px;
+  overflow: visible;
+  font-size: 1.5rem;
+  text-align: center;
+  transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  border-radius: 50%;
+  border: 0;
+  cursor: pointer;
+  margin: 0;
+  display: inline-flex;
+  outline: 0;
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  height: 50px;
+  width: 50px;
+  align-items: center;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  justify-content: center;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-appearance: none;
+  -webkit-tap-highlight-color: transparent;
+}
 `;


### PR DESCRIPTION
Material-UI was not building correctly, leaving the styles behind when
using esbuild, so I have simply hand-coded this, copying their styles and
SVG.  See vzome-viewer.css.ts.