### PR TITLE
Material-UI is working again in the custom element

### DIFF
--- a/online/src/wc/urlviewer.jsx
+++ b/online/src/wc/urlviewer.jsx
@@ -3,6 +3,8 @@ import React from 'react'
 import { ShapedGeometry } from './components/geometry.jsx'
 import { DesignCanvas } from './components/designcanvas.jsx'
 import { useVZomeUrl } from './components/hooks.js'
+import IconButton from '@material-ui/core/IconButton'
+import GetAppRoundedIcon from '@material-ui/icons/GetAppRounded'
 
 // from https://www.bitdegree.org/learn/javascript-download
 export const download = ( url, xml ) =>
@@ -24,18 +26,16 @@ export const UrlViewer = props =>
 {
   const { text, scene } = useVZomeUrl( props.url, props.camera )
   return (
-    <div style={ { display: 'flex', height: '100%' } }>
+    <div style={ { display: 'flex', height: '100%', position: 'relative' } }>
       <DesignCanvas {...scene} >
         { (scene && scene.shapes)? <ShapedGeometry {...scene} /> : null }
       </DesignCanvas>
       { text &&
-        <button className='muiButton' onClick={ () => download( props.url, text ) }>
-          {/* Material-UI was not building correctly, leaving the styles behind when using esbuild,
-              so I have simply hand-coded this, copying their styles and SVG.  See vzome-viewer.css.ts. */}
-          <svg focusable="false" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M16.59 9H15V4c0-.55-.45-1-1-1h-4c-.55 0-1 .45-1 1v5H7.41c-.89 0-1.34 1.08-.71 1.71l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.63-.63.19-1.71-.7-1.71zM5 19c0 .55.45 1 1 1h12c.55 0 1-.45 1-1s-.45-1-1-1H6c-.55 0-1 .45-1 1z"></path>
-          </svg>
-        </button> }
+        <IconButton color="inherit" aria-label="download"
+            style={ { position: 'absolute', top: '5px', right: '5px' } }
+            onClick={() => download( props.url, text ) } >
+          <GetAppRoundedIcon fontSize='medium'/>
+        </IconButton> }
     </div>
   )
 }

--- a/online/src/wc/vzome-viewer.js
+++ b/online/src/wc/vzome-viewer.js
@@ -3,55 +3,67 @@ import "regenerator-runtime/runtime";
 
 import React from "react";
 import ReactDOM from "react-dom";
-// @ts-ignore // no types available
+import { StylesProvider, jssPreset } from '@material-ui/styles';
+import { create } from 'jss';
+
 import * as vZome from "./urlviewer";
 import { vZomeViewerCSS } from "./vzome-viewer.css";
 
 export class VZomeViewer extends HTMLElement {
-  #root: ShadowRoot;
-  #container: HTMLElement;
+  #root;
+  #stylesMount;
+  #container;
   constructor() {
     super();
     this.#root = this.attachShadow({ mode: "open" });
 
-    this.#root.appendChild(document.createElement("style")).textContent =
-      vZomeViewerCSS;
-    this.#container = this.#root.appendChild(document.createElement("div"));
+    this.#root.appendChild(document.createElement("style")).textContent = vZomeViewerCSS;
+    this.#stylesMount = document.createElement("div");
+    this.#container = this.#root.appendChild( this.#stylesMount );
   }
 
-  connectedCallback(): void {
+  connectedCallback() {
     this.#render();
   }
 
-  #reactElement: React.ComponentElement<vZome.UrlViewer, any> | null = null;
-  get reactElement(): React.ComponentElement<vZome.UrlViewer, any> | null {
+  #reactElement = null;
+  get reactElement() {
     return this.#reactElement;
   }
 
-  #render(): void {
+  #render() {
     if (this.src === null || this.src === "") {
       ReactDOM.unmountComponentAtNode(this.#container);
       this.#reactElement = null;
       return;
     }
 
-    // TODO: Scale canvas by `window.devicePixelRatio`.
     // TODO: Can we handle canvas resizing using `ResizeObserver` without modifying `vZome` or recreating the element constantly?
-    this.#reactElement = React.createElement(vZome.UrlViewer, {
+    const viewerElement = React.createElement(vZome.UrlViewer, {
       url: this.src,
     });
-    ReactDOM.render(this.#reactElement, this.#container);
+
+    // We need JSS to inject styles on our shadow root, not on the document head.
+    // I found this solution here:
+    //   https://stackoverflow.com/questions/51832583/react-components-material-ui-theme-not-scoped-locally-to-shadow-dom
+    const jss = create({
+        ...jssPreset(),
+        insertionPoint: this.#container
+    });
+    this.#reactElement = React.createElement(StylesProvider, { jss: jss }, [ viewerElement ] );
+
+    ReactDOM.render(this.#reactElement, this.#stylesMount);
   }
 
-  static get observedAttributes(): string[] {
+  static get observedAttributes() {
     return ["src"];
   }
 
   attributeChangedCallback(
-    attributeName: string,
-    _oldValue: string,
-    _newValue: string
-  ): void {
+    attributeName,
+    _oldValue,
+    _newValue
+  ) {
     switch (attributeName) {
       case "src":
         this.#render();
@@ -59,7 +71,7 @@ export class VZomeViewer extends HTMLElement {
   }
 
   // Reflect the attribute in a JS property.
-  set src(newSrc: string | null) {
+  set src(newSrc) {
     if (newSrc === null) {
       this.removeAttribute("src");
     } else {
@@ -67,7 +79,7 @@ export class VZomeViewer extends HTMLElement {
     }
   }
 
-  get src(): string | null {
+  get src() {
     return this.getAttribute("src");
   }
 }


### PR DESCRIPTION
MUI adds styles at runtime via JS, and by default they get added to the
HTML head.  I found a solution that adds them under the shadow root:

https://stackoverflow.com/questions/51832583/react-components-material-ui-theme-not-scoped-locally-to-shadow-dom