### PR TITLE
Removed log4j and other unneeded JARs from packaging

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -80,9 +80,11 @@ dependencies {
 	compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.9.3'
 	compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.3'
 
-    compile group: 'org.jsweet', name: 'jsweet-transpiler', version: '3.0.0'
-    compile group: 'org.jsweet', name: 'jsweet-core', version: "6.1.0"
-    compile group: 'org.jsweet', name: 'j4ts', version: '2.0.0'
+    if( project.gradle.startParameter.taskNames.contains( 'core:jsweet' ) ) {
+        compile group: 'org.jsweet', name: 'jsweet-transpiler', version: '3.0.0'
+        compile group: 'org.jsweet', name: 'jsweet-core', version: "6.1.0"
+        compile group: 'org.jsweet', name: 'j4ts', version: '2.0.0'
+    }
 
     runtime     group: 'org.python',        name: 'jython',            version:'2.7.1b3'
     runtime     group: 'java3d',            name: 'vecmath',           version:'1.6.0-final'


### PR DESCRIPTION
Since the jsweet Gradle plugin uses the "compile" configuration from the
Java plugin, it polluted the runtime classpath when I added JSweet and
its dependencies.  This is really a defect in the JSweet plugin.

I resolved it by making the dependency additions conditional on the task.