### PR TITLE
Fixed regression in older files

### DIFF
--- a/core/src/main/java/com/vzome/core/construction/Point.java
+++ b/core/src/main/java/com/vzome/core/construction/Point.java
@@ -21,7 +21,7 @@ public abstract class Point extends Construction
     
     public String getSignature()
     {
-        return this .mLocation .toString();
+        return this .mLocation .projectTo3d( true ) .toString();
     }
 
     @Override

--- a/core/src/main/java/com/vzome/core/construction/Polygon.java
+++ b/core/src/main/java/com/vzome/core/construction/Polygon.java
@@ -29,7 +29,7 @@ public abstract class Polygon extends Construction
     public String getSignature()
     {
 //    	System.err.println( "Warning, Polygon.getSignature() may not work in Javascript" );
-        String[] strArray = Arrays.stream( mVertices ) .map( ( av ) -> av.toString() ) .toArray( String[]::new );
+        String[] strArray = Arrays.stream( mVertices ) .map( ( av ) -> av.projectTo3d( true ).toString() ) .toArray( String[]::new );
 //        System.err.println( "unsorted: " + Arrays.toString( strArray ) );
         Arrays.sort( strArray ); // This sort implementation may be broken in Javascript
 //        System.err.println( "  sorted: " + Arrays.toString( strArray ) );

--- a/core/src/main/java/com/vzome/core/construction/Segment.java
+++ b/core/src/main/java/com/vzome/core/construction/Segment.java
@@ -27,8 +27,8 @@ public abstract class Segment extends Construction
     
     public String getSignature()
     {
-    	String start = this .mStart .toString();
-    	String end = this .getEnd() .toString();
+    	String start = this .mStart .projectTo3d( true ) .toString();
+    	String end = this .getEnd() .projectTo3d( true ) .toString();
     	if ( start .compareTo( end ) <= 0 )
     		return start + "," + end;
     	else


### PR DESCRIPTION
The recent changes related to Construction.getSignature() cause a regression
in older vZome files that had 4D data.  Signatures were computed using
4D data, but compared with signatures already in the RealizedModel
computed using 3D data.