### PR TITLE
Fixed the problem with async createWorkerStore

### DIFF
--- a/online/public/index.html
+++ b/online/public/index.html
@@ -25,7 +25,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <script type="module" src="/modules/vzome-online.js"></script>
+    <script type="module" src="../modules/vzome-online.js"></script>
     <script>
       // Check that service workers are supported
       if ('serviceWorker' in navigator) {

--- a/online/src/app/App.jsx
+++ b/online/src/app/App.jsx
@@ -4,17 +4,16 @@ import React from 'react'
 import { DesignHistoryInspector } from './components/inspector.jsx'
 import { ErrorAlert } from './components/alert.jsx'
 import { VZomeAppBar } from './components/appbar.jsx'
+import { getModelURL } from './components/folder.jsx';
 import { DesignViewer, WorkerContext, useVZomeUrl } from '../ui/viewer/index.jsx'
 
 const queryParams = new URLSearchParams( window.location.search );
 const url = queryParams.get( 'url' ); // support for legacy viewer usage (old vZome shares)
 const legacyViewerMode = !!url;
 
-console.log( 'App import.meta.url ===', JSON.stringify( import.meta.url ) );
-
 const App = () =>
 {
-  useVZomeUrl( url || '/app/models/vZomeLogo.vZome', { preview: legacyViewerMode } );
+  useVZomeUrl( url || getModelURL( 'vZomeLogo' ), { preview: legacyViewerMode } );
 
   return (
     <>

--- a/online/src/app/components/folder.jsx
+++ b/online/src/app/components/folder.jsx
@@ -50,7 +50,7 @@ const models = [
   },
 ]
 
-console.log( 'Folder import.meta.url ===', JSON.stringify( import.meta.url ) );
+export const getModelURL = key => new URL( `./models/${key}.vZome`, window.location ) .toString();
 
 export const OpenMenu = props =>
 {
@@ -91,7 +91,7 @@ export const OpenMenu = props =>
   const handleSelectModel = model => {
     setAnchorEl(null)
     const { url, key } = model
-    openUrl( url || `/app/models/${key}.vZome`, key )
+    openUrl( url || getModelURL( key ), key );
   }
 
   const handleClose = () => {

--- a/online/src/wc/vzome-viewer.js
+++ b/online/src/wc/vzome-viewer.js
@@ -9,7 +9,7 @@ export class VZomeViewer extends HTMLElement {
   #root;
   #stylesMount;
   #container;
-  #storePromise;
+  #store;
   #url;
   constructor() {
     super();
@@ -19,29 +19,27 @@ export class VZomeViewer extends HTMLElement {
     this.#stylesMount = document.createElement("div");
     this.#container = this.#root.appendChild( this.#stylesMount );
 
-    this.#storePromise = createWorkerStore( this );
+    this.#store = createWorkerStore( this );
 
-    this.#storePromise.then( store => {
-      if ( this.hasAttribute( 'src' ) ) {
-        const url = this.getAttribute( 'src' );
-        if ( ! url.endsWith( ".vZome" ) ) {
-          // This is the only case in which we don't resolve the promise with text,
-          //  since there is no point in allowing download of non-vZome text.
-          alert( `Unrecognized file name: ${url}` );
-        }
-        else
-          this.#url = url;
-          // Get the fetch started by the worker before we load the dynamic module below,
-          //  which is pretty big.  I really should encapsulate the message in a function!
-          store.dispatch( { type: 'URL_PROVIDED', payload: { url, viewOnly: true } } );
+    if ( this.hasAttribute( 'src' ) ) {
+      const url = this.getAttribute( 'src' );
+      if ( ! url.endsWith( ".vZome" ) ) {
+        // This is the only case in which we don't resolve the promise with text,
+        //  since there is no point in allowing download of non-vZome text.
+        alert( `Unrecognized file name: ${url}` );
       }
-    } );
+      else
+        this.#url = url;
+        // Get the fetch started by the worker before we load the dynamic module below,
+        //  which is pretty big.  I really should encapsulate the message in a function!
+        this.#store.dispatch( { type: 'URL_PROVIDED', payload: { url, viewOnly: true } } );
+    }
   }
 
   connectedCallback() {
-    Promise.all( [ this.#storePromise, import( '../ui/viewer/index.jsx' ) ] )
-      .then( ([ store, module ]) => {
-        this.#reactElement = module.renderViewer( store, this.#container, this.#stylesMount, this.#url );
+    import( '../ui/viewer/index.jsx' )
+      .then( module => {
+        this.#reactElement = module.renderViewer( this.#store, this.#container, this.#stylesMount, this.#url );
       })
   }
 
@@ -62,8 +60,7 @@ export class VZomeViewer extends HTMLElement {
     switch (attributeName) {
       case "src":
       this.#url = _newValue;
-      this.#storePromise.then( store => 
-        store.dispatch( { type: 'URL_PROVIDED', payload: { url: _newValue, viewOnly: true } } ) );
+      this.#store.dispatch( { type: 'URL_PROVIDED', payload: { url: _newValue, viewOnly: true } } );
     }
   }
 


### PR DESCRIPTION
Since the store dispatch to the worker is already async, it made much
more sense to hide the async nature within createWorkerStore().  This way
I can return the store synchronously, keeping client code simple.

I also (finally!) fixed the access pattern for built-in models, eliminating
the silly absolute paths.