### PR TITLE
Share gesture can now use the original file mod date-time

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/ApplicationController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/ApplicationController.java
@@ -353,6 +353,7 @@ public class ApplicationController extends DefaultController
 
             case "open":
                 docProps .setProperty( "window.file", path );
+                docProps .setProperty( "original.path", path );
                 break;
 
             case "newFromTemplate":
@@ -364,6 +365,7 @@ public class ApplicationController extends DefaultController
             case "openDeferringRedo":
                 docProps .setProperty( "open.undone", "true" );
                 docProps .setProperty( "window.file", path );
+                docProps .setProperty( "original.path", path );
                 break;
 
             default:

--- a/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
+++ b/desktop/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
@@ -1159,8 +1159,7 @@ public class DocumentController extends DefaultController implements Scene.Provi
             
         case "png-base64": {
             ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-            String maxSizeStr = getProperty( "max.image.size" );
-            final int maxSize = ( maxSizeStr != null )? Integer .parseInt( maxSizeStr ) : -1;
+            final int maxSize = 1600;
             boolean withAlpha = true;
             BufferedImage image = imageCaptureViewer .captureImage( maxSize, withAlpha );
             try {
@@ -1277,8 +1276,10 @@ public class DocumentController extends DefaultController implements Scene.Provi
             String oldValue = this .properties .getProperty( "window.file" );
             if ( value == null )
                 this .properties .remove( "window.file" );
-            else
+            else {
                 this .properties .setProperty( "window.file", (String) value );
+                this .properties .setProperty( "original.path", (String) value );
+            }
             // App controller is listening, will change its map
             firePropertyChange( "name", oldValue, value );
             firePropertyChange( "window.file", oldValue, value );

--- a/desktop/src/main/java/org/vorthmann/zome/ui/ShareDialog.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/ShareDialog.java
@@ -13,8 +13,6 @@ import java.awt.event.ActionListener;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -83,6 +81,7 @@ public class ShareDialog extends EscapeDialog
     
     // Inputs
     private transient String fileName, png, xml, shapesJson;
+    private LocalDateTime createTime;
         
     /* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
      * First, the code that runs on the Swing event dispatcher thread...
@@ -274,9 +273,10 @@ public class ShareDialog extends EscapeDialog
         }
     }
 
-    public void startUpload( String fileName, String xml, String png, String shapesJson )
+    public void startUpload( String fileName, LocalDateTime createTime, String xml, String png, String shapesJson )
     {
         this.fileName = fileName;
+        this.createTime = createTime;
         this.xml = xml;
         this.png = png;
         this.shapesJson = shapesJson;
@@ -385,14 +385,12 @@ public class ShareDialog extends EscapeDialog
             int index = designName .toLowerCase() .lastIndexOf( ".vZome" .toLowerCase() );
             if ( index > 0 )
                 designName = designName .substring( 0, index );
-//            String encodedName = URLEncoder.encode( designName, StandardCharsets.UTF_8.toString() );
             String title = designName .replaceAll( "-", " " );
 
             // prepare the substitutions
-            LocalDateTime now = LocalDateTime.now();
-            String time = DateTimeFormatter.ofPattern( "HH-mm-ss" ) .format( now );
-            String date = DateTimeFormatter.ofPattern( "yyyy-MM-dd" ) .format( now );
-            String dateFolder = DateTimeFormatter.ofPattern( "yyyy/MM/dd" ) .format( now );
+            String time = DateTimeFormatter.ofPattern( "HH-mm-ss" ) .format( this .createTime );
+            String date = DateTimeFormatter.ofPattern( "yyyy-MM-dd" ) .format( createTime );
+            String dateFolder = DateTimeFormatter.ofPattern( "yyyy/MM/dd" ) .format( createTime );
             
             String postSrcPath = "_posts/" + date + "-" + designName + "-" + time + ".md";// e.g. _posts/2021-11-29-sample-vZome-share-08-01-41.md
             String postPath = dateFolder + "/" + designName + "-" + time + ".html";       // e.g. 2021/11/29/sample-vZome-share-08-01-41.html

--- a/desktop/src/main/java/org/vorthmann/zome/ui/SymmetryToolbarsPanel.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/SymmetryToolbarsPanel.java
@@ -81,7 +81,7 @@ public class SymmetryToolbarsPanel extends JPanel
             @Override
             public void propertyChange( PropertyChangeEvent evt )
             {
-                if ( "window.file" .equals( evt .getPropertyName() ) )
+                if ( "original.path" .equals( evt .getPropertyName() ) )
                 {
                     shareButton .setEnabled( evt .getNewValue() != null );
                 }


### PR DESCRIPTION
If the `share.last.mod.time` property is true, an opened file's last mod
time is used for the share timestamp.  By default, the current time will
be used, as before.

I also placed a maximum of 1600px on the image size for shares.