### PR TITLE
Using a shadow DOM slot to render fallback content

### DIFF
--- a/online/src/ui/viewer/store.js
+++ b/online/src/ui/viewer/store.js
@@ -132,7 +132,7 @@ export const createWorkerStore = customElement =>
   });
 
   const onWorkerMessage = ({ data }) => {
-    // console.log( `Message received from worker: ${JSON.stringify( data.type, null, 2 )}` );
+    console.log( `Message received from worker: ${JSON.stringify( data.type, null, 2 )}` );
     store .dispatch( data );
 
     // Useful for supporting regression testing of the vzome-viewer web component

--- a/online/src/wc/vzome-viewer.js
+++ b/online/src/wc/vzome-viewer.js
@@ -9,7 +9,6 @@ import { createWorkerStore } from '../ui/viewer/store.js';
 
 export class VZomeViewer extends HTMLElement {
   #root;
-  #stylesMount;
   #container;
   #store;
   #url;
@@ -17,10 +16,10 @@ export class VZomeViewer extends HTMLElement {
     super();
     this.#root = this.attachShadow({ mode: "open" });
 
-    this.#root.appendChild(document.createElement("style")).textContent = vZomeViewerCSS;
-    this.#root.appendChild(document.createElement("style")).textContent = muiCSS;
-    this.#stylesMount = document.createElement("div");
-    this.#container = this.#root.appendChild( this.#stylesMount );
+    this.#root.appendChild( document.createElement("style") ).textContent = vZomeViewerCSS;
+    this.#root.appendChild( document.createElement("style") ).textContent = muiCSS;
+    this.#container = document.createElement("div");
+    this.#root.appendChild( this.#container );
 
     this.#store = createWorkerStore( this );
 
@@ -42,7 +41,7 @@ export class VZomeViewer extends HTMLElement {
   connectedCallback() {
     import( '../ui/viewer/index.jsx' )
       .then( module => {
-        this.#reactElement = module.renderViewer( this.#store, this.#container, this.#stylesMount, this.#url );
+        this.#reactElement = module.renderViewer( this.#store, this.#container, this.#url );
       })
   }
 

--- a/online/test/index.html
+++ b/online/test/index.html
@@ -62,18 +62,21 @@
     </script>
   </head>
   <body>
-    <section>
+    <!-- <section>
       <vzome-viewer id="controlled" >
       </vzome-viewer>
-    </section>
-    <!-- <section class="fortyPercent">
-      <vzome-viewer src="./models/C240.vZome">
+    </section> -->
+    <section class="fortyPercent">
+      <vzome-viewer src="./models/orangePurpleChiral.vZome">
+        <img src="./models/orangePurpleChiral.png" >
       </vzome-viewer>
     </section>
     <section class="fortyPercent">
-      <vzome-viewer src="./models/affineDodec.vZome">
+      <vzome-viewer
+            src="https://vorth.github.io/vzome-sharing/2022/02/06/13-23-08-Yellow-Stretch-120cell/Yellow-Stretch-120cell.vZome" >
+        <img src="https://vorth.github.io/vzome-sharing/2022/02/06/13-23-08-Yellow-Stretch-120cell/Yellow-Stretch-120cell.png" />
       </vzome-viewer>
-    </section> -->
+    </section>
     <p>Failures:</p>
     <ul id="failures">
     </ul>


### PR DESCRIPTION
The "light DOM" generated for a `vzome-viewer` element is an `<img>` tag,
originally intended to show when Javascript is disabled, or any other
reason that the web component might not work.  By rendering a `<slot/>`,
we can also choose to show that content if anything goes wrong with
fetching, interpreting, and loading the 3D scene.

For example, this gives a better experience in Firefox, where the lack of
support for module workers means nothing will be rendered.