### PR TITLE
Fixed a defect in serialization of ApplyTool copyColors

### DIFF
--- a/core/src/main/java/com/vzome/core/editor/ApplyTool.java
+++ b/core/src/main/java/com/vzome/core/editor/ApplyTool.java
@@ -110,8 +110,9 @@ public class ApplyTool extends ChangeManifestations
             element .setAttribute( "hideInputs", "true" );
         if ( deleteInputs )
             element .setAttribute( "deleteInputs", "true" );
-        if ( copyColors )
-            element .setAttribute( "copyColors", "true" );
+        
+        // Let's be explicit for new configurations, true or false
+        element .setAttribute( "copyColors", Boolean.toString( this.copyColors ) );
     }
 
     @Override


### PR DESCRIPTION
Since the legacy default is "true" when the attribute is missing, we have
to explicitly write "false".