### PR TITLE
Fixed JSweet transpile error from branch merge

### DIFF
--- a/.github/workflows/test-and-regression.yml
+++ b/.github/workflows/test-and-regression.yml
@@ -7,12 +7,14 @@ on:
   push:
     paths:
       - 'core/src/main/java/**'
+      - 'core/src/jsweet/java/**'
       - 'core/src/regression/**'
       - 'core/src/test/java/**'
       - 'core/build.gradle'
   pull_request:
     paths:
       - 'core/src/main/java/**'
+      - 'core/src/jsweet/java/**'
       - 'core/src/regression/**'
       - 'core/src/test/java/**'
       - 'core/build.gradle'
@@ -29,10 +31,12 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '8'
-        distribution: 'adopt'
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    - name: Build with Gradle
+        distribution: 'temurin'
+    - name: Grant execute permissions
+      run: chmod +x gradlew cicd/jsweet-legacy-code.bash
+    - name: check for JSweet regression
+      run: cicd/jsweet-legacy-code.bash
+    - name: Run unit and regression tests
       run: ./gradlew test regression -PregressionOutput=failures.xml
     - name: Archive regression failures
       uses: actions/upload-artifact@v2

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ vzome-react-vzome-*.tgz
 .vscode
 online/dist
 history.txt
+jsweet-errors.txt
+online-app.zip
+online.tgz
+deploy-to-dreamhost.sh

--- a/cicd/jsweet-legacy-code.bash
+++ b/cicd/jsweet-legacy-code.bash
@@ -1,15 +1,13 @@
 #!/bin/bash
 
 banner() {
-  echo '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%'
-  echo '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%'
+  echo ''
   echo '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%'
   echo '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%'
   echo '%%%%    '$1
   echo '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%'
   echo '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%'
-  echo '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%'
-  echo '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%'
+  echo ''
 }
 
 # This is designed to run from the main repo as a working directory.
@@ -17,7 +15,12 @@ banner() {
 
 banner 'Transpiling Java sources with JSweet'
 
-./gradlew core:jsweet -x compileJava && exit $?
+./gradlew --continue core:jsweet -x compileJava &> jsweet-errors.txt    # ignore the exit code, it always fails
+cat jsweet-errors.txt
+
+grep -q 'transpilation failed with 106 error(s) and 0 warning(s)' jsweet-errors.txt \
+  && banner 'JSweet transpile found the expected errors' \
+  || { banner 'UNEXPECTED CHANGE IN JSWEET ERRORS'; exit 1; }
 
 banner 'Patching up the bundle as an ES6 module'
 
@@ -30,5 +33,3 @@ cat 'online/jsweetOut/js/bundle.js' | \
     -e 's/var java;//' \
     -e 's/(java || (java = {}));/(java);/' \
   >> $OUTJS
-
-banner 'finished transpiling Java sources with JSweet'

--- a/core/src/jsweet/java/com/vzome/jsweet/JsAlgebraicField.java
+++ b/core/src/jsweet/java/com/vzome/jsweet/JsAlgebraicField.java
@@ -480,7 +480,11 @@ public class JsAlgebraicField implements AlgebraicField
     
     
     
-    
+    public AlgebraicNumber getNumberByName( String name )
+    {
+        throw new RuntimeException( "unimplemented JsAlgebraicField.getNumberByName" );
+    }
+
     int[] scaleBy( int[] factors, int whichIrrational )
     {
         throw new RuntimeException( "unimplemented JsAlgebraicField.scaleBy" );


### PR DESCRIPTION
I have also modified cicd/jsweet-legacy-code.bash to fail only when the
expected error output changes, and I've added this step to the test-and-
regression GitHub Actions workflow.

Hopefully this will prevent future failures of this nature.