### PR TITLE
Fixed several bugs in GitHub sharing

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/ui/HyperlinkPanel.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/HyperlinkPanel.java
@@ -66,7 +66,7 @@ public class HyperlinkPanel extends JPanel
         hyperlink .addMouseListener( new MouseAdapter()
         {
             @Override
-            public void mouseClicked( MouseEvent e )
+            public void mousePressed( MouseEvent e )
             {
                 try {
                     Desktop .getDesktop() .browse( new URI( url ) );

--- a/desktop/src/main/java/org/vorthmann/zome/ui/ShareDialog.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/ShareDialog.java
@@ -407,11 +407,15 @@ public class ShareDialog extends EscapeDialog
         this.shapesJson = shapesJson;
         
         // Initialize the transient, file-specific state
-        this.designName = fileName;
+        this.designName = fileName .trim() .replaceAll( " ", "-" ); // we don't want spaces in our URLs
         int index = designName .toLowerCase() .lastIndexOf( ".vZome" .toLowerCase() );
         if ( index > 0 )
             designName = designName .substring( 0, index );
-        this.title = designName .replaceAll( "-", " " );
+        while ( designName .startsWith( "-" ) ) // leading hyphens can break things for Jekyll posts
+            designName = designName .substring( 1 );
+        while ( designName .endsWith( "-" ) ) // so can trailing hyphens
+            designName = designName .substring( 0, designName .lastIndexOf( '-' ) );
+        this.title = designName .replaceAll( "-", " " ) .trim();    // but we do want spaces in the title
         this.description = "A 3D design created in vZome.  Use your mouse or touch to interact.";
         this.error = null;
         this.gitUrl = null;

--- a/desktop/src/main/resources/org/vorthmann/zome/ui/githubPostTemplate.md
+++ b/desktop/src/main/resources/org/vorthmann/zome/ui/githubPostTemplate.md
@@ -7,8 +7,8 @@ layout: vzome
 ---
 
 {% comment %}
- - [***web page generated from this source***](${siteUrl}/${postPath})
- - [data assets and more info](${assetsUrl})
+ - [***web page generated from this source***](<${siteUrl}/${postPath}>)
+ - [data assets and more info](<${assetsUrl}>)
  
 {% endcomment %}
 

--- a/desktop/src/main/resources/org/vorthmann/zome/ui/githubReadmeNoPostTemplate.md
+++ b/desktop/src/main/resources/org/vorthmann/zome/ui/githubReadmeNoPostTemplate.md
@@ -1,7 +1,7 @@
 
 ## How to Use or Share this Design
 
- - [raw vZome file](${rawUrl}) to use in vZome desktop or vZome Online
+ - [raw vZome file](<${rawUrl}>) to use in vZome desktop or vZome Online
  
  HTML custom element for embedding in any web page:
  ```html


### PR DESCRIPTION
1. The "View on GitHub" link required a full click, sometimes hard with
    a mouse even, and especially hard with a trackpad.
2. That link could be broken if the filename started (or ended?) with
    a hyphen.
3. Spaces in filenames caused havoc.