### PR TITLE
Fixing the module paths for the three separate apps

### DIFF
--- a/ideas-today.txt
+++ b/ideas-today.txt
@@ -1,0 +1,16 @@
+restore article mode
+fix array index OOB defect in article mode
+share enable.article.creation flag with that guy
+create article about the OpenSCAD rotations, but using blue axes for everything
+JSON preview support for different scenes (article mode export), and thus support in the web component
+talk to Ben Eater about smoothing & interactive animations (tell Grant first)
+
+
+------- 2022-05-17
+
+ - commit old vZome assets to GitHub: notes, ideas, wiki, designs, etc.... but only if dates are captured
+
+ - switch the fivecell and bhall apps to use the web component?
+
+ - automate deploy to Dreamhost from GitHub Actions
+ 

--- a/online/public/bhall/basic/index.html
+++ b/online/public/bhall/basic/index.html
@@ -16,6 +16,6 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <script type="module" src="../../../modules/bhall-basic.js"></script>
+    <script type="module" src="/modules/bhall-basic.js"></script>
   </body>
 </html>

--- a/online/public/browser/index.html
+++ b/online/public/browser/index.html
@@ -16,6 +16,6 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <script type="module" src="../../modules/vzome-browser.js"></script>
+    <script type="module" src="/modules/vzome-browser.js"></script>
   </body>
 </html>

--- a/online/public/fivecell/index.html
+++ b/online/public/fivecell/index.html
@@ -16,6 +16,6 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <script type="module" src="./modules/fivecell.js"></script>
+    <script type="module" src="/modules/fivecell.js"></script>
   </body>
 </html>


### PR DESCRIPTION
There is no reason not to use the global path /modules, since that must
always exist to support the web component anyway.

I'm also committing my ideas-today.txt file, just for grins.