### PR TITLE
Supporting article/lesson viewing in vzome-viewer

### DIFF
--- a/online/src/app/components/debugger.jsx
+++ b/online/src/app/components/debugger.jsx
@@ -240,7 +240,6 @@ export const HistoryInspector = ( { debug=false } )  =>
             </TableHead>
             <TableBody>
               {current && allAttributes[ current ] && Object.keys( allAttributes[ current ] ).map( name => (
-                ( name !== 'id' ) &&
                 <StyledTableRow key={name}>
                   <StyledTableCell component="th" scope="row">{name}</StyledTableCell>
                   <StyledTableCell>{allAttributes[ current ][ name ]}</StyledTableCell>

--- a/online/src/app/index.jsx
+++ b/online/src/app/index.jsx
@@ -23,7 +23,7 @@ const App = () =>
   return (
     <>
       <VZomeAppBar oneDesign={legacyViewerMode} />
-      { legacyViewerMode? <DesignViewer useSpinner/> : <DesignHistoryInspector/> }
+      { legacyViewerMode? <DesignViewer useSpinner showSnapshots /> : <DesignHistoryInspector/> }
     </>
   );
 }

--- a/online/src/ui/viewer/store.js
+++ b/online/src/ui/viewer/store.js
@@ -24,8 +24,8 @@ const reducer = ( state = initialState, event ) =>
     case 'TEXT_FETCHED':
       return { ...state, source: event.payload };
 
-    case 'DESIGN_RENDERED': {
-      let { scene, xmlTree } = event.payload;
+    case 'DESIGN_INTERPRETED': {
+      let { xmlTree, snapshots } = event.payload;
       const attributes = {};
       const indexAttributes = node => node.children && node.children.map( child => {
         attributes[ child.id ] = child.attributes;
@@ -35,14 +35,18 @@ const reducer = ( state = initialState, event ) =>
         indexAttributes( xmlTree );
         xmlTree = branchSelectionBlocks( xmlTree );
       }
-      // may need to merge scene.shapes here, for incremental case
-      return { ...state, scene: { ...state.scene, ...scene }, waiting: false, xmlTree, attributes };
+      return { ...state, waiting: false, xmlTree, attributes, snapshots };
     }
 
-    case 'EDIT_RENDERED': {
+    case 'SCENE_RENDERED': {
       const { scene } = event.payload;
       // may need to merge scene.shapes here, for incremental case
       return { ...state, scene: { ...state.scene, ...scene }, waiting: false };
+    }
+
+    case 'CAMERA_DEFINED': {
+      const camera = event.payload;
+      return { ...state, scene: { ...state.scene, camera } };
     }
 
     default:
@@ -97,8 +101,10 @@ export const createWorkerStore = customElement =>
       case 'ALERT_DISMISSED':
       case 'FETCH_STARTED':
       case 'TEXT_FETCHED':
-      case 'DESIGN_RENDERED':
-      case 'EDIT_RENDERED':
+      case 'DESIGN_INTERPRETED':
+      case 'SCENE_RENDERED':
+      // This is a local state change
+      case 'CAMERA_DEFINED':
         report( event );
         break;
 
@@ -139,7 +145,7 @@ export const createWorkerStore = customElement =>
     if ( customElement ) {
       switch (data.type) {
 
-        case 'DESIGN_RENDERED':
+        case 'DESIGN_INTERPRETED':
           customElement.dispatchEvent( new Event( 'vzome-design-rendered' ) );
           break;
       

--- a/online/src/wc/mui-styles.css.js
+++ b/online/src/wc/mui-styles.css.js
@@ -208,89 +208,98 @@ export const muiCSS = `
 .MuiSvgIcon-fontSizeLarge {
   font-size: 2.1875rem;
 }
-/* </style><style data-jss="" data-meta="MuiBackdrop"> */
-.MuiBackdrop-root {
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  display: flex;
-  z-index: -1;
-  position: fixed;
-  align-items: center;
-  justify-content: center;
-  background-color: rgba(0, 0, 0, 0.5);
-  -webkit-tap-highlight-color: transparent;
+/* </style><style data-jss="" data-meta="MuiFormLabel"> */
+.MuiFormLabel-root {
+  color: rgba(0, 0, 0, 0.54);
+  padding: 0;
+  font-size: 1rem;
+  font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+  font-weight: 400;
+  line-height: 1;
+  letter-spacing: 0.00938em;
 }
-.MuiBackdrop-invisible {
-  background-color: transparent;
-}
-/* </style><style data-jss="" data-meta="MuiCircularProgress"> */
-.MuiCircularProgress-root {
-  display: inline-block;
-}
-.MuiCircularProgress-static {
-  transition: transform 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-}
-.MuiCircularProgress-indeterminate {
-  animation: MuiCircularProgress-keyframes-circular-rotate 1.4s linear infinite;
-}
-.MuiCircularProgress-determinate {
-  transition: transform 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-}
-.MuiCircularProgress-colorPrimary {
+.MuiFormLabel-root.Mui-focused {
   color: #3f51b5;
 }
-.MuiCircularProgress-colorSecondary {
+.MuiFormLabel-root.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+}
+.MuiFormLabel-root.Mui-error {
+  color: #f44336;
+}
+.MuiFormLabel-colorSecondary.Mui-focused {
   color: #f50057;
 }
-.MuiCircularProgress-svg {
+.MuiFormLabel-asterisk.Mui-error {
+  color: #f44336;
+}
+/* </style><style data-jss="" data-meta="MuiInputLabel"> */
+.MuiInputLabel-root {
   display: block;
+  transform-origin: top left;
 }
-.MuiCircularProgress-circle {
-  stroke: currentColor;
-}
-.MuiCircularProgress-circleStatic {
-  transition: stroke-dashoffset 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-}
-.MuiCircularProgress-circleIndeterminate {
-  animation: MuiCircularProgress-keyframes-circular-dash 1.4s ease-in-out infinite;
-  stroke-dasharray: 80px, 200px;
-  stroke-dashoffset: 0px;
-}
-.MuiCircularProgress-circleDeterminate {
-  transition: stroke-dashoffset 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-}
-@-webkit-keyframes MuiCircularProgress-keyframes-circular-rotate {
-  0% {
-    transform-origin: 50% 50%;
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-}
-@-webkit-keyframes MuiCircularProgress-keyframes-circular-dash {
-  0% {
-    stroke-dasharray: 1px, 200px;
-    stroke-dashoffset: 0px;
-  }
-  50% {
-    stroke-dasharray: 100px, 200px;
-    stroke-dashoffset: -15px;
-  }
-  100% {
-    stroke-dasharray: 100px, 200px;
-    stroke-dashoffset: -125px;
-  }
-}
-.MuiCircularProgress-circleDisableShrink {
-  animation: none;
-}
-/* </style><style data-jss="" data-meta="makeStyles"> */
-.makeStyles-backdrop-1 {
-  color: #fff;
-  z-index: 1199;
+.MuiInputLabel-formControl {
+  top: 0;
+  left: 0;
   position: absolute;
+  transform: translate(0, 24px) scale(1);
+}
+.MuiInputLabel-marginDense {
+  transform: translate(0, 21px) scale(1);
+}
+.MuiInputLabel-shrink {
+  transform: translate(0, 1.5px) scale(0.75);
+  transform-origin: top left;
+}
+.MuiInputLabel-animated {
+  transition: color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+}
+.MuiInputLabel-filled {
+  z-index: 1;
+  transform: translate(12px, 20px) scale(1);
+  pointer-events: none;
+}
+.MuiInputLabel-filled.MuiInputLabel-marginDense {
+  transform: translate(12px, 17px) scale(1);
+}
+.MuiInputLabel-filled.MuiInputLabel-shrink {
+  transform: translate(12px, 10px) scale(0.75);
+}
+.MuiInputLabel-filled.MuiInputLabel-shrink.MuiInputLabel-marginDense {
+  transform: translate(12px, 7px) scale(0.75);
+}
+.MuiInputLabel-outlined {
+  z-index: 1;
+  transform: translate(14px, 20px) scale(1);
+  pointer-events: none;
+}
+.MuiInputLabel-outlined.MuiInputLabel-marginDense {
+  transform: translate(14px, 12px) scale(1);
+}
+.MuiInputLabel-outlined.MuiInputLabel-shrink {
+  transform: translate(14px, -6px) scale(0.75);
+}
+/* </style><style data-jss="" data-meta="MuiFormControl"> */
+.MuiFormControl-root {
+  border: 0;
+  margin: 0;
+  display: inline-flex;
+  padding: 0;
+  position: relative;
+  min-width: 0;
+  flex-direction: column;
+  vertical-align: top;
+}
+.MuiFormControl-marginNormal {
+  margin-top: 16px;
+  margin-bottom: 8px;
+}
+.MuiFormControl-marginDense {
+  margin-top: 8px;
+  margin-bottom: 4px;
+}
+.MuiFormControl-fullWidth {
+  width: 100%;
 }
 /* </style><style data-jss="" data-meta="MuiPaper"> */
 .MuiPaper-root {
@@ -378,6 +387,416 @@ export const muiCSS = `
 }
 .MuiPaper-elevation24 {
   box-shadow: 0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12);
+}
+/* </style><style data-jss="" data-meta="MuiSvgIcon"> */
+.MuiSvgIcon-root {
+  fill: currentColor;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  font-size: 1.5rem;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  flex-shrink: 0;
+  user-select: none;
+}
+.MuiSvgIcon-colorPrimary {
+  color: #3f51b5;
+}
+.MuiSvgIcon-colorSecondary {
+  color: #f50057;
+}
+.MuiSvgIcon-colorAction {
+  color: rgba(0, 0, 0, 0.54);
+}
+.MuiSvgIcon-colorError {
+  color: #f44336;
+}
+.MuiSvgIcon-colorDisabled {
+  color: rgba(0, 0, 0, 0.26);
+}
+.MuiSvgIcon-fontSizeInherit {
+  font-size: inherit;
+}
+.MuiSvgIcon-fontSizeSmall {
+  font-size: 1.25rem;
+}
+.MuiSvgIcon-fontSizeLarge {
+  font-size: 2.1875rem;
+}
+/* </style><style data-jss="" data-meta="MuiInputBase"> */
+@-webkit-keyframes mui-auto-fill {}
+@-webkit-keyframes mui-auto-fill-cancel {}
+.MuiInputBase-root {
+  color: rgba(0, 0, 0, 0.87);
+  cursor: text;
+  display: inline-flex;
+  position: relative;
+  font-size: 1rem;
+  box-sizing: border-box;
+  align-items: center;
+  font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+  font-weight: 400;
+  line-height: 1.1876em;
+  letter-spacing: 0.00938em;
+}
+.MuiInputBase-root.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+  cursor: default;
+}
+.MuiInputBase-multiline {
+  padding: 6px 0 7px;
+}
+.MuiInputBase-multiline.MuiInputBase-marginDense {
+  padding-top: 3px;
+}
+.MuiInputBase-fullWidth {
+  width: 100%;
+}
+.MuiInputBase-input {
+  font: inherit;
+  color: currentColor;
+  width: 100%;
+  border: 0;
+  height: 1.1876em;
+  margin: 0;
+  display: block;
+  padding: 6px 0 7px;
+  min-width: 0;
+  background: none;
+  box-sizing: content-box;
+  animation-name: mui-auto-fill-cancel;
+  letter-spacing: inherit;
+  animation-duration: 10ms;
+  -webkit-tap-highlight-color: transparent;
+}
+.MuiInputBase-input::-webkit-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+.MuiInputBase-input::-moz-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+.MuiInputBase-input:-ms-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+.MuiInputBase-input::-ms-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+.MuiInputBase-input:focus {
+  outline: 0;
+}
+.MuiInputBase-input:invalid {
+  box-shadow: none;
+}
+.MuiInputBase-input::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+.MuiInputBase-input.Mui-disabled {
+  opacity: 1;
+}
+.MuiInputBase-input:-webkit-autofill {
+  animation-name: mui-auto-fill;
+  animation-duration: 5000s;
+}
+label[data-shrink=false] + .MuiInputBase-formControl .MuiInputBase-input::-webkit-input-placeholder {
+  opacity: 0 !important;
+}
+label[data-shrink=false] + .MuiInputBase-formControl .MuiInputBase-input::-moz-placeholder {
+  opacity: 0 !important;
+}
+label[data-shrink=false] + .MuiInputBase-formControl .MuiInputBase-input:-ms-input-placeholder {
+  opacity: 0 !important;
+}
+label[data-shrink=false] + .MuiInputBase-formControl .MuiInputBase-input::-ms-input-placeholder {
+  opacity: 0 !important;
+}
+label[data-shrink=false] + .MuiInputBase-formControl .MuiInputBase-input:focus::-webkit-input-placeholder {
+  opacity: 0.42;
+}
+label[data-shrink=false] + .MuiInputBase-formControl .MuiInputBase-input:focus::-moz-placeholder {
+  opacity: 0.42;
+}
+label[data-shrink=false] + .MuiInputBase-formControl .MuiInputBase-input:focus:-ms-input-placeholder {
+  opacity: 0.42;
+}
+label[data-shrink=false] + .MuiInputBase-formControl .MuiInputBase-input:focus::-ms-input-placeholder {
+  opacity: 0.42;
+}
+.MuiInputBase-inputMarginDense {
+  padding-top: 3px;
+}
+.MuiInputBase-inputMultiline {
+  height: auto;
+  resize: none;
+  padding: 0;
+}
+.MuiInputBase-inputTypeSearch {
+  -moz-appearance: textfield;
+  -webkit-appearance: textfield;
+}
+/* </style><style data-jss="" data-meta="PrivateNotchedOutline"> */
+.PrivateNotchedOutline-root-5 {
+  top: -5px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: 0;
+  padding: 0 8px;
+  overflow: hidden;
+  position: absolute;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: inherit;
+  pointer-events: none;
+}
+.PrivateNotchedOutline-legend-6 {
+  padding: 0;
+  text-align: left;
+  transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  line-height: 11px;
+}
+.PrivateNotchedOutline-legendLabelled-7 {
+  width: auto;
+  height: 11px;
+  display: block;
+  padding: 0;
+  font-size: 0.75em;
+  max-width: 0.01px;
+  text-align: left;
+  transition: max-width 50ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  visibility: hidden;
+}
+.PrivateNotchedOutline-legendLabelled-7 > span {
+  display: inline-block;
+  padding-left: 5px;
+  padding-right: 5px;
+}
+.PrivateNotchedOutline-legendNotched-8 {
+  max-width: 1000px;
+  transition: max-width 100ms cubic-bezier(0.0, 0, 0.2, 1) 50ms;
+}
+/* </style><style data-jss="" data-meta="MuiOutlinedInput"> */
+.MuiOutlinedInput-root {
+  position: relative;
+  border-radius: 4px;
+}
+.MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.87);
+}
+@media (hover: none) {
+  .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline {
+    border-color: rgba(0, 0, 0, 0.23);
+  }
+}
+.MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-color: #3f51b5;
+  border-width: 2px;
+}
+.MuiOutlinedInput-root.Mui-error .MuiOutlinedInput-notchedOutline {
+  border-color: #f44336;
+}
+.MuiOutlinedInput-root.Mui-disabled .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.26);
+}
+.MuiOutlinedInput-colorSecondary.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-color: #f50057;
+}
+.MuiOutlinedInput-adornedStart {
+  padding-left: 14px;
+}
+.MuiOutlinedInput-adornedEnd {
+  padding-right: 14px;
+}
+.MuiOutlinedInput-multiline {
+  padding: 18.5px 14px;
+}
+.MuiOutlinedInput-multiline.MuiOutlinedInput-marginDense {
+  padding-top: 10.5px;
+  padding-bottom: 10.5px;
+}
+.MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.23);
+}
+.MuiOutlinedInput-input {
+  padding: 18.5px 14px;
+}
+.MuiOutlinedInput-input:-webkit-autofill {
+  border-radius: inherit;
+}
+.MuiOutlinedInput-inputMarginDense {
+  padding-top: 10.5px;
+  padding-bottom: 10.5px;
+}
+.MuiOutlinedInput-inputMultiline {
+  padding: 0;
+}
+.MuiOutlinedInput-inputAdornedStart {
+  padding-left: 0;
+}
+.MuiOutlinedInput-inputAdornedEnd {
+  padding-right: 0;
+}
+/* </style><style data-jss="" data-meta="MuiSelect"> */
+.MuiSelect-select {
+  cursor: pointer;
+  min-width: 16px;
+  user-select: none;
+  border-radius: 0;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+}
+.MuiSelect-select:focus {
+  border-radius: 0;
+  background-color: rgba(0, 0, 0, 0.05);
+}
+.MuiSelect-select::-ms-expand {
+  display: none;
+}
+.MuiSelect-select.Mui-disabled {
+  cursor: default;
+}
+.MuiSelect-select[multiple] {
+  height: auto;
+}
+.MuiSelect-select:not([multiple]) option, .MuiSelect-select:not([multiple]) optgroup {
+  background-color: #fff;
+}
+.MuiSelect-select.MuiSelect-select {
+  padding-right: 24px;
+}
+.MuiSelect-filled.MuiSelect-filled {
+  padding-right: 32px;
+}
+.MuiSelect-outlined {
+  border-radius: 4px;
+}
+.MuiSelect-outlined.MuiSelect-outlined {
+  padding-right: 32px;
+}
+.MuiSelect-selectMenu {
+  height: auto;
+  overflow: hidden;
+  min-height: 1.1876em;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.MuiSelect-icon {
+  top: calc(50% - 12px);
+  color: rgba(0, 0, 0, 0.54);
+  right: 0;
+  position: absolute;
+  pointer-events: none;
+}
+.MuiSelect-icon.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+}
+.MuiSelect-iconOpen {
+  transform: rotate(180deg);
+}
+.MuiSelect-iconFilled {
+  right: 7px;
+}
+.MuiSelect-iconOutlined {
+  right: 7px;
+}
+.MuiSelect-nativeInput {
+  left: 0;
+  width: 100%;
+  bottom: 0;
+  opacity: 0;
+  position: absolute;
+  pointer-events: none;
+}
+/* </style><style data-jss="" data-meta="MuiBackdrop"> */
+.MuiBackdrop-root {
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  z-index: -1;
+  position: fixed;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.5);
+  -webkit-tap-highlight-color: transparent;
+}
+.MuiBackdrop-invisible {
+  background-color: transparent;
+}
+/* </style><style data-jss="" data-meta="MuiCircularProgress"> */
+.MuiCircularProgress-root {
+  display: inline-block;
+}
+.MuiCircularProgress-static {
+  transition: transform 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+.MuiCircularProgress-indeterminate {
+  animation: MuiCircularProgress-keyframes-circular-rotate 1.4s linear infinite;
+}
+.MuiCircularProgress-determinate {
+  transition: transform 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+.MuiCircularProgress-colorPrimary {
+  color: #3f51b5;
+}
+.MuiCircularProgress-colorSecondary {
+  color: #f50057;
+}
+.MuiCircularProgress-svg {
+  display: block;
+}
+.MuiCircularProgress-circle {
+  stroke: currentColor;
+}
+.MuiCircularProgress-circleStatic {
+  transition: stroke-dashoffset 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+.MuiCircularProgress-circleIndeterminate {
+  animation: MuiCircularProgress-keyframes-circular-dash 1.4s ease-in-out infinite;
+  stroke-dasharray: 80px, 200px;
+  stroke-dashoffset: 0px;
+}
+.MuiCircularProgress-circleDeterminate {
+  transition: stroke-dashoffset 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+@-webkit-keyframes MuiCircularProgress-keyframes-circular-rotate {
+  0% {
+    transform-origin: 50% 50%;
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+@-webkit-keyframes MuiCircularProgress-keyframes-circular-dash {
+  0% {
+    stroke-dasharray: 1px, 200px;
+    stroke-dashoffset: 0px;
+  }
+  50% {
+    stroke-dasharray: 100px, 200px;
+    stroke-dashoffset: -15px;
+  }
+  100% {
+    stroke-dasharray: 100px, 200px;
+    stroke-dashoffset: -125px;
+  }
+}
+.MuiCircularProgress-circleDisableShrink {
+  animation: none;
+}
+/* </style><style data-jss="" data-meta="makeStyles"> */
+.makeStyles-backdrop-1 {
+  color: #fff;
+  z-index: 1199;
+  position: absolute;
 }
 /* </style><style data-jss="" data-meta="MuiAlert"> */
 .MuiAlert-root {
@@ -645,4 +1064,13 @@ export const muiCSS = `
   z-index: 1199;
   position: absolute;
 }
+/* </style><style data-jss="" data-meta="makeStyles"> */
+.makeStyles-formControl-3 {
+  margin: 8px;
+  min-width: 120px;
+}
+.makeStyles-selectEmpty-4 {
+  margin-top: 16px;
+}
+/* </style> */
 `

--- a/online/src/wc/vzome-viewer.css.js
+++ b/online/src/wc/vzome-viewer.css.js
@@ -17,8 +17,7 @@ export const vZomeViewerCSS = `
 }
 
 :host > div,
-:host > div > div,
-:host > div > div > div {
+:host > div > div {
   width: 100% !important;
   height: 100% !important;
   overflow: hidden;

--- a/online/src/worker/legacy/js2jsweet.js
+++ b/online/src/worker/legacy/js2jsweet.js
@@ -553,7 +553,8 @@ const legacyCommandFactory = ( createEditor, className ) => ( config ) =>
   // dispatch( { type: WORK_FINISHED } )
 }
 
-const assignIds = ( txmlElement, id=':' ) => {
+const assignIds = ( txmlElement, id=':' ) =>
+{
   txmlElement.id = id;
   txmlElement.children.map( (child,index) => {
     if ( child instanceof Object ) {
@@ -562,6 +563,20 @@ const assignIds = ( txmlElement, id=':' ) => {
     }
   });
   return txmlElement
+}
+
+const findSnapshots = ( txmlElement, snapshots ) =>
+{
+  if ( txmlElement.tagName === "Snapshot" ) {
+    const snapshotId = parseInt( txmlElement.attributes.id );
+    snapshots[ snapshotId ] = txmlElement.id;
+  } else {
+    txmlElement.children.map( child => {
+      if ( child instanceof Object ) {
+        findSnapshots( child, snapshots )
+      }
+    });
+  }
 }
 
 const parseVector = ( element, name ) =>
@@ -608,8 +623,16 @@ const parseViewXml = ( viewingElement ) =>
   const lookAt = parseVector( viewModel, "LookAtPoint" )
   const up = parseVector( viewModel, "UpDirection" )
   const lookDirection = parseVector( viewModel, "LookDirection" )
-  const position = lookAt.map( (e,i) => e - distance * lookDirection[ i ] )
-  return { position, lookAt, up, near, far }
+  const position = lookAt.map( (e,i) => e - distance * lookDirection[ i ] );
+  return { position, lookAt, up, near, far, fov: 0.43915263 };
+}
+
+const parseArticlePage = ( pageElement, snapshots ) =>
+{
+  const { snapshot, title } = pageElement.attributes;
+  const nodeId = snapshots[ snapshot ];
+  const camera = parseViewXml( new JavaDomElement( pageElement ) );
+  return { title, nodeId, camera };
 }
 
 const createParser = ( createDocument ) => ( xmlText ) =>
@@ -631,11 +654,17 @@ const createParser = ( createDocument ) => ( xmlText ) =>
 
   const xmlTree = assignIds( vZomeRoot.getChildElement( "EditHistory" ).nativeElement );
   const edits = new LegacyEdit( xmlTree, null, interpretEdit );
-  // Note: I'm adding one so that this matches the assigned ID of the next edit to do
   const targetEditId = `:${edits.getAttribute( "editNumber" )}:`
   const firstEdit = edits.firstChild()
 
-  return { firstEdit, camera, field, targetEditId, renderer, lighting, batchRender, xmlTree }
+  const snapshotNodes = [];
+  findSnapshots( xmlTree, snapshotNodes );
+
+  const notes = vZomeRoot.getChildElement( "notes" );
+  const realSnapshots = notes.nativeElement.children.map( pageElement => parseArticlePage( pageElement, snapshotNodes ) );
+  const snapshots = [ { nodeId: targetEditId, camera }, ...realSnapshots ];
+
+  return { firstEdit, camera, field, targetEditId, renderer, lighting, batchRender, xmlTree, snapshots }
 }
 
 export const parserPromise = init()


### PR DESCRIPTION
I've added SceneMenu to the DesignViewer component, as well as a
toggle to disable it.  It won't work for JSON previews, of course, so we
always fetch the actual XML now.  If the toggle is on, we replace
the preview scene seamlessly.

I have completely decoupled SCENE_RENDERED, so it stays uniform for all
use-cases.  The full, indexed DOM tree and possible article snapshots
are returned separately in DESIGN_INTERPRETED.