### PR TITLE
Fixed the preview-then-interpret defect

### DIFF
--- a/online/src/app/bhall/basic/index.jsx
+++ b/online/src/app/bhall/basic/index.jsx
@@ -84,7 +84,8 @@ const metadata = {
     },
     "doubleSpiral": {
       "parts": "10 short reds, 10 medium reds, 20 long reds, 10 short yellows, and 47 balls.",
-      "description": ""
+      "description": "",
+      config: { showSnapshots: false }
     },
   },
 }
@@ -109,7 +110,7 @@ const viewerStyle = {
   border: "solid",
 }
 
-const VZomeViewer = ({ name, parts }) =>
+const VZomeViewer = ({ name, parts, config }) =>
 {
   const url = name && new URL( `/bhall/basics/${name}.vZome`, window.location ) .toString();
 
@@ -117,7 +118,7 @@ const VZomeViewer = ({ name, parts }) =>
     <>
       <Divider />
       <div style={viewerStyle}>
-        <UrlViewer url={url} />
+        <UrlViewer url={url} config={config} />
       </div>
       <Typography gutterBottom align='center' variant="h6" >{name}</Typography>
       <Typography gutterBottom align='center' >Build with {parts}</Typography>
@@ -150,7 +151,7 @@ const BHallBasic = () =>
             explore different possibilities,
             Brian was able to create a number of beautiful and interesting designs,
             all constructible with fairly small Zometool sets.
-            Here are a few of them for your enjoyment; try constructing them with Zometool!
+            Here are a few of them for your enjoyment; try constructing them in the real world!
             Note that they are organized into three sections, by difficulty.
           </Typography>
           <Typography gutterBottom color='secondary' >
@@ -164,7 +165,8 @@ const BHallBasic = () =>
               <Tab label={labels[2]} />
             </Tabs>
           </Paper>
-          { Object.entries( metadata[ labels[ difficulty ] ] ).map( ([ name, value ]) => <VZomeViewer name={name} parts={value.parts} /> )}
+          { Object.entries( metadata[ labels[ difficulty ] ] ).map( ([ name, value, config={} ]) =>
+            <VZomeViewer name={name} parts={value.parts} config={config} /> )}
         </Paper>
       </Container>
     </>

--- a/online/src/app/browser/browser.jsx
+++ b/online/src/app/browser/browser.jsx
@@ -80,7 +80,7 @@ export const DesignBrowser = ( { debug } ) =>
           <DesignList setUrl={setUrl}/>
         </Grid>
         <Grid id='editor-canvas' item xs={canvasColumns} >
-          <DesignViewer useSpinner />
+          <DesignViewer config={ { useSpinner: true } } />
         </Grid>
       </Grid>
     </div>

--- a/online/src/app/components/inspector.jsx
+++ b/online/src/app/components/inspector.jsx
@@ -86,7 +86,7 @@ export const DesignHistoryInspector = ( { debug } ) =>
           <HistoryInspector/>
         </Grid>
         <Grid id='editor-canvas' item xs={canvasColumns} >
-          <DesignViewer useSpinner>
+          <DesignViewer config={ { useSpinner: true } }>
             {/* { workingPlane && workingPlane.enabled &&
                 <BuildPlane config={workingPlane} {...{ startGridHover, stopGridHover }} /> } */}
             {/* <UndoRedoButtons {...{ canRedo, canUndo,

--- a/online/src/app/index.jsx
+++ b/online/src/app/index.jsx
@@ -23,7 +23,7 @@ const App = () =>
   return (
     <>
       <VZomeAppBar oneDesign={legacyViewerMode} />
-      { legacyViewerMode? <DesignViewer useSpinner showSnapshots /> : <DesignHistoryInspector/> }
+      { legacyViewerMode? <DesignViewer config={ { useSpinner: true, showSnapshots: true } } /> : <DesignHistoryInspector/> }
     </>
   );
 }

--- a/online/src/ui/viewer/index.jsx
+++ b/online/src/ui/viewer/index.jsx
@@ -83,8 +83,9 @@ export const SceneMenu = ( { snapshots } ) =>
   );
 }
 
-export const DesignViewer = ( { children, children3d, useSpinner=false, showSnapshots=false } ) =>
+export const DesignViewer = ( { children, children3d, config={} } ) =>
 {
+  const { showSnapshots=false, useSpinner=false } = config;
   const source = useSelector( state => state.source );
   const scene = useSelector( state => state.scene );
   const waiting = useSelector( state => !!state.waiting );
@@ -165,10 +166,10 @@ export const useVZomeUrl = ( url, config ) =>
 // This component has to be separate from UrlViewer because of the useDispatch hook used in
 //  useVZomeUrl above.  I shouldn't really need to export it, but React (or the dev tools)
 //  got pissy when I didn't.
-export const UrlViewerInner = ({ url, children }) =>
+export const UrlViewerInner = ({ url, children, config }) =>
 {
   useVZomeUrl( url, { preview: true } );
-  return ( <DesignViewer showSnapshots >
+  return ( <DesignViewer config={config} >
              {children}
            </DesignViewer> );
 }
@@ -179,9 +180,9 @@ export const UrlViewerInner = ({ url, children }) =>
 //  It is also used by the web component, but with the worker-store injected so that the
 //  worker can get initialized and loaded while the main context is still fetching
 //  this module.
-export const UrlViewer = ({ url, store, children }) => (
+export const UrlViewer = ({ url, store, children, config={} }) => (
   <WorkerContext store={store} >
-    <UrlViewerInner url={url}>
+    <UrlViewerInner url={url} config={config}>
       {children}
     </UrlViewerInner>
   </WorkerContext>


### PR DESCRIPTION
In order to support showing snapshots with a preview JSON, the online
code was rendering twice, once for the preview and again after interpreting
the vZome XML.  In general we want to avoid that, since the interpretation
may have bugs.

Now parseAndInterpret() takes a new "render" argument that defaults to
true.  If a preview JSON was found and rendered, then we call
parseAndInterpret with render=false.

I also added a toggle to disable showing the snapshots menu.  This was
necessary for one of the bhall/basic models.  In the process, I added a
"config" property to the DesignViewer component and its wrappers,
subsuming the old "useSpinner" property.