### PR TITLE
Fixed missing renderHistory

### DIFF
--- a/online/src/worker/vzome-worker-static.js
+++ b/online/src/worker/vzome-worker-static.js
@@ -94,10 +94,10 @@ const parseAndInterpret = ( xmlLoading, report, render=true ) =>
     .then( design => {
       const { renderer, camera, lighting, xmlTree, targetEditId, snapshots } = design;
       // the next step may take several seconds, which is why we already reported PARSE_COMPLETED
-      if ( render ) { // if we already have a preview, we don't want to interpret and render
-        const { embedding } = renderer;
-        renderHistory = legacyModule .interpretAndRender( design );
+      renderHistory = legacyModule .interpretAndRender( design ); // always have the renderHistory ready for snapshots
+      if ( render ) { // if we already have a preview, we don't want to render
         const { shapes } = renderHistory .getScene( targetEditId, true );
+        const { embedding } = renderer;
         const scene = { lighting, camera, embedding, shapes };
         // TODO: massage xmlTree to make branches from BeginBlock ... EndBlock sequences
         report( { type: 'SCENE_RENDERED', payload: { scene } } );

--- a/online/test/models/orangePurpleChiral.vZome
+++ b/online/test/models/orangePurpleChiral.vZome
@@ -1,86 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<vzome:vZome field="golden" edition="vZome" version="4.0, build 0" revision="999" xmlns:vzome="http://xml.vzome.com/vZome/4.0.0/">
-  <sceneModel ambientLight="45,45,45" background="219,230,240">
-    <directionalLight x="1.0" y="-1.0" z="-1.0" color="236,236,236"/>
-    <directionalLight x="-1.0" y="0.0" z="0.0" color="236,236,236"/>
-    <directionalLight x="0.0" y="0.0" z="-1.0" color="30,30,30"/>
-  </sceneModel>
-  <Viewing>
-    <ViewModel near="0.1521961616306925" far="121.75692749023433" width="27.39530868530272" distance="80"
-    stereoAngle="0.0" parallel="false">
-      <LookAtPoint x="0.0" y="0.0" z="0.0"/>
-      <UpDirection x="0.8283078658787578" y="0.5454043829326404" z="0.1282191031056217"/>
-      <LookDirection x="-0.41390728159116585" y="0.749919480440954" z="-0.5160441212735023"/>
-    </ViewModel>
-  </Viewing>
-  <SymmetrySystem name="icosahedral" renderingStyle="lifelike" single="true">
-    <Direction name="blue" available="true" snap="true" render="true" color="0,160,228">
-      <LengthModel scale="3" taus="0" ones="1" divisor="1"/>
-    </Direction>
-    <Direction name="red" available="true" snap="true" render="true" color="175,0,0">
-      <LengthModel scale="3" taus="0" ones="1" divisor="1"/>
-    </Direction>
-    <Direction name="yellow" available="true" snap="true" render="true" color="240,160,0">
-      <LengthModel scale="2" taus="0" ones="1" divisor="1"/>
-    </Direction>
-    <Direction name="green" available="true" snap="true" render="true" color="0,141,54">
-      <LengthModel scale="3" taus="0" ones="1" divisor="1"/>
-    </Direction>
-    <Direction name="orange" available="true" build="true" render="true" color="220,76,0">
-      <LengthModel scale="3" taus="0" ones="1" divisor="1"/>
-    </Direction>
-    <Direction name="purple" available="true" render="true" color="108,0,198">
-      <LengthModel scale="5" taus="0" ones="1" divisor="1"/>
-    </Direction>
-    <Direction name="black" available="true" render="true" color="30,30,30">
-      <LengthModel scale="3" taus="0" ones="1" divisor="1"/>
-    </Direction>
-    <Direction name="lavender" available="true" render="true" color="175,135,255">
-      <LengthModel scale="3" taus="0" ones="1" divisor="1"/>
-    </Direction>
-    <Direction name="olive" available="true" render="true" color="100,113,0">
-      <LengthModel scale="3" taus="0" ones="1" divisor="1"/>
-    </Direction>
-    <Direction name="maroon" available="true" render="true" color="117,0,50">
-      <LengthModel scale="3" taus="0" ones="1" divisor="1"/>
-    </Direction>
-    <Direction name="rose" available="true" render="true" color="255,51,143">
-      <LengthModel scale="3" taus="0" ones="1" divisor="1"/>
-    </Direction>
-    <Direction name="navy" available="true" render="true" color="0,0,153">
-      <LengthModel scale="3" taus="0" ones="1" divisor="1"/>
-    </Direction>
-    <Direction name="turquoise" available="true" render="true" color="18,205,148">
-      <LengthModel scale="3" taus="0" ones="1" divisor="1"/>
-    </Direction>
-    <Direction name="coral" available="true" render="true" color="255,126,106">
-      <LengthModel scale="3" taus="0" ones="1" divisor="1"/>
-    </Direction>
-    <Direction name="sulfur" available="true" render="true" color="230,245,62">
-      <LengthModel scale="3" taus="0" ones="1" divisor="1"/>
-    </Direction>
-    <Direction name="sand" available="true" render="true" color="154,117,74">
-      <LengthModel scale="3" taus="0" ones="1" divisor="1"/>
-    </Direction>
-    <Direction name="apple" available="true" render="true" color="116,195,0">
-      <LengthModel scale="3" taus="0" ones="1" divisor="1"/>
-    </Direction>
-    <Direction name="cinnamon" available="true" render="true" color="136,37,0">
-      <LengthModel scale="3" taus="0" ones="1" divisor="1"/>
-    </Direction>
-    <Direction name="spruce" available="true" render="true" color="18,73,48">
-      <LengthModel scale="3" taus="0" ones="1" divisor="1"/>
-    </Direction>
-    <Direction name="brown" available="true" render="true" color="107,53,26">
-      <LengthModel scale="3" taus="0" ones="1" divisor="1"/>
-    </Direction>
-  </SymmetrySystem>
-  <EditHistory editNumber="36" lastStickyEdit="17">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<vzome:vZome xmlns:vzome="http://xml.vzome.com/vZome/4.0.0/" buildNumber="76" field="golden" version="7.0">
+  <EditHistory editNumber="38" lastStickyEdit="46">
     <StrutCreation anchor="0 0 0 0 0 0" dir="yellow" index="7" len="0 1"/>
     <StrutCreation anchor="0 0 0 1 1 2" dir="yellow" index="4" len="0 1"/>
     <SelectManifestation point="-1 -1 1 2 2 3"/>
     <Symmetry>
-      <Boolean value="true" attrName="org.vorthmann.zome.editor.Command.LOADING_FROM_FILE"/>
+      <Boolean attrName="org.vorthmann.zome.editor.Command.LOADING_FROM_FILE" value="true"/>
     </Symmetry>
     <BeginBlock/>
     <DeselectAll/>
@@ -90,7 +15,7 @@
     <SelectNeighbors/>
     <EndBlock/>
     <Hide>
-      <Boolean value="true" attrName="org.vorthmann.zome.editor.Command.LOADING_FROM_FILE"/>
+      <Boolean attrName="org.vorthmann.zome.editor.Command.LOADING_FROM_FILE" value="true"/>
     </Hide>
     <BeginBlock/>
     <SelectManifestation point="-1 -2 2 3 1 1"/>
@@ -99,15 +24,15 @@
     <Branch>
       <JoinPoints/>
       <Symmetry>
-        <Boolean value="true" attrName="org.vorthmann.zome.editor.Command.LOADING_FROM_FILE"/>
+        <Boolean attrName="org.vorthmann.zome.editor.Command.LOADING_FROM_FILE" value="true"/>
       </Symmetry>
       <DeselectAll/>
       <StrutCreation anchor="1 1 -1 -2 -2 -3" dir="orange" index="31" len="1 2"/>
       <BeginBlock/>
-      <SelectManifestation startSegment="1 1 -1 -2 -2 -3" endSegment="-1 -1 1 2 -2 -3"/>
-      <SelectManifestation startSegment="1 1 -1 -2 -2 -3" endSegment="3/2 2 -3 -11/2 -3/2 -5/2"/>
+      <SelectManifestation endSegment="-1 -1 1 2 -2 -3" startSegment="1 1 -1 -2 -2 -3"/>
+      <SelectManifestation endSegment="3/2 2 -3 -11/2 -3/2 -5/2" startSegment="1 1 -1 -2 -2 -3"/>
       <EndBlock/>
-      <ScalingTool symmetry="icosahedral" name="scaling.1/scaling.1"/>
+      <ScalingTool name="scaling.1/scaling.1" symmetry="icosahedral"/>
     </Branch>
     <BeginBlock/>
     <DeselectAll/>
@@ -116,7 +41,7 @@
     <EndBlock/>
     <JoinPoints/>
     <Symmetry>
-      <Boolean value="true" attrName="org.vorthmann.zome.editor.Command.LOADING_FROM_FILE"/>
+      <Boolean attrName="org.vorthmann.zome.editor.Command.LOADING_FROM_FILE" value="true"/>
     </Symmetry>
     <BeginBlock/>
     <DeselectAll/>
@@ -125,13 +50,100 @@
     <EndBlock/>
     <JoinPoints/>
     <Symmetry>
-      <Boolean value="true" attrName="org.vorthmann.zome.editor.Command.LOADING_FROM_FILE"/>
+      <Boolean attrName="org.vorthmann.zome.editor.Command.LOADING_FROM_FILE" value="true"/>
     </Symmetry>
     <BeginBlock/>
     <DeselectAll/>
     <SelectAll/>
     <EndBlock/>
-    <ApplyTool name="scaling.1/scaling.1" deselectOutputs="true" hideInputs="true"/>
+    <ApplyTool copyColors="true" deselectOutputs="true" hideInputs="true" name="scaling.1/scaling.1"/>
+    <Snapshot id="0"/>
+    <Snapshot id="1"/>
+    <StrutCreation anchor="0 0 2 3 0 0" index="1" len="2 4"/>
+    <BeginBlock/>
+    <SelectManifestation endSegment="0 0 4 7 0 0" startSegment="0 0 2 3 0 0"/>
+    <SelectManifestation point="0 0 4 7 0 0"/>
+    <EndBlock/>
+    <ApplyTool copyColors="true" name="icosahedral.builtin/icosahedral around origin" selectInputs="true"/>
+    <DeselectAll/>
+    <Snapshot id="2"/>
   </EditHistory>
-  <notes/>
+  <notes>
+    <page snapshot="0" title="3-fold axis">
+      <ViewModel distance="89.02163696289062" far="135.48757934570312" near="0.169359490275383" parallel="false" stereoAngle="0.0" width="30.484697341918945">
+        <LookAtPoint x="0.0" y="0.0" z="0.0"/>
+        <UpDirection x="0.80901700258255" y="0.30901700258255005" z="-0.5000000596046448"/>
+        <LookDirection x="0.5773502588272095" y="-0.5773502588272095" z="0.5773502588272095"/>
+      </ViewModel>
+      <content xml:space="preserve"/>
+    </page>
+    <page snapshot="1" title="5-fold axis">
+      <ViewModel distance="89.02163696289062" far="135.48757934570312" near="0.169359490275383" parallel="false" stereoAngle="0.0" width="30.484697341918945">
+        <LookAtPoint x="0.0" y="0.0" z="0.0"/>
+        <UpDirection x="0.9510564804077148" y="-0.1624598503112793" z="-0.2628655731678009"/>
+        <LookDirection x="0.0" y="-0.8506507873535156" z="0.525731086730957"/>
+      </ViewModel>
+      <content xml:space="preserve"/>
+    </page>
+    <page snapshot="2" title="vertex rays">
+      <ViewModel distance="141.01686096191406" far="214.62234497070312" near="0.26827794313430786" parallel="false" stereoAngle="0.0" width="48.29001235961914">
+        <LookAtPoint x="0.0" y="0.0" z="0.0"/>
+        <UpDirection x="0.9511484503746033" y="0.1432134062051773" z="-0.2735077738761902"/>
+        <LookDirection x="0.30845677852630615" y="-0.47833412885665894" z="0.8222231268882751"/>
+      </ViewModel>
+      <content xml:space="preserve"/>
+    </page>
+  </notes>
+  <sceneModel ambientLight="41,41,41" background="188,215,242">
+    <directionalLight color="235,235,228" x="1.0" y="-1.0" z="-1.0"/>
+    <directionalLight color="228,228,235" x="-1.0" y="0.0" z="0.0"/>
+    <directionalLight color="30,30,30" x="0.0" y="0.0" z="-1.0"/>
+  </sceneModel>
+  <Viewing>
+    <ViewModel distance="141.01686096191406" far="214.62234497070312" near="0.26827794313430786" parallel="false" stereoAngle="0.0" width="48.29001235961914">
+      <LookAtPoint x="0.0" y="0.0" z="0.0"/>
+      <UpDirection x="0.9511484503746033" y="0.1432134062051773" z="-0.2735077738761902"/>
+      <LookDirection x="0.30845677852630615" y="-0.47833412885665894" z="0.8222231268882751"/>
+    </ViewModel>
+  </Viewing>
+  <SymmetrySystem name="icosahedral" renderingStyle="lifelike">
+    <Direction color="0,160,228" name="blue"/>
+    <Direction color="0,141,54" name="green"/>
+    <Direction color="154,117,74" name="sand"/>
+    <Direction color="18,73,48" name="spruce"/>
+    <Direction color="175,0,0" name="red"/>
+    <Direction color="255,126,106" name="coral"/>
+    <Direction color="30,30,30" name="black"/>
+    <Direction color="117,0,50" name="maroon"/>
+    <Direction color="240,160,0" name="yellow"/>
+    <Direction color="230,245,62" name="sulfur"/>
+    <Direction color="255,51,143" name="rose"/>
+    <Direction color="18,205,148" name="turquoise"/>
+    <Direction color="116,195,0" name="apple"/>
+    <Direction color="136,37,0" name="cinnamon"/>
+    <Direction color="108,0,198" name="purple"/>
+    <Direction color="220,76,0" name="orange"/>
+    <Direction color="0,0,153" name="navy"/>
+    <Direction color="107,53,26" name="brown"/>
+    <Direction color="175,135,255" name="lavender"/>
+    <Direction color="100,113,0" name="olive"/>
+  </SymmetrySystem>
+  <OtherSymmetries>
+    <SymmetrySystem name="octahedral" renderingStyle="trapezoids">
+      <Direction color="0,118,149" name="blue"/>
+      <Direction color="175,135,255" name="lavender"/>
+      <Direction color="18,205,148" name="turquoise"/>
+      <Direction color="30,30,30" name="black"/>
+      <Direction color="0,141,54" name="green"/>
+      <Direction color="100,113,0" name="olive"/>
+      <Direction color="117,0,50" name="maroon"/>
+      <Direction color="107,53,26" name="brown"/>
+      <Direction color="240,160,0" name="yellow"/>
+      <Direction color="175,0,0" name="red"/>
+      <Direction color="108,0,198" name="purple"/>
+    </SymmetrySystem>
+  </OtherSymmetries>
+  <Tools>
+    <Tool copyColors="true" deleteInputs="true" id="scaling.1/scaling.1" label="" selectInputs="false"/>
+  </Tools>
 </vzome:vZome>


### PR DESCRIPTION
Even if we don't want to render the XML when we've already rendered a
preview, we still need the renderHistory in case the snapshots will be
available in the viewer.