### PR TITLE
Fixed the show-scene attribute for the web component

### DIFF
--- a/online/src/app/browser/browser.jsx
+++ b/online/src/app/browser/browser.jsx
@@ -1,6 +1,7 @@
 
 import React, { useEffect } from 'react'
 import { useDispatch } from 'react-redux';
+import { fetchDesign } from '../../ui/viewer/store.js';
 
 import { DesignViewer } from '../../ui/viewer/index.jsx'
 
@@ -68,7 +69,7 @@ const DesignList = ( { setUrl } ) =>
 export const DesignBrowser = ( { debug } ) =>
 {
   const report = useDispatch();
-  const setUrl = url => report( { type: 'URL_PROVIDED', payload: { url, config: { preview: true } } } );
+  const setUrl = url => report( fetchDesign( url, true ) );
 
   const drawerColumns = 5;
   const canvasColumns = 12 - drawerColumns;

--- a/online/src/app/components/debugger.jsx
+++ b/online/src/app/components/debugger.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { selectEditAfter } from '../../ui/viewer/store';
 
 import { withStyles, makeStyles } from '@material-ui/core/styles'
 import Toolbar from '@material-ui/core/Toolbar'
@@ -147,7 +148,7 @@ export const HistoryInspector = ( { debug=false } )  =>
   const onNodeSelect = ( event, value ) =>
   {
     setCurrent( value );
-    report( { type: 'EDIT_SELECTED', payload: { after: value } } );
+    report( selectEditAfter( value ) );
   }
 
   const renderTree = ( edit ) =>

--- a/online/src/app/components/folder.jsx
+++ b/online/src/app/components/folder.jsx
@@ -1,6 +1,7 @@
 
 import React, { useRef, useState } from 'react'
 import { useDispatch } from 'react-redux';
+import { fetchDesign } from '../../ui/viewer/store.js';
 
 import IconButton from '@material-ui/core/IconButton'
 import Tooltip from '@material-ui/core/Tooltip'
@@ -72,7 +73,7 @@ export const OpenMenu = props =>
 
   const openUrl = url => {
     if ( url && url.endsWith( ".vZome" ) ) {
-      report( { type: 'URL_PROVIDED', payload: { url, config: { preview: false } } } );
+      report( fetchDesign( url, false ) );
     }
   }
 

--- a/online/src/app/index.jsx
+++ b/online/src/app/index.jsx
@@ -18,7 +18,7 @@ const url = relativeUrl && new URL( relativeUrl, window.location ) .toString();
 
 const App = () =>
 {
-  useVZomeUrl( url || getModelURL( 'vZomeLogo' ), { preview: legacyViewerMode } );
+  useVZomeUrl( url || getModelURL( 'vZomeLogo' ), legacyViewerMode );
 
   return (
     <>

--- a/online/src/ui/viewer/index.jsx
+++ b/online/src/ui/viewer/index.jsx
@@ -14,7 +14,7 @@ import { create } from 'jss';
 
 import { ShapedGeometry } from './geometry.jsx'
 import { DesignCanvas } from './designcanvas.jsx'
-import { createWorkerStore } from './store.js';
+import { createWorkerStore, defineCamera, fetchDesign, selectEditBefore } from './store.js';
 import { Spinner } from './spinner.jsx'
 import { ErrorAlert } from './alert.jsx'
 
@@ -53,8 +53,8 @@ export const SceneMenu = ( { snapshots } ) =>
     const index = event.target.value;
     setSnapshotIndex( index );
     const { nodeId, camera } = snapshots[ index ];
-    report( { type: 'EDIT_SELECTED', payload: { before: nodeId } } );
-    report( { type: 'CAMERA_DEFINED', payload: camera } );
+    report( selectEditBefore( nodeId ) );
+    report( defineCamera( camera ) );
   }
 
   return (
@@ -155,11 +155,11 @@ export const WorkerContext = props =>
   );
 }
 
-export const useVZomeUrl = ( url, config ) =>
+export const useVZomeUrl = ( url, preview ) =>
 {
   const report = useDispatch();
   // TODO: this should be encapsulated in an API on the store
-  useEffect( () => !!url && report( { type: 'URL_PROVIDED', payload: { url, config } } ), [ url ] );
+  useEffect( () => !!url && report( fetchDesign( url, preview ) ), [ url ] );
 }
 
 // This component has to be separate from UrlViewer because of the useDispatch hook used in
@@ -169,8 +169,8 @@ export const UrlViewerInner = ({ url, children, config }) =>
 {
   const { showSnapshots } = config;
   // "preview" means show a preview if you find one.  When "showSnapshots" is true, the
-  //   XML will have to be parsed, so a preview JSON is not desirable.
-  useVZomeUrl( url, { preview: !showSnapshots, ...config } );
+  //   XML will have to be parsed, so a preview JSON is not sufficient.
+  useVZomeUrl( url, !showSnapshots );
   return ( <DesignViewer config={config} >
              {children}
            </DesignViewer> );

--- a/online/src/ui/viewer/store.js
+++ b/online/src/ui/viewer/store.js
@@ -3,6 +3,11 @@ import { configureStore } from '@reduxjs/toolkit'
 
 export const initialState = {};
 
+export const selectEditBefore = nodeId => ({ type: 'EDIT_SELECTED', payload: { before: nodeId } } );
+export const selectEditAfter = nodeId => ({ type: 'EDIT_SELECTED', payload: { after: nodeId } } );
+export const defineCamera = camera => ({ type: 'CAMERA_DEFINED', payload: camera });
+export const fetchDesign = ( url, preview ) => ({ type: 'URL_PROVIDED', payload: { url, preview } });
+
 const reducer = ( state = initialState, event ) =>
 {
   switch ( event.type ) {

--- a/online/src/worker/vzome-worker-static.js
+++ b/online/src/worker/vzome-worker-static.js
@@ -131,14 +131,13 @@ const urlLoader = ( report, event ) =>
   if ( event.type !== 'URL_PROVIDED' ) {
     return report( event );
   }
-  const { url, config={} } = event.payload;
+  const { url, preview=false } = event.payload;
   if ( !url ) {
     throw new Error( "No url field in URL_PROVIDED event payload" );
   }
   const name = url.split( '\\' ).pop().split( '/' ).pop()
   report( { type: 'FETCH_STARTED', payload: event.payload } );
 
-  const { preview=false } = config;
   console.log( `%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% ${preview? "previewing" : "interpreting " } ${url}` );
   const xmlLoading = fetchUrlText( url );
 

--- a/online/test/index.html
+++ b/online/test/index.html
@@ -67,12 +67,11 @@
       </vzome-viewer>
     </section> -->
     <section class="fortyPercent">
-      <vzome-viewer src="./models/orangePurpleChiral.vZome">
+      <vzome-viewer src="./models/orangePurpleChiral.vZome" show-scenes="false" >
         <img src="./models/orangePurpleChiral.png" >
       </vzome-viewer>
     </section>
     <section class="fortyPercent">
-      <!-- TODO: show-scenes is not working -->
       <vzome-viewer src="./models/vZomeLogo.vZome" show-scenes="true" >
       </vzome-viewer>
     </section>


### PR DESCRIPTION
Web component users can now opt-in to `show-scene`.  If set, the vZome
XML will always be interpreted by the worker, and the DesignViewer will
show the scenes menu if any scenes are found.

I also tightened up the APIs at several levels.

First, `useVZomeUrl()` no longer takes a config param, going back to just
a `preview` parameter.  UrlViewer continues to have a `config` property.

I defined four action functions in the Redux store, notably `fetchDesign()`.

In the web component, I am being more careful about detecting actual attribute changes.

All apps have been tested.