### PR TITLE
Fixing transpilation bug in SelectManifestation

### DIFF
--- a/cicd/jsweet-legacy-code.bash
+++ b/cicd/jsweet-legacy-code.bash
@@ -18,7 +18,7 @@ banner 'Transpiling Java sources with JSweet'
 ./gradlew --continue core:jsweet -x compileJava &> jsweet-errors.txt    # ignore the exit code, it always fails
 cat jsweet-errors.txt
 
-grep -q 'transpilation failed with 106 error(s) and 0 warning(s)' jsweet-errors.txt \
+grep -q 'transpilation failed with 104 error(s) and 0 warning(s)' jsweet-errors.txt \
   && banner 'JSweet transpile found the expected errors' \
   || { banner 'UNEXPECTED CHANGE IN JSWEET ERRORS'; exit 1; }
 

--- a/core/src/main/java/com/vzome/core/edits/SelectManifestation.java
+++ b/core/src/main/java/com/vzome/core/edits/SelectManifestation.java
@@ -13,6 +13,7 @@ import com.vzome.core.construction.Polygon;
 import com.vzome.core.construction.Segment;
 import com.vzome.core.editor.api.ChangeSelection;
 import com.vzome.core.editor.api.EditorModel;
+import com.vzome.core.editor.api.SideEffects;
 import com.vzome.core.model.Manifestation;
 import com.vzome.core.model.RealizedModel;
 import com.vzome.xml.DomUtils;
@@ -133,7 +134,7 @@ public class SelectManifestation extends ChangeSelection
             construction = format .parsePolygonReversed( xml, "polygonVertex" );
             mManifestation = mRealized .getManifestation( construction );
             if ( mManifestation != null )
-                logBugAccommodation( "reverse-oriented polygon" );
+                SideEffects.logBugAccommodation( "reverse-oriented polygon" );
         }
     }
 

--- a/core/src/main/java/com/vzome/core/tools/ScalingTool.java
+++ b/core/src/main/java/com/vzome/core/tools/ScalingTool.java
@@ -21,6 +21,7 @@ import com.vzome.core.editor.AbstractToolFactory;
 import com.vzome.core.editor.Tool;
 import com.vzome.core.editor.ToolsModel;
 import com.vzome.core.editor.api.Selection;
+import com.vzome.core.editor.api.SideEffects;
 import com.vzome.core.math.symmetry.Axis;
 import com.vzome.core.math.symmetry.Direction;
 import com.vzome.core.math.symmetry.Symmetry;
@@ -229,7 +230,7 @@ public class ScalingTool extends SymmetryTool
         if ( symmName == null || symmName .isEmpty() )
         {
             element .setAttribute( "symmetry", "icosahedral" );
-            logBugAccommodation( "scaling tool serialized with no symmetry; assuming icosahedral" );
+            SideEffects.logBugAccommodation( "scaling tool serialized with no symmetry; assuming icosahedral" );
         }
         super .setXmlAttributes( element, format );
     }


### PR DESCRIPTION
JSweet is not clever enough when handling static methods from superclasses.
This change is a workaround, making the superclass name explicit.