### PR TITLE
Diffing side effects when loading a history export

### DIFF
--- a/core/src/jsweet/java/com/vzome/jsweet/JsAlgebraicField.java
+++ b/core/src/jsweet/java/com/vzome/jsweet/JsAlgebraicField.java
@@ -97,6 +97,12 @@ public class JsAlgebraicField implements AlgebraicField
         Function f = (Function) this.delegate .$get( "negate" );
         return (int[]) f.$apply( any( factors ) );
     }
+    
+    String toString( int[] factors, int format )
+    {
+        Function f = (Function) this.delegate .$get( "toString" );
+        return (String) f.$apply( any( factors ), any( format ) );
+    }
 
     @Override
     public AlgebraicNumber zero()

--- a/core/src/jsweet/java/com/vzome/jsweet/JsAlgebraicNumber.java
+++ b/core/src/jsweet/java/com/vzome/jsweet/JsAlgebraicNumber.java
@@ -168,7 +168,7 @@ public class JsAlgebraicNumber implements AlgebraicNumber
      */
     public String toString( int format )
     {
-        return Arrays .toString( this .factors );
+        return this.field .toString( this.factors, format );
     }
 
     @Override

--- a/core/src/main/java/com/vzome/core/tools/TransformationTool.java
+++ b/core/src/main/java/com/vzome/core/tools/TransformationTool.java
@@ -74,7 +74,7 @@ public abstract class TransformationTool extends Tool
             result .setColor( color ); // just for consistency
             Manifestation m = applyTool .manifestConstruction( result );
             if ( m != null )  // not sure why, but this happens
-                if ( color != null ) // This can be true in the Javascript world
+                if ( color != null && ! color.equals( m .getColor() )  ) // color can be null in the Javascript world
                     applyTool .colorManifestation( m, c .getColor() );
         }
         applyTool .redo();

--- a/online/src/app/components/debugger.jsx
+++ b/online/src/app/components/debugger.jsx
@@ -152,7 +152,7 @@ export const HistoryInspector = props  =>
     if ( edit.tagName === 'Boolean' || edit.tagName === 'polygonVertex' )
       return null;
     const kids = ( edit.children.length > 0 )? edit.children : null;
-    let subtrees = kids && kids.map( child => renderTree( child ) );
+    let subtrees = kids && kids.filter( kid => kid.tagName !== 'effects' ) .map( child => renderTree( child ) );
     if ( subtrees && subtrees.length === 1 && subtrees[ 0 ] === null )
       subtrees = null;
     return (

--- a/online/src/worker/fields/common.js
+++ b/online/src/worker/fields/common.js
@@ -174,6 +174,49 @@ const origin3 = dimensions =>
   return result
 }
 
+const Format = { DEFAULT: 0, EXPRESSION: 1, ZOMIC: 2, VEF: 3 }
+
+function bigRationalToString( num, denom )
+{
+  if ( denom === 1n )
+    return num.toString()
+  else
+    return num.toString() + "/" + denom.toString()
+}
+
+function toString2( trailingDivisor, format )
+{
+  const [ a0=0n, a1=0n, d=1n ] = trailingDivisor
+  const [ n0, d0 ] = simplify( [ BigInt(a0), BigInt(d) ] );
+  const [ n1, d1 ] = simplify( [ BigInt(a1), BigInt(d) ] );
+  switch (format)
+  {
+    case Format.ZOMIC:
+      return bigRationalToString( n0, d0 ) + " " + bigRationalToString( n1, d1 );
+  
+    case Format.VEF:
+    default:
+      return "(" + bigRationalToString( n1, d1 ) + "," + bigRationalToString( n0, d0 ) + ")";
+  }
+}
+
+function toString3( trailingDivisor, format )
+{
+  const [ a0=0n, a1=0n, a2=0n, d=1n ] = trailingDivisor
+  const [ n0, d0 ] = simplify( [ BigInt(a0), BigInt(d) ] );
+  const [ n1, d1 ] = simplify( [ BigInt(a1), BigInt(d) ] );
+  const [ n2, d2 ] = simplify( [ BigInt(a2), BigInt(d) ] );
+  switch (format)
+  {
+    case Format.ZOMIC:
+      return bigRationalToString( n0, d0 ) + " " + bigRationalToString( n1, d1 ) + " " + bigRationalToString( n2, d2 );
+  
+    case Format.VEF:
+    default:
+      return "(" + bigRationalToString( n2, d2 ) + "," + bigRationalToString( n1, d1 ) + "," + bigRationalToString( n0, d0 ) + ")";
+  }
+}
+
 export const createField = ( { name, order, times, embed, reciprocal } ) =>
 {
   let scalarTerm = 1
@@ -185,6 +228,7 @@ export const createField = ( { name, order, times, embed, reciprocal } ) =>
   let minus = minus2
   let createNumberFromPairs = createNumberFromPairs2
   let createNumber = createNumber2
+  let toString = toString2
   if ( order === 3 ) {
     scalarTerm = 2
     zero = [ 0n, 0n, 0n, 1n ]
@@ -195,6 +239,7 @@ export const createField = ( { name, order, times, embed, reciprocal } ) =>
     minus = minus3
     createNumberFromPairs = createNumberFromPairs3
     createNumber = createNumber3
+    toString = toString3
   }
 
   const scalarmul = ( s, v ) => [ ...v.values() ].map( ( vi=[0n] ) => times( s, vi ) )
@@ -231,6 +276,6 @@ export const createField = ( { name, order, times, embed, reciprocal } ) =>
     plus, minus, times, embed, reciprocal, negate,
     scalarmul, vectoradd, quatTransform, quatmul,
     embedv: (v) => v.map( embed ),
-    createNumberFromPairs, createNumber,
+    createNumberFromPairs, createNumber, toString,
   }
 }


### PR DESCRIPTION
In js2jsweet.js, during interpretEdit(), just after loadAndPerform(), I'm
calling a new checkSideEffects(), which checks for an "effects" element
in the parsed txml.  If it finds it, it generates a new element using
edit.getDetailXml(), then stringifies and compares the two, throwing an
error if they don't match.

This required a correct implementation of JsAlgebraicNumber.toString(ZOMIC),
which further required a new toString() function on JS-implemented fields.

I also had to add enough DOM implementation to satisfy edit.getDetailsXml().
That included a JavaDomAttributes object that overrides toJSON() to sort
the attributes the same way DOM serialization would.

Note that I also had to make a correction to remove redundant
ColorManifestation side-effects during tool application.  This won't affect
older histories, since tools didn't apply color until recently.

I'm now in a position to start tracking down disparities between the Java
code and the JSweet transpiled code.  There may still canonicalization
issues with the history diff, but the feature looks ready for use.