### PR TITLE
Fix tetrahedral symm defect in rootTwo for Online

### DIFF
--- a/core/src/main/java/com/vzome/core/editor/SymmetrySystem.java
+++ b/core/src/main/java/com/vzome/core/editor/SymmetrySystem.java
@@ -143,6 +143,15 @@ public class SymmetrySystem implements OrbitSource
             List<Tool.Factory> list = this .symmetryPerspective .createToolFactories( kind, tools );
             // toolFactoryLists manifest to the Controller automatically
             this .toolFactoryLists .put( kind, list );
+            
+            // TODO: fix this horrible hack!
+            //  All SymmetrySystems feed their predef tools into the same ToolsModel,
+            //  with name collisions!  That only works if the transformations of, say,
+            //  tetrahedral symmetry are the same for all systems.  That was mostly
+            //  true, except for a defect for the "synestructics" system that bit me
+            //  in the transcribed Javascript, where the collision resolved differently!
+            //  See SymmetryTool.checkSelection().
+            //
             List<Tool> toolList = this .symmetryPerspective .predefineTools( kind, tools );
             this .toolLists .put( kind, toolList );
         }

--- a/core/src/main/java/com/vzome/core/tools/SymmetryTool.java
+++ b/core/src/main/java/com/vzome/core/tools/SymmetryTool.java
@@ -144,7 +144,7 @@ public class SymmetryTool extends TransformationTool
 
 	    int[] closure = symmetry .subgroup( Symmetry.TETRAHEDRAL );
 
-	    switch ( symmetry .getName() ) {
+	    switch ( symmetry .getName() ) { // OMG former self, this is such a $#$%^! hack!  What part of OO didn't you understand?
 
 	    case "icosahedral":
 	        if ( !prepareTool && ( axis != null ) && getCategory() .equals( "icosahedral" ) )
@@ -233,7 +233,8 @@ public class SymmetryTool extends TransformationTool
 	        }
 	        break;
 
-	    case "octahedral":
+        case "synestructics":
+        case "octahedral":
 	        if ( prepareTool ) {
 	            if ( getCategory() .equals( "tetrahedral" ) ) {
 	                int order = closure .length;


### PR DESCRIPTION
This was a beast.

The defect was in SymmetryTool, where the switch statement wasn't handling
"synestructics" as a symmetry name.  That switch statement itself, of
course, is an egregious hack.  There should be subclasses for
OctahedralSymmetryTool and TetrahedralSymmetryTool.  Due to this missing
switch case, the tetrahedral symmetry case was falling through to the
default, producing 23 transformations rather than 11.

Furthermore, the defect was obscured on desktop vZome because the
ToolsModel map resolved a collision differently.  The ToolsModel pools
all tools from all SymmetrySystems, making the assumption that
"tetrahedral.whatever" means the same thing in all systems.
Due to the defect above, this was not true.  In the online code, the
Javascript implementation of ToolsModel resolved the conflict differently.