### PR TITLE
Corrected side-effects and history exporters

### DIFF
--- a/core/src/main/java/com/vzome/core/model/ManifestationImpl.java
+++ b/core/src/main/java/com/vzome/core/model/ManifestationImpl.java
@@ -150,8 +150,8 @@ public abstract class ManifestationImpl implements GroupElement, Manifestation, 
 
     public Element getXml( Document doc )
     {
-        return mManifests .isEmpty()
-                ? doc .createElement( "NoConstructions" )
-                        : mManifests .iterator() .next() .getXml( doc );
+        // This is better than the old way, which was subject to mutation,
+        //   but it may break some history diffs in regression testing.
+        return toConstruction() .getXml( doc );
     }
 }


### PR DESCRIPTION
Note: this may break some regression tests that compare history.

Manifestation.getXml() was exporting "NoConstructions" due to mutations
of the mManifests list later in the history.  A simple correction is to
always generate a Construction if the list is empty.

I need to do this in order to correctly compare the batch side-effects
export from Java with the incremental side-effects export in Javascript.
The incremental export happens before subsequent edits mutate the
mManifests lists, so it never generates "NoConstructions".