### PR TITLE
Improved figure styling for vzome-viewer elements

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/ui/ShareDialog.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/ShareDialog.java
@@ -615,7 +615,7 @@ public class ShareDialog extends EscapeDialog
 
             // create commit
             Commit commit = new Commit();
-            commit.setMessage( "shared from vZome" );
+            commit.setMessage( this .title );
             commit.setTree( newTree );
             
             // Due to an error with github api we have to do this

--- a/desktop/src/main/resources/org/vorthmann/zome/ui/githubPostTemplate.md
+++ b/desktop/src/main/resources/org/vorthmann/zome/ui/githubPostTemplate.md
@@ -14,7 +14,13 @@ layout: vzome
 
 ${description}
 
-<vzome-viewer style="width: 87%; height: 60vh; margin: 5%"
+<figure style="width: 87%; margin: 5%">
+  <vzome-viewer style="width: 100%; height: 60vh"
        src="${siteUrl}/${designPath}" >
-  <img src="${siteUrl}/${imagePath}" />
-</vzome-viewer>
+    <img  style="width: 100%"
+       src="${siteUrl}/${imagePath}" >
+  </vzome-viewer>
+  <figcaption style="text-align: center; font-style: italic;">
+    ${title}
+  </figcaption>
+</figure>

--- a/desktop/src/main/resources/org/vorthmann/zome/ui/githubReadmeNoPostTemplate.md
+++ b/desktop/src/main/resources/org/vorthmann/zome/ui/githubReadmeNoPostTemplate.md
@@ -3,12 +3,18 @@
 
  - [raw vZome file](<${rawUrl}>) to use in vZome desktop or vZome Online
  
- HTML custom element for embedding in any web page:
+ HTML for embedding in any web page:
  ```html
-<vzome-viewer style="width: 87%; height: 60vh; margin: 5%"
+<figure style="width: 87%; margin: 5%">
+  <vzome-viewer style="width: 100%; height: 60vh"
        src="${siteUrl}/${designPath}" >
-  <img src="${siteUrl}/${imagePath}" />
-</vzome-viewer>
+    <img  style="width: 100%"
+       src="${siteUrl}/${imagePath}" >
+  </vzome-viewer>
+  <figcaption style="text-align: center; font-style: italic;">
+     REPLACE this caption!
+  </figcaption>
+</figure>
  ```
 
 [vZome Sharing documentation](https://vzome.github.io/vzome/sharing.html#how-it-works)

--- a/desktop/src/main/resources/org/vorthmann/zome/ui/githubReadmeTemplate.md
+++ b/desktop/src/main/resources/org/vorthmann/zome/ui/githubReadmeTemplate.md
@@ -5,12 +5,18 @@
  - [source file for that custom page][source]; click to customize
  - [raw vZome file][raw] to use in vZome desktop or vZome Online
  
- HTML custom element for embedding in any web page:
+ HTML for embedding in any web page:
  ```html
-<vzome-viewer style="width: 87%; height: 60vh; margin: 5%"
+<figure style="width: 87%; margin: 5%">
+  <vzome-viewer style="width: 100%; height: 60vh"
        src="${siteUrl}/${designPath}" >
-  <img src="${siteUrl}/${imagePath}" />
-</vzome-viewer>
+    <img  style="width: 100%"
+       src="${siteUrl}/${imagePath}" >
+  </vzome-viewer>
+  <figcaption style="text-align: center; font-style: italic;">
+     REPLACE this caption!
+  </figcaption>
+</figure>
  ```
 
 [vZome Sharing documentation](https://vzome.github.io/vzome/sharing.html#how-it-works)


### PR DESCRIPTION
The image is now fitting correctly in the same rectangle that the custom
element takes up, and we don't have doubled margins any more.

I also improved the commit message for GitHub share, using the post title.