### PR TITLE
Improve logging to help with migration to Java 17 on Windows

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/ui/ApplicationUI.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/ApplicationUI.java
@@ -152,7 +152,7 @@ public final class ApplicationUI implements ApplicationController.UI, PropertyCh
             initialize( args );
         } catch ( Throwable e ) {
             e .printStackTrace();
-            System.out.println( "problem in main(): " + e.getMessage() );
+			logger.severe("problem in main(): " + e.getMessage());
         }
     }
 

--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
@@ -672,10 +672,18 @@ public class DocumentFrame extends JFrame implements PropertyChangeListener, Con
 		}
 		this.setExtendedState(java.awt.Frame.MAXIMIZED_BOTH);
 
-        this.pack();
-        this.setVisible( true );
-        this.setFocusable( true );
-
+		try {
+			// This is where the GraphicsConfiguration fails on David's Windows 10 using Java 17
+			this.pack();
+	        this.setVisible( true );
+	        this.setFocusable( true );
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			errors.reportError( "Failed to initialize UI. Exiting the application.", new Object[] { ex } );
+			// go ahead and exit so the process is killed
+			// and log files have their associated .lck files removed correctly. 
+			System.exit(-1);
+		}
 
         new ExclusiveAction( this .getExcluder() )
         {

--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
@@ -679,9 +679,11 @@ public class DocumentFrame extends JFrame implements PropertyChangeListener, Con
 	        this.setFocusable( true );
 		} catch (Exception ex) {
 			ex.printStackTrace();
-			errors.reportError( "Failed to initialize UI. Exiting the application.", new Object[] { ex } );
+			final String msg = "Failed to initialize GraphicsConfiguration.\nExiting the application.";
+			errors.reportError(msg, new Object[] { ex } );
 			// go ahead and exit so the process is killed
-			// and log files have their associated .lck files removed correctly. 
+			// and log files have their associated .lck files removed correctly.
+			JOptionPane.showMessageDialog( null, msg, "vZome Fatal Error", JOptionPane.ERROR_MESSAGE );
 			System.exit(-1);
 		}
 


### PR DESCRIPTION
Call System.exit() when UI can't initialize so that file locks and zombie processes are cleaned up.