### PR TITLE
Add logging for missing build.properties and similar resources

### DIFF
--- a/core/src/main/java/com/vzome/core/editor/Application.java
+++ b/core/src/main/java/com/vzome/core/editor/Application.java
@@ -89,7 +89,7 @@ public class Application implements AlgebraicField.Registry
 
     private final Map<String, Supplier<SnapshotExporter>> exporters2d = new HashMap<>();
 
-    private static final Logger logger = Logger.getLogger( "com.vzome.core.editor" );
+    private static final Logger LOGGER = Logger.getLogger( "com.vzome.core.editor" );
 
     public Application( boolean enableCommands, Command.FailureChannel failures, Properties overrides )
     {
@@ -178,11 +178,11 @@ public class Application implements AlgebraicField.Registry
             String error = "Unknown " + edition + " file format.";
             if ( ! version .isEmpty() )
                 error += "\n Cannot open files created by " + edition + " " + version;
-            logger .severe( error );
+            LOGGER .severe( error );
             throw new IllegalStateException( error );
         }
         else
-            logger .fine( "supported format: " + tns );
+            LOGGER .fine( "supported format: " + tns );
 
         String fieldName = element .getAttribute( "field" );
         if ( fieldName .isEmpty() )
@@ -269,8 +269,11 @@ public class Application implements AlgebraicField.Registry
         try {
             ClassLoader cl = Application.class.getClassLoader();
             InputStream in = cl.getResourceAsStream( defaultRsrc );
-            if ( in != null )
-                defaults .load( in );
+			if (in != null) {
+				defaults.load(in);
+			} else {
+				LOGGER.warning("RESOURCE NOT FOUND. Ensure that the build path for the core project includes " + defaultRsrc);
+			}
         } catch ( IOException ioe ) {
             System.err.println( "problem reading default preferences: " + defaultRsrc );
         }
@@ -284,10 +287,18 @@ public class Application implements AlgebraicField.Registry
         try {
             ClassLoader cl = Application.class.getClassLoader();
             InputStream in = cl.getResourceAsStream( defaultRsrc );
-            if ( in != null )
-                defaults .load( in );
+			if (in != null) {
+				defaults.load(in);
+			} else {
+				// Gradle builds normally regenerate this file in core/build/buildPropsResource, 
+				// but it's not generated in Eclipse builds.
+				// Be sure to manually add build/buildPropsResource to both the core and desktop projects in Eclipse
+				// then run gradlew core:recordBuildProperties desktop:recordBuildProperties from the command line
+				// to generate them. Otherwise "about" version info and log file names will show up as "null".
+				LOGGER.warning("RESOURCE NOT FOUND. Ensure that the build path for the core project includes " + defaultRsrc);
+			}
         } catch ( IOException ioe ) {
-            logger.warning( "problem reading build properties: " + defaultRsrc );
+            LOGGER.warning( "problem reading build properties: " + defaultRsrc );
         }
         return defaults;
     }

--- a/desktop/src/main/java/com/vzome/desktop/awt/ApplicationController.java
+++ b/desktop/src/main/java/com/vzome/desktop/awt/ApplicationController.java
@@ -41,7 +41,7 @@ import com.vzome.desktop.controller.DefaultController;
 
 public class ApplicationController extends DefaultController
 {
-    private static final Logger logger = Logger.getLogger( "org.vorthmann.zome.controller" );
+    private static final Logger LOGGER = Logger.getLogger( "org.vorthmann.zome.controller" );
 
     private final Map<String, DocumentController> docControllers = new HashMap<>();
 
@@ -78,8 +78,8 @@ public class ApplicationController extends DefaultController
 
         long starttime = System.currentTimeMillis();
 
-        if ( logger .isLoggable( Level .INFO ) )
-            logger .info( "ApplicationController .initialize() starting" );
+        if ( LOGGER .isLoggable( Level .INFO ) )
+            LOGGER .info( "ApplicationController .initialize() starting" );
 
         this.ui = ui;
 
@@ -94,14 +94,14 @@ public class ApplicationController extends DefaultController
         }
         Properties userPrefs = new Properties();
         if ( ! prefsFile .exists() ) {
-            logger .config( "Used default preferences." );
+            LOGGER .config( "Used default preferences." );
         } else {
             try {
                 InputStream in = new FileInputStream( prefsFile );
                 userPrefs .load( in );
-                logger .config( "User Preferences loaded from " + prefsFile .getAbsolutePath() );
+                LOGGER .config( "User Preferences loaded from " + prefsFile .getAbsolutePath() );
             } catch ( Throwable t ) {
-                logger .severe( "problem reading user preferences: " + t.getMessage() );
+                LOGGER .severe( "problem reading user preferences: " + t.getMessage() );
             }
         }
 
@@ -110,9 +110,9 @@ public class ApplicationController extends DefaultController
             try {
                 InputStream in = new FileInputStream( this.configFile );
                 storedConfig .load( in );
-                logger .config( "Stored config loaded from " + this.configFile .getAbsolutePath() );
+                LOGGER .config( "Stored config loaded from " + this.configFile .getAbsolutePath() );
             } catch ( Throwable t ) {
-                logger .severe( "problem reading stored config: " + t.getMessage() );
+                LOGGER .severe( "problem reading stored config: " + t.getMessage() );
             }
         }
 
@@ -121,10 +121,13 @@ public class ApplicationController extends DefaultController
         try {
             ClassLoader cl = ApplicationUI.class.getClassLoader();
             InputStream in = cl.getResourceAsStream( defaultRsrc );
-            if ( in != null )
-                defaults .load( in ); // override the core defaults
+			if (in != null) {
+				defaults.load(in); // override the core defaults
+			} else {
+				LOGGER.warning("RESOURCE NOT FOUND. Ensure that the build path for the desktop project includes " + defaultRsrc);
+			}
         } catch ( IOException ioe ) {
-            logger.severe( "problem reading default preferences: " + defaultRsrc );
+            LOGGER.severe( "problem reading default preferences: " + defaultRsrc );
         }
 
         // last-wins, so getProperty() will show command-line args overriding stored configs,
@@ -142,7 +145,7 @@ public class ApplicationController extends DefaultController
         final String NOERASEBACKGROUND = "sun.awt.noerasebackground";
         if( propertyIsTrue(NOERASEBACKGROUND)) { // if it's set to true in the prefs file or command line
             System.setProperty(NOERASEBACKGROUND, "true"); // then set the System property so the AWT/Swing components will use it.
-            logger .config( NOERASEBACKGROUND + " is set to 'true'." );
+            LOGGER .config( NOERASEBACKGROUND + " is set to 'true'." );
         }
 
         final FailureChannel failures = new FailureChannel()
@@ -175,8 +178,8 @@ public class ApplicationController extends DefaultController
         }
 
         long endtime = System.currentTimeMillis();
-        if ( logger .isLoggable( Level .INFO ) )
-            logger .log(Level.INFO, "ApplicationController initialization in milliseconds: {0}", ( endtime - starttime ));
+        if ( LOGGER .isLoggable( Level .INFO ) )
+            LOGGER .log(Level.INFO, "ApplicationController initialization in milliseconds: {0}", ( endtime - starttime ));
     }
 
     public RenderedModel getSymmetryModel( String path, Symmetry symmetry )
@@ -238,7 +241,7 @@ public class ApplicationController extends DefaultController
                         this.storedConfig .store( writer, "This file is managed by vZome.  Do not edit." );
                         writer .close();
                     } catch ( IOException e ) {
-                        logger.fine(e.toString());
+                        LOGGER.fine(e.toString());
                     }
                     return;
                 }
@@ -255,7 +258,7 @@ public class ApplicationController extends DefaultController
                 String fieldName = action .substring( "new-" .length() );
                 File prototype = new File( Platform .getPreferencesFolder(), "Prototypes/" + fieldName + ".vZome" );
                 if ( prototype .exists() ) {
-                    logger.log(Level.CONFIG, "Loading default template from {0}", prototype.getCanonicalPath());
+                    LOGGER.log(Level.CONFIG, "Loading default template from {0}", prototype.getCanonicalPath());
                     doFileAction( "newFromTemplate", prototype );
                 }
                 else
@@ -331,7 +334,7 @@ public class ApplicationController extends DefaultController
     @Override
     public void doFileAction( String command, File file )
     {
-        if ( logger .isLoggable( Level.INFO ) ) logger .info( String.format( "ApplicationController.doFileAction: %s %s", command, file .getAbsolutePath() ) );
+        if ( LOGGER .isLoggable( Level.INFO ) ) LOGGER .info( String.format( "ApplicationController.doFileAction: %s %s", command, file .getAbsolutePath() ) );
         if ( file != null )
         {
             Properties docProps = new Properties();
@@ -540,7 +543,7 @@ public class ApplicationController extends DefaultController
                 this.storedConfig .store( writer, "This file is managed by vZome.  Do not edit." );
                 writer .close();
             } catch ( IOException e ) {
-                logger.fine(e.toString());
+                LOGGER.fine(e.toString());
             }
             break;
 

--- a/desktop/src/main/java/org/vorthmann/zome/ui/ApplicationUI.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/ApplicationUI.java
@@ -82,10 +82,7 @@ public final class ApplicationUI implements ApplicationController.UI, PropertyCh
 
     private final Collection<DocumentFrame> windowsToClose = new ArrayList<>();
 
-    // loggerClassName = "org.vorthmann.zome.ui.ApplicationUI"
-    // Initializing it this way just ensures that any copied code uses the correct class name for a static Logger in any class.
-    private static final String loggerClassName = new Throwable().getStackTrace()[0].getClassName();
-    private static final Logger logger = Logger .getLogger( loggerClassName );
+    private static final Logger LOGGER = Logger .getLogger( "org.vorthmann.zome.ui.ApplicationUI" );
 
     // static class initializer configures global logging before any instance of the class is created.
     static {
@@ -171,6 +168,7 @@ public final class ApplicationUI implements ApplicationController.UI, PropertyCh
             if ( desktop .isSupported( Action.APP_OPEN_FILE ) )
                 desktop .setOpenFileHandler( new OpenFilesHandler()
                 {
+                    @Override
                     public void openFiles( OpenFilesEvent ofe )
                     {
                         for (Iterator<?> iterator = ofe .getFiles() .iterator(); iterator.hasNext(); ) {
@@ -183,6 +181,7 @@ public final class ApplicationUI implements ApplicationController.UI, PropertyCh
             if ( desktop .isSupported( Action.APP_ABOUT ) )
                 desktop .setAboutHandler( new AboutHandler()
                 {
+                    @Override
                     public void handleAbout( AboutEvent about )
                     {
                         theUI .about();
@@ -192,6 +191,7 @@ public final class ApplicationUI implements ApplicationController.UI, PropertyCh
             if ( desktop .isSupported( Action.APP_QUIT_HANDLER ) )
                 desktop .setQuitHandler( new QuitHandler()
                 {
+                    @Override
                     public void handleQuitRequestWith( QuitEvent qe, QuitResponse qr )
                     {
                         if ( theUI .quit() )
@@ -204,7 +204,7 @@ public final class ApplicationUI implements ApplicationController.UI, PropertyCh
 
         } catch ( Throwable e ) {
             e .printStackTrace();
-			logger.severe("problem in main(): " + e.getMessage());
+			LOGGER.severe("problem in main(): " + e.getMessage());
         }
     }
 
@@ -228,9 +228,9 @@ public final class ApplicationUI implements ApplicationController.UI, PropertyCh
             // This can happen in the rare case when Explorer.exe has been killed and restarted manually.
             // We will allow for that condition to avoid the NPE.
             if( sessionName != null && "console".compareToIgnoreCase(sessionName) != 0) {
-                logger.info("Java OpenGL (JOGL) is not supported by Windows Terminal Services.");
+                LOGGER.info("Java OpenGL (JOGL) is not supported by Windows Terminal Services.");
                 final String msg = "vZome cannot be run under Windows Terminal Services.";
-                logger.severe(msg);
+                LOGGER.severe(msg);
                 JOptionPane.showMessageDialog( null, msg, "vZome Fatal Error", JOptionPane.ERROR_MESSAGE );
                 System .exit( 0 );
             }
@@ -244,7 +244,7 @@ public final class ApplicationUI implements ApplicationController.UI, PropertyCh
         String splashImage = "org/vorthmann/zome/ui/vZome-splash.png";
         splash = new SplashScreen( splashImage );
         splash .splash();
-        logger .info( "splash screen displayed" );
+        LOGGER .info( "splash screen displayed" );
 
         theUI = new ApplicationUI();
 
@@ -292,7 +292,7 @@ public final class ApplicationUI implements ApplicationController.UI, PropertyCh
                     configuration .setProperty( propName, propValue );
                 } else {
                     String arg = args[i];
-                    logger.info( "OS file argument: " + arg );
+                    LOGGER.info( "OS file argument: " + arg );
                     Path normalizedPath = null;
                     try {
                         // standard Java 7 idiom for dealing with file URIs, which is what
@@ -303,11 +303,11 @@ public final class ApplicationUI implements ApplicationController.UI, PropertyCh
                         normalizedPath = Paths .get( arg );
                     } catch ( FileSystemNotFoundException e ) {
                         // Someone passed an HTTP URL, and Paths.get() can't handle it.
-                        logger.warning( "URL command-line arguments are not supported." );
+                        LOGGER.warning( "URL command-line arguments are not supported." );
                         continue; // leave fileArgument as null
                     }
                     fileArgument = normalizedPath .toAbsolutePath() .normalize();
-                    logger.info( "Normalized file argument: " + fileArgument );
+                    LOGGER.info( "Normalized file argument: " + fileArgument );
                 }
             }
 
@@ -323,7 +323,7 @@ public final class ApplicationUI implements ApplicationController.UI, PropertyCh
                 } 
                 catch (Exception e) {
                     // live without it
-                    logger.severe( "The look&feel was not set successfully: " + className );
+                    LOGGER.severe( "The look&feel was not set successfully: " + className );
                 }
             }
 
@@ -340,13 +340,13 @@ public final class ApplicationUI implements ApplicationController.UI, PropertyCh
                     if ( Controller.USER_ERROR_CODE.equals( errorCode ) ) {
                         errorCode = ( (Exception) arguments[0] ).getMessage();
                         // don't want a stack trace for a user error
-                        logger.log( Level.WARNING, errorCode );
+                        LOGGER.log( Level.WARNING, errorCode );
                     } else if ( Controller.UNKNOWN_ERROR_CODE.equals( errorCode ) ) {
                         errorCode = ( (Exception) arguments[0] ).getMessage();
-                        logger.log( Level.WARNING, "internal error: " + errorCode, ( (Exception) arguments[0] ) );
+                        LOGGER.log( Level.WARNING, "internal error: " + errorCode, ( (Exception) arguments[0] ) );
                         errorCode = "internal error has been logged";
                     } else {
-                        logger.log( Level.WARNING, "reporting error: " + errorCode, arguments );
+                        LOGGER.log( Level.WARNING, "reporting error: " + errorCode, arguments );
                         if(arguments != null) {
                             StringBuilder buf = new StringBuilder(errorCode);
                             for(Object arg : arguments) {
@@ -384,8 +384,8 @@ public final class ApplicationUI implements ApplicationController.UI, PropertyCh
                     Integer debugPort = Integer .parseInt( debugPortStr );
                     ui .debugger .startServer( debugPort, ui .mController );
                 } catch ( NumberFormatException e ) {
-                    if ( logger .isLoggable( Level .WARNING ) )
-                        logger .warning( "debug.adapter.port not an integer; debugger not listening" );
+                    if ( LOGGER .isLoggable( Level .WARNING ) )
+                        LOGGER .warning( "debug.adapter.port not an integer; debugger not listening" );
                 }
             }
         }
@@ -493,10 +493,18 @@ public final class ApplicationUI implements ApplicationController.UI, PropertyCh
         try {
             ClassLoader cl = ApplicationUI.class.getClassLoader();
             InputStream in = cl.getResourceAsStream( defaultRsrc );
-            if ( in != null ) 
-                defaults .load( in );
+			if (in != null) {
+				defaults.load(in);
+			} else {
+				// Gradle builds normally regenerate this file in desktop/build/buildPropsResource, 
+				// but it's not generated in Eclipse builds.
+				// Be sure to manually add build/buildPropsResource to both the core and desktop projects in Eclipse
+				// then run gradlew core:recordBuildProperties desktop:recordBuildProperties from the command line
+				// to generate them. Otherwise "about" version info and log file names will show up as "null".
+				LOGGER.warning("RESOURCE NOT FOUND. Ensure that the build path for the desktop project includes " + defaultRsrc);
+			}
         } catch ( IOException ioe ) {
-            logger.warning( "problem reading build properties: " + defaultRsrc );
+            LOGGER.warning( "problem reading build properties: " + defaultRsrc );
         }
         return defaults;
     }
@@ -567,7 +575,7 @@ public final class ApplicationUI implements ApplicationController.UI, PropertyCh
 
     private static void logJVMArgs() {
         Level level = Level.CONFIG;
-        if(logger.isLoggable(level)) {
+        if(LOGGER.isLoggable(level)) {
             Properties props = new Properties();
             RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
             List<String> arguments = runtimeMxBean.getInputArguments();
@@ -579,13 +587,13 @@ public final class ApplicationUI implements ApplicationController.UI, PropertyCh
             }
             StringBuilder sb = new StringBuilder("JVM args:");
             appendPropertiesList(sb, props);
-            logger.log(level, sb.toString());
+            LOGGER.log(level, sb.toString());
         }
     }
 
     private static void logExtendedCharacters() {
         Level level = Level.FINE;
-        if(logger.isLoggable(level)) {
+        if(LOGGER.isLoggable(level)) {
             Properties props = new Properties();
             props.put("phi",   "\u03C6");
             props.put("rho",   "\u03C1");
@@ -594,7 +602,7 @@ public final class ApplicationUI implements ApplicationController.UI, PropertyCh
             props.put("xi",    "\u03BE");
             StringBuilder sb = new StringBuilder("Extended characters:");
             appendPropertiesList(sb, props);
-            logger.log(level, sb.toString());
+            LOGGER.log(level, sb.toString());
         }
     }
 


### PR DESCRIPTION
Since log file names are now generated at run time based on the version info in the build.properties resource files, their names showed up something like vZome-null.null_0_0.log when running in Eclipse, but not in the release builds or with gradlew run. I added comments about how to fix the build paths which Eclipse does not pick up automatically from build.gradle. I also added better logging when these resources are missing.

* Renamed some static final "logger" variables to use the conventional upper case "LOGGER".
* Added some missing @Override annotations