### PR TITLE
Fixed registration of RotationToolFactory

### DIFF
--- a/core/src/main/java/com/vzome/core/kinds/DefaultFieldApplication.java
+++ b/core/src/main/java/com/vzome/core/kinds/DefaultFieldApplication.java
@@ -34,8 +34,8 @@ import com.vzome.core.tools.ModuleToolFactory;
 import com.vzome.core.tools.OctahedralToolFactory;
 import com.vzome.core.tools.PlaneSelectionToolFactory;
 import com.vzome.core.tools.ProjectionToolFactory;
+import com.vzome.core.tools.RotationToolFactory;
 import com.vzome.core.tools.ScalingToolFactory;
-import com.vzome.core.tools.SymmetryToolFactory;
 import com.vzome.core.tools.TranslationToolFactory;
 
 public class DefaultFieldApplication implements FieldApplication
@@ -111,7 +111,7 @@ public class DefaultFieldApplication implements FieldApplication
 	    // These symm parameters can be null since it will be overwritten by SymmetryTool.setXmlAttributes()
         // Any SymmetryTool factory here is good enough
 	    toolFactories .put( "SymmetryTool", new OctahedralToolFactory( tools, null ) );
-	    toolFactories .put( "RotationTool", new SymmetryToolFactory( tools, null ) );
+	    toolFactories .put( "RotationTool", new RotationToolFactory( tools, null ) );
 	    toolFactories .put( "ScalingTool", new ScalingToolFactory( tools, null ) );
 	    
 	    toolFactories .put( "InversionTool", new InversionToolFactory( tools ) );

--- a/core/src/test/java/com/vzome/core/kinds/FieldApplicationTest.java
+++ b/core/src/test/java/com/vzome/core/kinds/FieldApplicationTest.java
@@ -62,8 +62,8 @@ import com.vzome.core.tools.ModuleToolFactory;
 import com.vzome.core.tools.OctahedralToolFactory;
 import com.vzome.core.tools.PlaneSelectionToolFactory;
 import com.vzome.core.tools.ProjectionToolFactory;
+import com.vzome.core.tools.RotationToolFactory;
 import com.vzome.core.tools.ScalingToolFactory;
-import com.vzome.core.tools.SymmetryToolFactory;
 import com.vzome.core.tools.TranslationToolFactory;
 import com.vzome.fields.sqrtphi.SqrtPhiField;
 import com.vzome.fields.sqrtphi.SqrtPhiFieldApplication;
@@ -544,7 +544,7 @@ public class FieldApplicationTest
         ToolsModel tools = null;
         app.registerToolFactories( toolFactories, tools );
         
-        assertTrue(toolFactories .get( "RotationTool") instanceof SymmetryToolFactory);
+        assertTrue(toolFactories .get( "RotationTool") instanceof RotationToolFactory);
         assertTrue(toolFactories .get( "ScalingTool") instanceof ScalingToolFactory);
         
         assertTrue(toolFactories .get( "InversionTool") instanceof InversionToolFactory);


### PR DESCRIPTION
Somehow the refactoring got this wrong when I extracted the factories as
top-level classes.