### PR TITLE
Changed shapes.json file extension to match shares

### DIFF
--- a/core/src/main/java/com/vzome/core/exporters/ShapesJsonExporter.java
+++ b/core/src/main/java/com/vzome/core/exporters/ShapesJsonExporter.java
@@ -102,7 +102,7 @@ public class ShapesJsonExporter extends Exporter3d
     @Override
     public String getFileExtension()
     {
-        return "json";
+        return "shapes.json";
     }
 
     @Override


### PR DESCRIPTION
Manual export produced "foo.json" instead of "foo.shapes.json".  The
latter is consistent with Online preview logic.