### PR TITLE
Fixing the issue toggling full-viewport while in orthographic mode

### DIFF
--- a/online/src/ui/viewer/designcanvas.jsx
+++ b/online/src/ui/viewer/designcanvas.jsx
@@ -1,5 +1,5 @@
 
-import React, { useMemo, useRef, useEffect } from 'react'
+import React, { useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
 import { Canvas, useThree, useFrame } from '@react-three/fiber'
 import { VRCanvas, DefaultXRControllers, useXR, RayGrab } from '@react-three/xr'

--- a/online/src/ui/viewer/index.jsx
+++ b/online/src/ui/viewer/index.jsx
@@ -19,7 +19,7 @@ import { create } from 'jss';
 
 import { ShapedGeometry } from './geometry.jsx'
 import { DesignCanvas } from './designcanvas.jsx'
-import { createWorkerStore, defineCamera, fetchDesign, selectEditBefore } from './store.js';
+import { createWorkerStore, defineCamera, fetchDesign, selectEditBefore, whilePerspective } from './store.js';
 import { Spinner } from './spinner.jsx'
 import { ErrorAlert } from './alert.jsx'
 import { SettingsDialog } from './settings.jsx';
@@ -121,6 +121,17 @@ export const DesignViewer = ( { children, children3d, config={} } ) =>
   const vrAvailable = useVR();
   const containerRef = useRef();
 
+  const report = useDispatch();
+  const sceneCamera = useSelector( state => state.scene && state.scene.camera );
+  const toggleFullScreen = () =>
+  {
+    const { perspective } = sceneCamera || {};
+    // This is a complete hack to work around the issue with resize in OrthographicCamera.
+    //  We simply use a thunk to switch to a perspective camera before we toggle fullScreen.
+    //  Note that this does NOT help with window resize.
+    report( whilePerspective( perspective, () => setFullScreen( !fullScreen ) ) );
+  }
+
   return (
     <div ref={containerRef} style={ fullScreen? fullScreenStyle : normalStyle }>
       { scene?
@@ -139,7 +150,7 @@ export const DesignViewer = ( { children, children3d, config={} } ) =>
       { allowFullViewport &&
         <IconButton color="inherit" aria-label="fullscreen"
             style={ { position: 'absolute', bottom: '5px', right: '5px' } }
-            onClick={() => setFullScreen(!fullScreen)} >
+            onClick={toggleFullScreen} >
           { fullScreen? <FullscreenExitIcon fontSize='large'/> : <FullscreenIcon fontSize='large'/> }
         </IconButton>
       }

--- a/online/src/ui/viewer/store.js
+++ b/online/src/ui/viewer/store.js
@@ -19,6 +19,16 @@ export const initialState = {
 export const defineCamera = camera => ({ type: 'CAMERA_DEFINED', payload: camera });
 export const setPerspective = value => ({ type: 'PERSPECTIVE_SET', payload: value });
 
+export const whilePerspective = ( perspective, doSetter ) => async dispatch =>
+{
+  const wait = ms => new Promise( (resolve) => setTimeout(resolve, 100) );
+  dispatch( setPerspective( true ) );
+  await wait( 10 );
+  doSetter();
+  await wait( 10 );
+  dispatch( setPerspective( perspective ) );
+}
+
 const workerAction = ( type, payload ) => ({ type, payload, meta: 'WORKER' } );
 
 export const selectEditBefore = nodeId => workerAction( 'EDIT_SELECTED', { before: nodeId } );


### PR DESCRIPTION
This is a workaround, and a partial one... it does not address the same behavior
issue with window resize.