### PR TITLE
Laying out components for the classic editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ online/src/worker/legacy/candies
 online/src/ui/legacy/candies
 
 desktop-errors.txt
+
+online/public/classic/icons/

--- a/cicd/build-online.bash
+++ b/cicd/build-online.bash
@@ -21,6 +21,10 @@ yarn install || exit $?
 rm -rf dist || exit $?
 yarn run build || exit $?
 
+rm -rf public/classic/icons || exit $?
+mkdir -p public/classic/icons || exit $?
+cp -R ../desktop/src/main/resources/icons/* public/classic/icons || exit $?
+
 pushd dist
 
 REVISION=${BUILD_NUMBER:-'dev'}

--- a/cicd/jsweet-legacy-code.bash
+++ b/cicd/jsweet-legacy-code.bash
@@ -33,10 +33,13 @@ CANDIES_OUT="$LEGACY/candies"
 
 banner 'Patching up the j4ts bundle as an ES6 module' ######################################
 
+# also, working around https://github.com/cincheo/jsweet/issues/740
+
 mkdir -p $CANDIES_OUT/j4ts-2.1.0-SNAPSHOT
 cat $CANDIES_IN/j4ts-2.1.0-SNAPSHOT/bundle.js | \
   sed \
     -e 's/^var java/export var java/' \
+    -e 's/return this.size();/return this.__parent.size();/' \
   > $CANDIES_OUT/j4ts-2.1.0-SNAPSHOT/bundle.js || exit $?
 
 banner 'Patching up the core bundle as an ES6 module' ######################################

--- a/desktop/src/main/java/com/vzome/desktop/awt/DocumentController.java
+++ b/desktop/src/main/java/com/vzome/desktop/awt/DocumentController.java
@@ -84,6 +84,7 @@ import com.vzome.desktop.controller.PartsController;
 import com.vzome.desktop.controller.PolytopesController;
 import com.vzome.desktop.controller.SymmetryController;
 import com.vzome.desktop.controller.ToolFactoryController;
+import com.vzome.desktop.controller.ToolsController;
 import com.vzome.desktop.controller.UndoRedoController;
 import com.vzome.desktop.controller.VectorController;
 

--- a/desktop/src/main/java/com/vzome/desktop/controller/SymmetryController.java
+++ b/desktop/src/main/java/com/vzome/desktop/controller/SymmetryController.java
@@ -164,23 +164,26 @@ public class SymmetryController extends DefaultController
 
         case "symmetryToolFactories":
 
-            // This will be called only once, before any relevant getSubController, so it is OK to do creations
-            for ( Tool.Factory factory : this .symmetrySystem .getToolFactories( Tool.Kind.SYMMETRY ) )
-                this .symmetryToolFactories .put( factory .getId(), new ToolFactoryController( factory ) );
+            if ( this .symmetryToolFactories .isEmpty() ) {
+                for ( Tool.Factory factory : this .symmetrySystem .getToolFactories( Tool.Kind.SYMMETRY ) )
+                    this .symmetryToolFactories .put( factory .getId(), new ToolFactoryController( factory ) );
+            }
             return this .symmetryToolFactories .keySet() .toArray( new String[]{} );
 
         case "transformToolFactories":
 
-            // This will be called only once, before any relevant getSubController, so it is OK to do creations
-            for ( Tool.Factory factory : this .symmetrySystem .getToolFactories( Tool.Kind.TRANSFORM ) )
-                this .transformToolFactories .put( factory .getId(), new ToolFactoryController( factory ) );
+            if ( this .transformToolFactories .isEmpty() ) {
+                for ( Tool.Factory factory : this .symmetrySystem .getToolFactories( Tool.Kind.TRANSFORM ) )
+                    this .transformToolFactories .put( factory .getId(), new ToolFactoryController( factory ) );
+            }
             return this .transformToolFactories .keySet() .toArray( new String[]{} );
 
         case "linearMapToolFactories":
 
-            // This will be called only once, before any relevant getSubController, so it is OK to do creations
-            for ( Tool.Factory factory : this .symmetrySystem .getToolFactories( Tool.Kind.LINEAR_MAP ) )
-                this .linearMapToolFactories .put( factory .getId(), new ToolFactoryController( factory ) );
+            if ( this .linearMapToolFactories .isEmpty() ) {
+                for ( Tool.Factory factory : this .symmetrySystem .getToolFactories( Tool.Kind.LINEAR_MAP ) )
+                    this .linearMapToolFactories .put( factory .getId(), new ToolFactoryController( factory ) );
+            }
             return this .linearMapToolFactories .keySet() .toArray( new String[]{} );
 
         case "builtInSymmetryTools":

--- a/desktop/src/main/java/com/vzome/desktop/controller/ToolController.java
+++ b/desktop/src/main/java/com/vzome/desktop/controller/ToolController.java
@@ -1,10 +1,8 @@
-package com.vzome.desktop.awt;
-
-import java.awt.event.MouseEvent;
+package com.vzome.desktop.controller;
 
 import com.vzome.api.Tool;
 
-public class ToolController extends DefaultGraphicsController
+public class ToolController extends DefaultController
 {
 	private Tool tool;
 	private boolean selectOutputs;
@@ -125,27 +123,5 @@ public class ToolController extends DefaultGraphicsController
 		default:
 			super .setModelProperty( name, value );
 		}
-	}
-
-	@Override
-	public boolean[] enableContextualCommands( String[] menu, MouseEvent e )
-	{
-		boolean[] result = new boolean[ menu .length ];
-		for (int i = 0; i < menu.length; i++) {
-			switch ( menu[ i ] ) {
-
-			case "selectInputs":
-				result[ i ] = ! this .tool .isDeleteInputs();
-				break;
-
-			case "selectOutputs":
-				result[ i ] = ! this .justSelect;
-				break;
-
-			default:
-				result[ i ] = true;
-			}
-		}
-		return result;
 	}
 }

--- a/desktop/src/main/java/com/vzome/desktop/controller/ToolsController.java
+++ b/desktop/src/main/java/com/vzome/desktop/controller/ToolsController.java
@@ -1,5 +1,5 @@
 
-package com.vzome.desktop.awt;
+package com.vzome.desktop.controller;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -7,7 +7,6 @@ import java.beans.PropertyChangeListener;
 import com.vzome.api.Tool;
 import com.vzome.core.editor.ToolsModel;
 import com.vzome.desktop.api.Controller;
-import com.vzome.desktop.controller.DefaultController;
 
 public class ToolsController extends DefaultController implements PropertyChangeListener
 {

--- a/online/public/App.css
+++ b/online/public/App.css
@@ -21,3 +21,35 @@ body {
 .FileInput {
   display: none;
 }
+
+img {
+  display: block;
+}
+
+.placeholder {
+  border: 3px solid lightgray;
+  color: gray;
+}
+
+.editor-main {
+  display: grid;
+  grid-template-columns: 80% 20%;
+}
+
+.editor-drawer {
+  display: grid;
+  grid-template-rows: min-content 1fr;
+}
+
+@media ( orientation: portrait ) {
+
+  .editor-main {
+    display: grid;
+    grid-template-rows: 100%;
+    grid-template-columns: 100%;
+  }
+
+  .editor-drawer {
+    display: none;
+  }
+}

--- a/online/src/app/classic/classic.jsx
+++ b/online/src/app/classic/classic.jsx
@@ -1,34 +1,47 @@
 
 import React from 'react';
-import Grid from '@material-ui/core/Grid'
-import Button from '@material-ui/core/Button';
 
 import { DesignViewer } from '../../ui/viewer/index.jsx'
+import { subcontroller } from '../../ui/viewer/store.js';
+import { ToolBar, ToolFactoryBar } from './components/toolbars.jsx';
 import { useNewDesign } from './controller-hooks.js';
 import { OrbitPanel } from './orbit-panel.jsx';
 
 export const ClassicEditor = () =>
 {
   useNewDesign();
+  const symmController = subcontroller( 'strutBuilder', 'symmetry' );
   // const makeHyperdo = useControllerAction( '', 'Polytope4d' );
 
-  const rightColumns = 2;
-  const canvasColumns = 12 - rightColumns;
-
   return (
-    <div style={{ flex: '1', height: '100%' }}>
-      <Grid id='editor-main' container spacing={0} style={{ height: '100%' }}>        
-        <Grid id='editor-canvas' item xs={canvasColumns}>
-          <DesignViewer config={ { useSpinner: true } } />
-        </Grid>
-        <Grid id='editor-drawer' item xs={rightColumns} style={{ position: 'relative' }}>
-          <div id="camera-control" style={{ minHeight: '280px' }}></div>
-          <OrbitPanel symmController='strutBuilder/symmetry' orbitSet='buildOrbits' />
-          {/* <Button variant="contained" color="primary" >
-            Hyperdo
-          </Button> */}
-        </Grid>
-      </Grid>
-    </div>
+    // <div id='classic' style={{ display: 'grid', gridTemplateRows: 'min-content 1fr' }}>
+    //   <div id='menu-bar' class='placeholder' style={{ minHeight: '25px' }}>Menus</div>
+      <div id='editor-main' class='editor-main' style={{ backgroundColor: 'whitesmoke' }}>        
+
+        <div id='editor-canvas' style={{ display: 'grid', gridTemplateRows: 'min-content min-content min-content 1fr' }}>
+          <div id='article-and-status' style={{ display: 'grid', gridTemplateColumns: 'min-content 1fr' }}>
+            <div id='model-article' class='placeholder' style={{ minWidth: '250px' }} >Model | Capture | Article</div>
+            <div id='stats-bar' class='placeholder' style={{ minHeight: '30px' }} >Status</div>
+          </div>
+          <ToolFactoryBar controller={symmController} />
+          <ToolBar symmetryController={symmController} toolsController={subcontroller( 'strutBuilder', 'tools' )} />
+          <div id='canvas-and-bookmarks' style={{ display: 'grid', gridTemplateColumns: 'min-content 1fr' }}>
+            <div id='bookmark-bar' class='placeholder' style={{ minWidth: '40px' }}>Bmks</div>
+            <DesignViewer config={ { useSpinner: true } } />
+          </div>
+        </div>
+
+        <div id='editor-drawer' class='editor-drawer'>
+          <div id="camera-control" class='placeholder' style={{ minHeight: '250px' }}>Camera controls</div>
+          <div id="build-parts-measure" style={{ height: '100%' }}>
+            <div id="build" style={{ display: 'grid', gridTemplateRows: '1fr min-content', height: '100%' }}>
+              <OrbitPanel symmController={symmController} orbitSet='buildOrbits' style={{ height: '100%' }} />
+              <div id='length' class='placeholder' style={{ minHeight: '250px' }}>Length</div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    // </div>
   )
 }

--- a/online/src/app/classic/components/toolbars.jsx
+++ b/online/src/app/classic/components/toolbars.jsx
@@ -1,0 +1,86 @@
+
+import React from 'react';
+import { IconButton } from '@material-ui/core';
+
+import { useControllerProperty, useControllerAction } from '../controller-hooks.js';
+
+const ToolbarSpacer = () => ( <div style={{ minWidth: '10px' }}></div> )
+
+const ToolFactoryButton = ( { factoryName } ) =>
+(
+  <button aria-label={factoryName} style={{ padding: '0px', borderWidth: '2px', borderColor: 'darkgray' }}>
+    <img key={factoryName} src={`./icons/tools/newTool/${factoryName}.png`}/>
+  </button>
+)
+
+export const ToolFactoryBar = ( { controller }) =>
+{
+  const symmFactoryNames = useControllerProperty( controller, 'symmetryToolFactories', 'symmetryToolFactories', true );
+  const transFactoryNames = useControllerProperty( controller, 'transformToolFactories', 'transformToolFactories', true );
+  const mapFactoryNames = useControllerProperty( controller, 'linearMapToolFactories', 'linearMapToolFactories', true );
+
+  return (
+    <div id='factory-bar' style={{ display: 'flex' }}>
+      { symmFactoryNames && symmFactoryNames.map && symmFactoryNames.map( factoryName =>
+        <ToolFactoryButton factoryName={factoryName}/>
+      ) }
+      <ToolbarSpacer/>
+      { transFactoryNames && transFactoryNames.map && transFactoryNames.map( factoryName =>
+        <ToolFactoryButton factoryName={factoryName}/>
+      ) }
+      <ToolbarSpacer/>
+      { mapFactoryNames && mapFactoryNames.map && mapFactoryNames.map( factoryName =>
+        <ToolFactoryButton factoryName={factoryName}/>
+      ) }
+    </div>
+  )
+}
+
+const CommandButton = ( { cmdName } ) =>
+{
+  return (
+    <button aria-label={cmdName} style={{ padding: '0px', borderWidth: '2px', borderColor: 'darkgray' }}>
+      <img key={cmdName} src={`./icons/tools/small/${cmdName}.png`}/>
+    </button>
+  )
+}
+
+const ToolButton = ( { controller } ) =>
+{
+  const kind = useControllerProperty( controller, 'kind', 'kind', false );
+  const label = useControllerProperty( controller, 'label', 'label', false );
+  return (
+    <button aria-label={label} style={{ padding: '0px', borderWidth: '2px', borderColor: 'darkgray' }}>
+      <img key={label} src={`./icons/tools/small/${kind}.png`}/>
+    </button>
+  )
+}
+
+export const ToolBar = ( { symmetryController, toolsController }) =>
+{
+  const symmToolNames = useControllerProperty( symmetryController, 'builtInSymmetryTools', 'builtInSymmetryTools', true );
+  const transToolNames = useControllerProperty( symmetryController, 'builtInTransformTools', 'builtInTransformTools', true );
+
+  return (
+    <div id='tools-bar' style={{ display: 'flex' }}>
+      <CommandButton cmdName='Delete'/>
+      <CommandButton cmdName='hideball'/>
+      <CommandButton cmdName='setItemColor'/>
+      <ToolbarSpacer/>
+      <CommandButton cmdName='JoinPoints/CLOSED_LOOP' hoverText='Connect balls in a loop'/>
+      <CommandButton cmdName='JoinPoints/CHAIN_BALLS' hoverText='Connect balls in a chain'/>
+      <CommandButton cmdName='JoinPoints/ALL_TO_LAST' hoverText='Connect all balls to last selected'/>
+      <CommandButton cmdName='JoinPoints/ALL_POSSIBLE' hoverText='Connect balls in all possible ways'/>
+      <CommandButton cmdName='panel' hoverText='Make a panel polygon'/>
+      <CommandButton cmdName='NewCentroid' hoverText='Construct centroid of points'/>
+      <ToolbarSpacer/>
+      { symmToolNames && symmToolNames.map && symmToolNames.map( toolName =>
+        <ToolButton controller={`${toolsController}:${toolName}`}/>
+      ) }
+      <ToolbarSpacer/>
+      { transToolNames && transToolNames.map && transToolNames.map( toolName =>
+        <ToolButton controller={`${toolsController}:${toolName}`}/>
+      ) }
+    </div>
+  )
+}

--- a/online/src/app/classic/controller-hooks.js
+++ b/online/src/app/classic/controller-hooks.js
@@ -1,7 +1,7 @@
 
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { newDesign, doControllerAction, requestControllerProperty } from '../../ui/viewer/store.js';
+import { newDesign, doControllerAction, requestControllerProperty, subcontroller } from '../../ui/viewer/store.js';
 
 export const useNewDesign = () =>
 {
@@ -12,7 +12,7 @@ export const useNewDesign = () =>
 export const useControllerProperty = ( controllerPath, propName, changeName=null, isList=false ) =>
 {
   const report = useDispatch();
-  const fullName = controllerPath + '/' + propName;
+  const fullName = subcontroller( controllerPath, propName );
   const controller = useSelector( state => state.controller );
   const value = useSelector( state => state.controller && state.controller[ fullName ] );
   useEffect( () => {

--- a/online/src/app/classic/orbit-panel.jsx
+++ b/online/src/app/classic/orbit-panel.jsx
@@ -10,6 +10,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 
 import { useControllerProperty, useControllerAction } from './controller-hooks.js';
+import { subcontroller } from '../../ui/viewer/store.js';
 
 export const OrbitDot = ( { controllerPath, orbit, selectedOrbitNames, relativeHeight, isLastSelected } ) =>
 {
@@ -46,7 +47,7 @@ export const OrbitDot = ( { controllerPath, orbit, selectedOrbitNames, relativeH
 export const OrbitPanel = ( { symmController, orbitSet, showLastOrbit=true } ) =>
 {
   const symmetryAction = useControllerAction( symmController );
-  const controllerPath = symmController + '/' + orbitSet;
+  const controllerPath = subcontroller( symmController, orbitSet );
   const orbitSetAction = useControllerAction( controllerPath );
   const orbitNames = useControllerProperty( controllerPath, 'allOrbits', 'orbits', true );
   const selectedOrbitNames = useControllerProperty( controllerPath, 'orbits', 'orbits', true );
@@ -78,7 +79,7 @@ export const OrbitPanel = ( { symmController, orbitSet, showLastOrbit=true } ) =
           />
         </FormGroup>
       </div>
-      <div style={{ position: 'relative' }}>
+      <div style={{ position: 'relative', backgroundColor: 'white' }}>
         <svg viewBox={viewBox} stroke="black" strokeWidth={0.005} >
           <g>
             {/* TODO: reversed triangle per the controller */}

--- a/online/src/ui/viewer/store.js
+++ b/online/src/ui/viewer/store.js
@@ -39,6 +39,8 @@ export const newDesign = () => workerAction( 'NEW_DESIGN_STARTED', { field: 'gol
 export const doControllerAction = ( controllerPath='', action, parameters={} ) => workerAction( 'ACTION_TRIGGERED', { controllerPath, action, parameters } );
 export const requestControllerProperty = ( controllerPath='', propName, changeName, isList ) => workerAction( 'PROPERTY_REQUESTED', { controllerPath, propName, changeName, isList } );
 
+export const subcontroller = ( controllerPath, subName ) => controllerPath + ':' + subName;
+
 const reducer = ( state = initialState, event ) =>
 {
   switch ( event.type ) {
@@ -102,7 +104,7 @@ const reducer = ( state = initialState, event ) =>
 
     case 'CONTROLLER_PROPERTY_CHANGED': {
       const { controllerPath, name, value } = event.payload;
-      return { ...state, controller: { ...state.controller, [ controllerPath + '/' + name ]: value } };
+      return { ...state, controller: { ...state.controller, [ subcontroller( controllerPath, name ) ]: value } };
     }
 
     default:

--- a/online/src/worker/legacy/controllers.js
+++ b/online/src/worker/legacy/controllers.js
@@ -5,13 +5,15 @@ import { RenderHistory } from './interpreter.js';
 
 export const newDesign = async fieldName =>
 {
-  const { orbitSource, batchRender } = documentFactory( fieldName );
+  const { orbitSource, batchRender, toolsModel } = documentFactory( fieldName );
   
   const controller = new com.vzome.desktop.controller.DefaultController();
   const strutBuilder = new com.vzome.desktop.controller.DefaultController();
   controller .addSubController( 'strutBuilder', strutBuilder );
   const symmController = new com.vzome.desktop.controller.SymmetryController( strutBuilder, orbitSource, null );
   strutBuilder .addSubController( 'symmetry', symmController );
+  const toolsController = new com.vzome.desktop.controller.ToolsController( toolsModel );
+  strutBuilder .addSubController( 'tools', toolsController );
 
   const design = { batchRender, firstEdit: null };
   const renderHistory = new RenderHistory( design );

--- a/online/src/worker/legacy/core.js
+++ b/online/src/worker/legacy/core.js
@@ -502,7 +502,7 @@ const makeFloatMatrices = ( matrices ) =>
       RM.renderChange( new RM( null, null ), renderedModel, renderingListener );
     }
 
-    return { interpretEdit, configureAndPerformEdit, field, batchRender, orbitSource };
+    return { interpretEdit, configureAndPerformEdit, field, batchRender, orbitSource, toolsModel };
   }
 
   // TODO: replace the legacyCommandFactory, which was for the old {shown,hidden,selected} model

--- a/online/src/worker/vzome-worker-static.js
+++ b/online/src/worker/vzome-worker-static.js
@@ -85,8 +85,9 @@ const fetchFileText = selected =>
 let designController;
 const propertyChanges = {};
 
-const getNamedController = controllerNames =>
+const getNamedController = controllerPath =>
 {
+  const controllerNames = controllerPath? controllerPath.split( ':' ) : [];
   const getSubController = ( controller, names ) => {
     if ( !names || names.length === 0 || ( names.length === 1 && !names[ 0 ] ) )
       return controller;
@@ -281,8 +282,7 @@ onmessage = ({ data }) =>
     case 'ACTION_TRIGGERED':
     {
       const { controllerPath, action, parameters } = payload;
-      const controllerNames = controllerPath? controllerPath.split( '/' ) : [];
-      const controller = getNamedController( controllerNames );
+      const controller = getNamedController( controllerPath );
       controller .actionPerformed( null, action );
       break;
     }
@@ -290,8 +290,7 @@ onmessage = ({ data }) =>
     case 'PROPERTY_REQUESTED':
     {
       const { controllerPath, propName, changeName, isList } = payload;
-      const controllerNames = controllerPath? controllerPath.split( '/' ) : [];
-      const controller = getNamedController( controllerNames );
+      const controller = getNamedController( controllerPath );
       registerChangeListener( controller, controllerPath, changeName, propName, isList );
       const value = isList? controller .getCommandList( propName ) : controller .getProperty( propName );
       postMessage( { type: 'CONTROLLER_PROPERTY_CHANGED', payload: { controllerPath, name: propName, value } } );


### PR DESCRIPTION
I'm discarding the MUI Grid, since I need full control.  I'm using CSS grid layout,
even though I just use it in one dimension at a time, since the mechanism of
`gridTemplateRows` etc. is clear and simple.

I switched from '/' to ':' for controller path separator, because tool controllers
can have names that include '/'.  I also created the subcontroller() function
in store.js, so there is one place to control this on the client side.

I had to work around a JSweet transpiler defect that manifests in j4ts, for
LinkedHashMap:

   https://github.com/cincheo/jsweet/issues/740

Status: the tool factory bar and tool bar are both rendering well, though the style
is quite dated.  I haven't attempted the build/parts/measure tabs yet, or anything
for the length controls.