### PR TITLE
Fix: Missing rotation tool factory icons

### DIFF
--- a/core/src/main/java/com/vzome/core/kinds/HeptagonFieldApplication.java
+++ b/core/src/main/java/com/vzome/core/kinds/HeptagonFieldApplication.java
@@ -14,6 +14,7 @@ import com.vzome.core.editor.ToolsModel;
 import com.vzome.core.tools.AxialSymmetryToolFactory;
 import com.vzome.core.tools.LinearMapToolFactory;
 import com.vzome.core.tools.MirrorToolFactory;
+import com.vzome.core.tools.RotationToolFactory;
 import com.vzome.core.tools.ScalingToolFactory;
 import com.vzome.core.tools.SymmetryToolFactory;
 import com.vzome.core.tools.TranslationToolFactory;
@@ -71,7 +72,7 @@ public class HeptagonFieldApplication extends DefaultFieldApplication
 
             case TRANSFORM:
                 result .add( new ScalingToolFactory( tools, this .symmetry ) );
-                result .add( new SymmetryToolFactory( tools, this .symmetry ) );
+                result .add( new RotationToolFactory( tools, this .symmetry ) );
                 result .add( new TranslationToolFactory( tools ) );
                 break;
 

--- a/core/src/main/java/com/vzome/core/kinds/IcosahedralSymmetryPerspective.java
+++ b/core/src/main/java/com/vzome/core/kinds/IcosahedralSymmetryPerspective.java
@@ -21,6 +21,7 @@ import com.vzome.core.tools.InversionToolFactory;
 import com.vzome.core.tools.LinearMapToolFactory;
 import com.vzome.core.tools.MirrorToolFactory;
 import com.vzome.core.tools.ProjectionToolFactory;
+import com.vzome.core.tools.RotationToolFactory;
 import com.vzome.core.tools.ScalingToolFactory;
 import com.vzome.core.tools.SymmetryToolFactory;
 import com.vzome.core.tools.TetrahedralToolFactory;
@@ -107,7 +108,7 @@ public class IcosahedralSymmetryPerspective extends AbstractSymmetryPerspective 
             break;
         case TRANSFORM:
             result.add(new ScalingToolFactory(tools, icosaSymm));
-            result.add(new SymmetryToolFactory(tools, icosaSymm));
+            result.add(new RotationToolFactory(tools, icosaSymm));
 //            result.add(new PlaneSelectionTool.Factory(tools));
             result.add(new TranslationToolFactory(tools));
             result.add(new ProjectionToolFactory(tools));

--- a/core/src/main/java/com/vzome/core/kinds/OctahedralSymmetryPerspective.java
+++ b/core/src/main/java/com/vzome/core/kinds/OctahedralSymmetryPerspective.java
@@ -13,6 +13,7 @@ import com.vzome.core.tools.LinearMapToolFactory;
 import com.vzome.core.tools.MirrorToolFactory;
 import com.vzome.core.tools.OctahedralToolFactory;
 import com.vzome.core.tools.ProjectionToolFactory;
+import com.vzome.core.tools.RotationToolFactory;
 import com.vzome.core.tools.ScalingToolFactory;
 import com.vzome.core.tools.SymmetryToolFactory;
 import com.vzome.core.tools.TetrahedralToolFactory;
@@ -47,7 +48,7 @@ public final class OctahedralSymmetryPerspective extends AbstractSymmetryPerspec
 
 		case TRANSFORM:
 			result .add( new ScalingToolFactory( tools, this .symmetry ) );
-			result .add( new SymmetryToolFactory( tools, this .symmetry ) );
+			result .add( new RotationToolFactory( tools, this .symmetry ) );
             result .add( new TranslationToolFactory( tools ) );
             result .add( new ProjectionToolFactory( tools ) );
 			break;

--- a/core/src/main/java/com/vzome/core/kinds/PolygonFieldApplication.java
+++ b/core/src/main/java/com/vzome/core/kinds/PolygonFieldApplication.java
@@ -110,7 +110,7 @@ public class PolygonFieldApplication extends DefaultFieldApplication
 
             case TRANSFORM:
                 result.add(new ScalingToolFactory(tools, this.symmetry));
-                result.add(new SymmetryToolFactory(tools, this.symmetry));
+                result.add(new RotationToolFactory(tools, this.symmetry));
                 result.add(new TranslationToolFactory(tools));
                 if(isTrivial) {
                 	// ProjectionTool should be OK as long as there is no embedding

--- a/core/src/main/java/com/vzome/core/kinds/RootThreeFieldApplication.java
+++ b/core/src/main/java/com/vzome/core/kinds/RootThreeFieldApplication.java
@@ -21,6 +21,7 @@ import com.vzome.core.tools.InversionToolFactory;
 import com.vzome.core.tools.LinearMapToolFactory;
 import com.vzome.core.tools.MirrorToolFactory;
 import com.vzome.core.tools.ProjectionToolFactory;
+import com.vzome.core.tools.RotationToolFactory;
 import com.vzome.core.tools.ScalingToolFactory;
 import com.vzome.core.tools.SymmetryToolFactory;
 import com.vzome.core.tools.TranslationToolFactory;
@@ -113,7 +114,7 @@ public class RootThreeFieldApplication extends DefaultFieldApplication
 
             case TRANSFORM:
                 result .add( new ScalingToolFactory( tools, this .symmetry ) );
-                result .add( new SymmetryToolFactory( tools, this .symmetry ) );
+                result .add( new RotationToolFactory( tools, this .symmetry ) );
                 result .add( new TranslationToolFactory( tools ) );
                 result .add( new ProjectionToolFactory( tools ) );
                 break;

--- a/core/src/main/java/com/vzome/core/kinds/RootTwoFieldApplication.java
+++ b/core/src/main/java/com/vzome/core/kinds/RootTwoFieldApplication.java
@@ -22,6 +22,7 @@ import com.vzome.core.tools.LinearMapToolFactory;
 import com.vzome.core.tools.MirrorToolFactory;
 import com.vzome.core.tools.OctahedralToolFactory;
 import com.vzome.core.tools.ProjectionToolFactory;
+import com.vzome.core.tools.RotationToolFactory;
 import com.vzome.core.tools.ScalingToolFactory;
 import com.vzome.core.tools.SymmetryToolFactory;
 import com.vzome.core.tools.TetrahedralToolFactory;
@@ -148,7 +149,7 @@ public class RootTwoFieldApplication extends DefaultFieldApplication
 
             case TRANSFORM:
                 result .add( new ScalingToolFactory( tools, this .symmetry ) );
-                result .add( new SymmetryToolFactory( tools, this .symmetry ) );
+                result .add( new RotationToolFactory( tools, this .symmetry ) );
                 result .add( new TranslationToolFactory( tools ) );
                 result .add( new ProjectionToolFactory( tools ) );
                 break;

--- a/core/src/main/java/com/vzome/fields/sqrtphi/SqrtPhiFieldApplication.java
+++ b/core/src/main/java/com/vzome/fields/sqrtphi/SqrtPhiFieldApplication.java
@@ -26,6 +26,7 @@ import com.vzome.core.math.symmetry.WythoffConstruction.Listener;
 import com.vzome.core.tools.AxialSymmetryToolFactory;
 import com.vzome.core.tools.LinearMapToolFactory;
 import com.vzome.core.tools.MirrorToolFactory;
+import com.vzome.core.tools.RotationToolFactory;
 import com.vzome.core.tools.ScalingToolFactory;
 import com.vzome.core.tools.SymmetryToolFactory;
 import com.vzome.core.tools.TranslationToolFactory;
@@ -134,7 +135,7 @@ public class SqrtPhiFieldApplication extends DefaultFieldApplication
 
 			case TRANSFORM:
 				result .add( new ScalingToolFactory( tools, pentaSymm ) );
-				result .add( new SymmetryToolFactory( tools, pentaSymm ) );
+				result .add( new RotationToolFactory( tools, pentaSymm ) );
 				result .add( new TranslationToolFactory( tools ) );
 				break;
 


### PR DESCRIPTION
* RotationToolFactory was accidentally replaced with SymmetryToolFactory in createToolFactories() of all FieldApplications at commit 9e09b72b4982117c4fad92df131676e04e3ac70a