### PR TITLE
Fix: Non-maximized window size too big at startup

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
@@ -682,7 +682,6 @@ public class DocumentFrame extends JFrame implements PropertyChangeListener, Con
 	        this.setVisible( true );
 	        // Java 17 seems to successfully set the frame size and extended state only after the frame is visible.
 	        if(bestWidth > 0 && bestHeight > 0) {
-		        this.setExtendedState(NORMAL);
 				int n = 15, d = n + 1; // set NORMAL size to 15/16 of full screen size then maximize it
 				this.setSize(bestWidth * n/d, bestHeight * n/d);
 	        }

--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
@@ -650,11 +650,15 @@ public class DocumentFrame extends JFrame implements PropertyChangeListener, Con
 		// Default to opening the window as maximized on the selected (or default) monitor.
 		GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
 		GraphicsDevice[] gs = ge.getScreenDevices();
+		int bestWidth = 0;
+		int bestHeight = 0;
 		if(gs.length > 0) {
 			int bestIndex = 0;
 			GraphicsDevice bestDevice = gs[bestIndex];
 			DisplayMode bestMode = bestDevice.getDisplayMode();
-			int bestArea = bestMode.getHeight() * bestMode.getWidth();
+			bestWidth = bestMode.getWidth();
+			bestHeight = bestMode.getHeight();
+			int bestArea = bestWidth * bestHeight;
 			for (int i = bestIndex+1; i < gs.length; i++) {
 				GraphicsDevice testDevice = gs[i];
 				DisplayMode testMode = testDevice.getDisplayMode();
@@ -663,12 +667,12 @@ public class DocumentFrame extends JFrame implements PropertyChangeListener, Con
 					bestArea = testArea;					
 					bestMode = testMode;					
 					bestDevice = testDevice;
+					bestWidth = bestMode.getWidth();
+					bestHeight = bestMode.getHeight();
 				}
 			}
 			Rectangle bounds = bestDevice.getDefaultConfiguration().getBounds();
 			this.setLocation(bounds.x, bounds.y);
-			int n = 15, d = n + 1; // set size to 15/16 of full screen size then maximize it
-			this.setSize(bestMode.getWidth() * n/d, bestMode.getHeight() * n/d);
 		}
 
 		try {
@@ -676,7 +680,12 @@ public class DocumentFrame extends JFrame implements PropertyChangeListener, Con
 			// before including the "--add-exports" JVM args to the build 
 			this.pack();
 	        this.setVisible( true );
-	        // Java 17 seems to successfully set the extended state only after the frame is visible.
+	        // Java 17 seems to successfully set the frame size and extended state only after the frame is visible.
+	        if(bestWidth > 0 && bestHeight > 0) {
+		        this.setExtendedState(NORMAL);
+				int n = 15, d = n + 1; // set NORMAL size to 15/16 of full screen size then maximize it
+				this.setSize(bestWidth * n/d, bestHeight * n/d);
+	        }
 	        this.setExtendedState(MAXIMIZED_BOTH);
 	        this.setFocusable( true );
 		} catch (Exception ex) {


### PR DESCRIPTION
This fixes an issue that initially showed up when we switched desktop to Java 17. The main window is correctly maximized at startup, but when it's later switched to normal size (not maximized or minimized) then it was much bigger than the actual screen, at least on Windows 10. I'm not sure about the MAC. The solution is to set the "normal" size after the frame is made visible in the same way as commit 0ff6a4f41ac0d655c203930b5b0a9ba04d215267 did for the maximized window state.