### PR TITLE
Fix missing DeselectAll after failure of any edit with orderSelection =  true

### DIFF
--- a/core/src/main/java/com/vzome/core/editor/DocumentModel.java
+++ b/core/src/main/java/com/vzome/core/editor/DocumentModel.java
@@ -403,6 +403,7 @@ public class DocumentModel implements Snapshot .Recorder, Context
         return out .toString();
     }
 
+    @Override
     public boolean doEdit( String action, Map<String,Object> props )
     {
         if ( this .editorModel .mSelection .isEmpty() && action .equals( "hideball" ) ) {

--- a/core/src/main/java/com/vzome/core/editor/SelectionImpl.java
+++ b/core/src/main/java/com/vzome/core/editor/SelectionImpl.java
@@ -31,6 +31,7 @@ public class SelectionImpl implements Selection
     
     private static final Logger logger = Logger .getLogger( "com.vzome.core.editor.selection" );
 
+    @Override
     public void copy( List<Manifestation> target )
     {
         target .addAll( mManifestations );
@@ -47,6 +48,7 @@ public class SelectionImpl implements Selection
     }
     
     
+    @Override
     public boolean manifestationSelected( Manifestation m )
     {
         return mManifestations .contains( m );
@@ -63,6 +65,7 @@ public class SelectionImpl implements Selection
         return mManifestations .iterator();
     }
     
+    @Override
     public void select( Manifestation m )
     {
         if ( mManifestations .contains( m ) )  // TO DO how does this happen?
@@ -75,6 +78,7 @@ public class SelectionImpl implements Selection
         }
     }
     
+    @Override
     public void unselect( Manifestation m )
     {
         if ( mManifestations .remove( m ) )
@@ -87,6 +91,7 @@ public class SelectionImpl implements Selection
         }
     }
     
+    @Override
     public void selectWithGrouping( Manifestation m )
     {
         if ( mManifestations .contains( m ) )
@@ -104,6 +109,7 @@ public class SelectionImpl implements Selection
         mSelectedGroup = group;
     }
     
+    @Override
     public void unselectWithGrouping( Manifestation m )
     {
         if ( mManifestations .contains( m ) ) {
@@ -158,6 +164,7 @@ public class SelectionImpl implements Selection
         }
     }
     
+    @Override
     public Manifestation getSingleSelection( final Class<? extends Manifestation> kind )
     {
         int count = 0;
@@ -174,6 +181,7 @@ public class SelectionImpl implements Selection
             return null;
     }
     
+    @Override
     public boolean isSelectionAGroup()
     {
         return getSelectedGroup( false ) != null;
@@ -201,6 +209,7 @@ public class SelectionImpl implements Selection
         return selectedGroup;
     }
     
+    @Override
     public void gatherGroup()
     {
 //        if ( getSelectedGroup() != null )
@@ -225,6 +234,7 @@ public class SelectionImpl implements Selection
         }
     }
 
+    @Override
     public void scatterGroup()
     {
         Group selectedGroup = getSelectedGroup( true );  // assume there's only one, already tested in isSelectionAGroup()
@@ -239,6 +249,7 @@ public class SelectionImpl implements Selection
         }
     }
 
+    @Override
     public void gatherGroup211()
     {
         if ( mSelectedGroup != null )
@@ -262,6 +273,7 @@ public class SelectionImpl implements Selection
         }
     }
 
+    @Override
     public void scatterGroup211()
     {
         if ( mSelectedGroup == null )
@@ -296,14 +308,41 @@ public class SelectionImpl implements Selection
         }
 	}
 
+    @Override
     public int size()
     {
         return this .mManifestations .size();
     }
 
+	@Override
 	public void clear()
 	{
 		// for ChangeSelection undo when the selection is ordered
-		this .mManifestations .clear();
+		
+		// DJH 10/25/2022
+		// I removed the only call to clear() which was in ChangeSelecion.undo()
+		// but prior to that, I had revised clear() to behave a little better
+		// and at least notify the listeners when the selection is cleared.
+		// I'll leave this new code in place in case we want it some day,
+		// even though it's no longer being called at this time.
+		if(!mManifestations.isEmpty()) {
+			if (logger.isLoggable(Level.FINER)) {
+				logger.finer("clearing selection");
+			}
+			// Removing elements inside a for loop when the collection 
+			// has more than 1 entry will throw a ConcurrentModificationException
+			// To remove elements inside a loop, we could use iterator.remove()
+			// but we still can't call this.unselect(m) since it calls mManifestations.remove()
+			// Instead. we'll make a new temp list with the same contents as mManifestations
+			// and iterate over that list as we remove them from mManifestations
+			Collection<Manifestation> temp = new LinkedHashSet<>(mManifestations);
+			for(Manifestation m : temp) {
+				// This will notify all listeners that we've removed the manifestation 
+				// from the selectionso it will  correctly un-hilight the manifestation.
+				// I expected it to also correct the selection count in the measure tab, 
+				// but that gets handled in the DocumentModel.
+				this.unselect(m);
+			}
+		}
 	}
 }

--- a/core/src/main/java/com/vzome/core/editor/SelectionSummary.java
+++ b/core/src/main/java/com/vzome/core/editor/SelectionSummary.java
@@ -66,6 +66,8 @@ public class SelectionSummary implements ManifestationChanges
 	        // When it does, we get NPEs in MeasureController.selectionChanged()
 	        // and there is no way to resync it without closing the document.
 	        // DJH - For now, I'm just going to log the error and correct the counts until I can find the root cause.
+	    	// DJH - 10/25/2022 I may have found one cause for this misbehavior.
+	    	// See other comments in the same git commit where this comment was added.
 	        if(LOGGER.isLoggable(Level.WARNING)) {
                 LOGGER.warning("Incorrect total for balls, struts and panels: "
                         + balls + " + " + struts + " + " + panels + " != " + selection .size());

--- a/core/src/main/java/com/vzome/core/editor/api/ChangeSelection.java
+++ b/core/src/main/java/com/vzome/core/editor/api/ChangeSelection.java
@@ -51,7 +51,18 @@ public abstract class ChangeSelection extends SideEffects
 			// selectionEffects must be set, so that selection-affecting side effects get pushed
 			super.undo();
 						
-			mSelection .clear();
+			// This is currently the only place that clear() is called.
+			// If undo() is called when a failure occcurs (e.g. invalid inputs) 
+			// on an edit with orderedSelection = true, then 
+			// the clearing of the selection here was not being recorded in the history
+			// and the document change listeners were not notified so,
+			// for example, the parts tab and the measure tab would get out of sync.
+			// The fact that the selection was cleared but not recorded in the history
+			// Obviously makes for some potentially difficult to track bugs when reopening documents.
+			// I don't know if any legacy behaviors will be broken if I remove this line.
+			// The regression tests amd unit tests don't indicate any issue so 
+			// I'll just comment it out for now and leave here it as a reminder.
+			// mSelection .clear();
 			
 			// to let the SideEffects undo correctly, selectionEffects must be cleared
 			this .selectionEffects = null;


### PR DESCRIPTION
An example of a file with the problem that is fixed by this PR can be found at https://gist.githubusercontent.com/david-hall/de899b729b1a4a067146eb6d51998090/raw/8ccd4185244396cf03f2a32ba39ba21130550897/unrecorded-DeselectAll-after-Failure.vZome.

It can't be opened in desktop and it can't be fully executed in the online debugger.

Read the snapshot comment within that file for an explanation of how to reproduce the problem and the solution I have implemented here.

This fix doesn't allow existing files with the problem to be opened, nor does it identify files having the problem, but it does avoid generating such files in the future.