### PR TITLE
Fix: built-in rotation tool invokes wrong ToolFactory

### DIFF
--- a/core/src/main/java/com/vzome/core/kinds/HeptagonFieldApplication.java
+++ b/core/src/main/java/com/vzome/core/kinds/HeptagonFieldApplication.java
@@ -101,7 +101,7 @@ public class HeptagonFieldApplication extends DefaultFieldApplication
             case TRANSFORM:
                 result .add( new ScalingToolFactory( tools, this .symmetry ) .createPredefinedTool( "scale down" ) );
                 result .add( new ScalingToolFactory( tools, this .symmetry ) .createPredefinedTool( "scale up" ) );
-                result .add( new SymmetryToolFactory( tools, this .symmetry ) .createPredefinedTool( "rotate around red through origin" ) );
+                result .add( new RotationToolFactory(tools, this.symmetry, true) .createPredefinedTool( "rotate around red through origin" ) );
                 result .add( new TranslationToolFactory( tools ) .createPredefinedTool( "b1 move along +X" ) );
                 break;
 

--- a/core/src/main/java/com/vzome/core/kinds/IcosahedralSymmetryPerspective.java
+++ b/core/src/main/java/com/vzome/core/kinds/IcosahedralSymmetryPerspective.java
@@ -23,7 +23,6 @@ import com.vzome.core.tools.MirrorToolFactory;
 import com.vzome.core.tools.ProjectionToolFactory;
 import com.vzome.core.tools.RotationToolFactory;
 import com.vzome.core.tools.ScalingToolFactory;
-import com.vzome.core.tools.SymmetryToolFactory;
 import com.vzome.core.tools.TetrahedralToolFactory;
 import com.vzome.core.tools.TranslationToolFactory;
 import com.vzome.core.viewing.AbstractShapes;
@@ -143,7 +142,7 @@ public class IcosahedralSymmetryPerspective extends AbstractSymmetryPerspective 
         case TRANSFORM:
             result.add(new ScalingToolFactory(tools, icosaSymm).createPredefinedTool("scale down"));
             result.add(new ScalingToolFactory(tools, icosaSymm).createPredefinedTool("scale up"));
-            result.add(new SymmetryToolFactory(tools, icosaSymm).createPredefinedTool("rotate around red through origin"));
+            result.add(new RotationToolFactory(tools, icosaSymm, true).createPredefinedTool("rotate around red through origin"));
             result.add(new TranslationToolFactory(tools).createPredefinedTool("b1 move along +X"));
             break;
         default:

--- a/core/src/main/java/com/vzome/core/kinds/OctahedralSymmetryPerspective.java
+++ b/core/src/main/java/com/vzome/core/kinds/OctahedralSymmetryPerspective.java
@@ -15,7 +15,6 @@ import com.vzome.core.tools.OctahedralToolFactory;
 import com.vzome.core.tools.ProjectionToolFactory;
 import com.vzome.core.tools.RotationToolFactory;
 import com.vzome.core.tools.ScalingToolFactory;
-import com.vzome.core.tools.SymmetryToolFactory;
 import com.vzome.core.tools.TetrahedralToolFactory;
 import com.vzome.core.tools.TranslationToolFactory;
 import com.vzome.core.viewing.OctahedralShapes;
@@ -80,7 +79,7 @@ public final class OctahedralSymmetryPerspective extends AbstractSymmetryPerspec
 		case TRANSFORM:
 			result .add( new ScalingToolFactory( tools, this .symmetry ) .createPredefinedTool( "scale down" ) );
 			result .add( new ScalingToolFactory( tools, this .symmetry ) .createPredefinedTool( "scale up" ) );
-			result .add( new SymmetryToolFactory( tools, this .symmetry ) .createPredefinedTool( "rotate around green through origin" ) );
+			result .add( new RotationToolFactory(tools, this.symmetry, true) .createPredefinedTool( "rotate around green through origin" ) );
 			result .add( new TranslationToolFactory( tools ) .createPredefinedTool( "b1 move along +X" ) );
 			break;
 

--- a/core/src/main/java/com/vzome/core/kinds/RootThreeFieldApplication.java
+++ b/core/src/main/java/com/vzome/core/kinds/RootThreeFieldApplication.java
@@ -145,7 +145,7 @@ public class RootThreeFieldApplication extends DefaultFieldApplication
             case TRANSFORM:
                 result .add( new ScalingToolFactory( tools, this .symmetry ) .createPredefinedTool( "scale down" ) );
                 result .add( new ScalingToolFactory( tools, this .symmetry ) .createPredefinedTool( "scale up" ) );
-                result .add( new SymmetryToolFactory( tools, this .symmetry ) .createPredefinedTool( "rotate around red through origin" ) );
+                result .add( new RotationToolFactory(tools, this.symmetry, true) .createPredefinedTool( "rotate around red through origin" ) );
                 result .add( new TranslationToolFactory( tools ) .createPredefinedTool( "b1 move along +X" ) );
                 break;
 

--- a/core/src/main/java/com/vzome/core/kinds/RootTwoFieldApplication.java
+++ b/core/src/main/java/com/vzome/core/kinds/RootTwoFieldApplication.java
@@ -24,7 +24,6 @@ import com.vzome.core.tools.OctahedralToolFactory;
 import com.vzome.core.tools.ProjectionToolFactory;
 import com.vzome.core.tools.RotationToolFactory;
 import com.vzome.core.tools.ScalingToolFactory;
-import com.vzome.core.tools.SymmetryToolFactory;
 import com.vzome.core.tools.TetrahedralToolFactory;
 import com.vzome.core.tools.TranslationToolFactory;
 import com.vzome.core.viewing.AbstractShapes;
@@ -181,7 +180,7 @@ public class RootTwoFieldApplication extends DefaultFieldApplication
             case TRANSFORM:
                 result .add( new ScalingToolFactory( tools, this .symmetry ) .createPredefinedTool( "scale down" ) );
                 result .add( new ScalingToolFactory( tools, this .symmetry ) .createPredefinedTool( "scale up" ) );
-                result .add( new SymmetryToolFactory( tools, this .symmetry ) .createPredefinedTool( "rotate around green through origin" ) );
+                result .add( new RotationToolFactory(tools, this.symmetry, true) .createPredefinedTool( "rotate around green through origin" ) );
                 result .add( new TranslationToolFactory( tools ) .createPredefinedTool( "b1 move along +X" ) );
                 break;
 

--- a/core/src/main/java/com/vzome/fields/sqrtphi/SqrtPhiFieldApplication.java
+++ b/core/src/main/java/com/vzome/fields/sqrtphi/SqrtPhiFieldApplication.java
@@ -169,7 +169,7 @@ public class SqrtPhiFieldApplication extends DefaultFieldApplication
 			case TRANSFORM:
 				result .add( new ScalingToolFactory( tools, pentaSymm ) .createPredefinedTool( "scale down" ) );
 				result .add( new ScalingToolFactory( tools, pentaSymm ) .createPredefinedTool( "scale up" ) );
-				result .add( new SymmetryToolFactory( tools,pentaSymm ) .createPredefinedTool( "fivefold rotation through origin" ) );
+				result .add( new RotationToolFactory(tools, pentaSymm, true) .createPredefinedTool( "fivefold rotation through origin" ) );
 				break;
 
 			default:


### PR DESCRIPTION
All field applications except PolygonField were incorrectly generating a SymmetryTool instead of a RotationTool for the predefined tool labeled "rotate around red (or green) through origin" or "fivefold rotation through origin".
This bug was introduced in version 7.1.5 commit 9e09b72b4982117c4fad92df131676e04e3ac70a