### PR TITLE
Better worker integration for buildplane

### DIFF
--- a/online/public/test/index.html
+++ b/online/public/test/index.html
@@ -83,7 +83,7 @@
         </vzome-viewer>
       </section>
       <section>
-        <vzome-viewer src="https://raw.githubusercontent.com/John-Kostick/vzome-sharing/main/2022/10/02/14-01-44-Stella-62/Stella-62.vZome" show-scenes="true" >
+        <vzome-viewer src="https://gist.githubusercontent.com/ThynStyx/47278c6c6e1a00b154a57a71ca1302d5/raw/c3433e180b86a9f4d1122ff5657199d5ae85f100/Nan-24-cell-F4-auto-2%20petrie%20polygon%20and%20hypercube.vZome" show-scenes="true" >
         </vzome-viewer>
       </section>
     </article>

--- a/online/src/app/buildplane/buildplane.jsx
+++ b/online/src/app/buildplane/buildplane.jsx
@@ -168,9 +168,9 @@ const Hinge = ( { state, buildPlanes, actions } ) =>
   )
 }
 
-export const BuildPlane = ( { buildPlanes, state, actions } ) =>
+export const BuildPlane = ( { state, actions } ) =>
 {
-  const { center, diskZone } = state;
+  const { center, diskZone, buildPlanes } = state;
   const { orbit, orientation } = diskZone;
   const [ planeMaterial, planeMaterialRef ] = useState()
 

--- a/online/src/worker/vzome-worker-static.js
+++ b/online/src/worker/vzome-worker-static.js
@@ -167,7 +167,7 @@ const clientEvents = report =>
 
   const selectionToggled = ( shapeId, id, selected ) => report( { type: 'SELECTION_TOGGLED', payload: { shapeId, id, selected } } );
 
-  const symmetryChanged = details => report( { type: 'WORKING_PLANE_GRID_DEFINED', payload: details } );
+  const symmetryChanged = details => report( { type: 'PLANES_DEFINED', payload: details } );
 
   const xmlParsed = xmlTree => report( { type: 'DESIGN_XML_PARSED', payload: xmlTree } );
 
@@ -183,6 +183,7 @@ const clientEvents = report =>
 
 const createDesign = ( report, fieldName ) =>
 {
+  report( { type: 'FETCH_STARTED', payload: { name: 'untitled.vZome', preview: false } } );
   return import( './legacy/dynamic.js' )
 
     .then( module => {


### PR DESCRIPTION
I have created
a `fallbackStore` notion to allow the buildplane store to react directly
to the worker responses.  This fixes the "red plane => octahedral symm."
bug.  I've also implemented a better plane-center state, based on the
same idea; FETCH_STARTED now always gets emitted, even for a new design.