### PR TITLE
Fixing regression in core tool deserialization

### DIFF
--- a/core/src/main/java/com/vzome/core/editor/AbstractToolFactory.java
+++ b/core/src/main/java/com/vzome/core/editor/AbstractToolFactory.java
@@ -129,15 +129,15 @@ public abstract class AbstractToolFactory implements Factory, SelectionSummary.L
 		} // else
 		   // legacy user tools don't consume NEW_PREFIX id space
 
+        int nextDot = id .indexOf( "." );
+        if ( nextDot > 0 ) {
+            tool .setCategory( id .substring( 0, nextDot ) );
+        } else {
+            tool .setCategory( this .getId() );
+        }
+
 		// Reattach the label and input behaviors, already loaded separately by ToolsModel
 		this .tools .setConfiguration( tool );
-
-		int nextDot = id .indexOf( "." );
-		if ( nextDot > 0 ) {
-			tool .setCategory( id .substring( 0, nextDot ) );
-		} else {
-			tool .setCategory( this .getId() );
-		}
 		return tool;
 	}
 


### PR DESCRIPTION
This defect is really dumb, because the tools model implementation
is really dumb.  We are emitting change events during deserialization
of hidden tools.

Fortunately, it seems to be save to call `setCategory()` before the
`setConfiguration()` call, which unfortunately has side-effects.