### PR TITLE
WIP Enabling more menu commands in classic

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentMenuBar.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentMenuBar.java
@@ -604,7 +604,7 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
         menu .add( createMenuItem( "vZome Tips on YouTube...", "browse-https://www.youtube.com/c/Vzome" ) );
         {
             JMenu submenu3d = new JMenu( "Social Media" );
-            submenu3d .add( createMenuItem( "Blog...", "browse-https://vzome.com/blog" ) );
+            submenu3d .add( createMenuItem( "Geometry Blog...", "browse-https://vorth.github.io/vzome-sharing/" ) );
             submenu3d .add( createMenuItem( "Facebook Page...", "browse-https://www.facebook.com/vZome" ) );
             submenu3d .add( createMenuItem( "Twitter Page...", "browse-https://twitter.com/vZome" ) );
             submenu3d .add( createMenuItem( "Discord Server...", "browse-https://discord.com/invite/vhyFsNAFPS" ) );
@@ -612,10 +612,10 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
         }
         {
             JMenu submenu3d = new JMenu( "Misc. Online Documentation" );
-            submenu3d .add( createMenuItem( "The Direction (Orbit) Triangle...", "browse-https://vzome.com/blog/2019/07/vzome-icosahedral-orbits/" ) );
-            submenu3d .add( createMenuItem( "Capturing Vector Graphics...", "browse-https://vzome.com/blog/2018/12/capturing-vector-graphics/" ) );
-            submenu3d .add( createMenuItem( "Toolbars for Diehards...", "browse-https://vzome.com/blog/2018/12/toolbars-for-diehards/" ) );
-            submenu3d .add( createMenuItem( "Content Workflows...", "browse-https://vzome.com/blog/2018/02/vzome-content-workflows/" ) );
+            submenu3d .add( createMenuItem( "The Direction (Orbit) Triangle...", "browse-https://vorth.github.io/vzome-sharing/2019/07/19/vzome-icosahedral-orbits.html" ) );
+            submenu3d .add( createMenuItem( "Capturing Vector Graphics...", "browse-https://vzome.github.io/vzome//capture-vector-graphics.html" ) );
+            submenu3d .add( createMenuItem( "Toolbars for Diehards...", "browse-https://vzome.github.io/vzome//toolbars-for-diehards.html" ) );
+            submenu3d .add( createMenuItem( "Content Workflows...", "browse-https://vzome.github.io/vzome//content-workflows.html" ) );
             menu.add( submenu3d );
         }
         {

--- a/online/build.gradle
+++ b/online/build.gradle
@@ -214,7 +214,6 @@ core.config {
     'com/vzome/core/edits/GhostSymmetry24Cell.java',
     'com/vzome/core/edits/Symmetry4d.java',
     'com/vzome/core/edits/Run*Script.java',
-    'com/vzome/core/edits/Validate2Manifold.java',
     'com/vzome/core/edits/RealizeMetaParts.java',
     'com/vzome/core/edits/ReplaceWithShape.java',
 

--- a/online/src/app/classic/appbar.jsx
+++ b/online/src/app/classic/appbar.jsx
@@ -5,6 +5,7 @@ import Link from '@material-ui/core/Link'
 
 import { VZomeAppBar } from '../components/appbar.jsx';
 import { WorkerContext } from '../../ui/viewer/index.jsx';
+import { ErrorAlert } from '../../ui/viewer/alert.jsx';
 
 export const ClassicAppBar = ( { worker } ) => (
   <WorkerContext worker={worker} >
@@ -21,5 +22,6 @@ export const ClassicAppBar = ( { worker } ) => (
           join the <Link target="_blank" rel="noopener" href="https://discord.gg/vhyFsNAFPS">Discord server</Link>.
         </Typography>
       </> } />
+    <ErrorAlert/>
   </WorkerContext>
 )

--- a/online/src/app/classic/classic.jsx
+++ b/online/src/app/classic/classic.jsx
@@ -16,8 +16,7 @@ export const ClassicEditor = ( { worker } ) =>
   const bkgdColor = () => getScene() ?.lighting .backgroundColor;
 
   const bookmarkController = () => subController( rootController(), 'bookmark' );
-  const editorController   = () => subController( rootController(), 'editor' );
-  const pickingController  = () => subController( editorController(), 'picking' );
+  const pickingController  = () => subController( rootController(), 'picking' );
   const strutBuilder       = () => subController( rootController(), 'strutBuilder' );
   const symmController     = () => subController( strutBuilder(), 'symmetry' );
   const toolsController    = () => subController( strutBuilder(), 'tools' );
@@ -27,7 +26,7 @@ export const ClassicEditor = ( { worker } ) =>
       onClick: ( id, position, type, selected ) =>
         controllerAction( pickingController(), 'SelectManifestation', { id } ),
       bkgdClick: () =>
-        controllerAction( editorController(), 'DeselectAll' ),
+        controllerAction( rootController(), 'DeselectAll' ),
     }
   };
 
@@ -42,7 +41,7 @@ export const ClassicEditor = ( { worker } ) =>
             <div id='stats-bar' class='placeholder' style={{ 'min-height': '30px' }} >Status</div>
           </div>
           <ToolFactoryBar controller={symmController()} />
-          <ToolBar symmetryController={symmController()} toolsController={toolsController()} editorController={editorController()} />
+          <ToolBar symmetryController={symmController()} toolsController={toolsController()} editorController={rootController()} />
           <div id='canvas-and-bookmarks' style={{ display: 'grid', 'grid-template-columns': 'min-content 1fr' }}>
             <BookmarkBar bookmarkController={bookmarkController()} toolsController={toolsController()} symmetryController={symmController()} />
             <SolidSceneCanvas scene={getScene()} toolRef={toolRef} syncCamera={ ()=>{} } style={{ position: 'relative', height: '100%' }} />

--- a/online/src/app/classic/components/menuaction.jsx
+++ b/online/src/app/classic/components/menuaction.jsx
@@ -2,17 +2,16 @@
 import MenuItem from "@suid/material/MenuItem"
 import Typography from "@suid/material/Typography";
 import ListItemText from "@suid/material/ListItemText";
-import { controllerAction, subController } from "../controllers-solid";
+import { controllerAction } from "../controllers-solid";
 
 const isMac = navigator.userAgentData?.platform === 'macOS';
 
-export const createActionItem = ( controller, fallback, doClose ) => ( props ) =>
+export const createMenuAction = ( controller, doClose ) => ( props ) =>
 {
-  const sub = subController( controller, props.controller || fallback );
   const doAction = () => 
   {
     doClose();
-    controllerAction( sub, props.action );
+    controllerAction( controller, props.action );
   }
 
   let modifiers = props.mods;
@@ -21,7 +20,6 @@ export const createActionItem = ( controller, fallback, doClose ) => ( props ) =
   if ( !props.disabled ) {
     const targetCodes = props.code?.split( '|' ) || ( props.key && [ "Key" + props.key.toUpperCase() ] );
     if ( targetCodes ) {
-      console.log( targetCodes );
       const hasMeta = !! modifiers ?.includes( '⌘' );
       const hasControl = !! modifiers ?.includes( '⌃' );
       const hasShift = !! modifiers ?.includes( '⇧' );

--- a/online/src/app/classic/components/menubar.jsx
+++ b/online/src/app/classic/components/menubar.jsx
@@ -5,6 +5,8 @@ import { FileMenu } from '../menus/filemenu.jsx';
 import { EditMenu } from '../menus/editmenu.jsx';
 import { ConstructMenu } from '../menus/constructmenu.jsx';
 import { ToolsMenu } from '../menus/toolsmenu.jsx';
+import { SystemMenu } from '../menus/systemmenu.jsx';
+import { HelpMenu } from '../menus/help.jsx';
 
 export const MenuBar = ( props ) =>
 {
@@ -14,6 +16,8 @@ export const MenuBar = ( props ) =>
       <EditMenu      controller={props.controller} />
       <ConstructMenu controller={props.controller} />
       <ToolsMenu     controller={props.controller} />
+      <SystemMenu    controller={props.controller} />
+      <HelpMenu      controller={props.controller} />
     </Toolbar>
   )
 }

--- a/online/src/app/classic/menus/constructmenu.jsx
+++ b/online/src/app/classic/menus/constructmenu.jsx
@@ -4,7 +4,8 @@ import Menu from "@suid/material/Menu"
 import Divider from "@suid/material/Divider";
 import { createSignal } from "solid-js";
 
-import { createActionItem } from "../components/actionitem.jsx";
+import { createMenuAction } from "../components/menuaction.jsx";
+import { subController } from "../controllers-solid.js";
 
 export const ConstructMenu = ( props ) =>
 {
@@ -12,7 +13,7 @@ export const ConstructMenu = ( props ) =>
   const open = () => Boolean( anchorEl() );
   const doClose = () => setAnchorEl( null );
 
-  const ActionItem = createActionItem( props.controller, 'editor', doClose );
+  const EditAction = createMenuAction( props.controller, doClose );
 
   return (
     <div>
@@ -25,39 +26,39 @@ export const ConstructMenu = ( props ) =>
       <Menu id="construct-menu-menu" MenuListProps={{ "aria-labelledby": "construct-menu-button" }}
         anchorEl={anchorEl()} open={open()} onClose={doClose}
       >
-        <ActionItem label="Loop Balls"         action="JoinPoints/CLOSED_LOOP" mods="⌘" key="J" />
-        <ActionItem label="Chain Balls"        action="JoinPoints/CHAIN_BALLS" mods="⌥⌘" key="J" />
-        <ActionItem label="Join Balls to Last" action="JoinPoints/ALL_TO_LAST" />
-        <ActionItem label="Make All Possible Struts" action="JoinPoints/ALL_POSSIBLE" />
+        <EditAction label="Loop Balls"         action="JoinPoints/CLOSED_LOOP" mods="⌘" key="J" />
+        <EditAction label="Chain Balls"        action="JoinPoints/CHAIN_BALLS" mods="⌥⌘" key="J" />
+        <EditAction label="Join Balls to Last" action="JoinPoints/ALL_TO_LAST" />
+        <EditAction label="Make All Possible Struts" action="JoinPoints/ALL_POSSIBLE" />
 
         <Divider />
 
-        <ActionItem label="Panel" action="panel" mods="⌘" key="P" />
-        <ActionItem label="Panel/Strut Vertices" action="ShowVertices" />
-        <ActionItem label="Panel Normals" action="ShowNormals" />
-
-        <Divider />
-        
-        <ActionItem label="Centroid" action="NewCentroid" />
-        <ActionItem label="Strut Midpoint" action="midpoint" />
-        <ActionItem label="Line-Line Intersection"  action="StrutIntersection" />
-        <ActionItem label="Line-Plane Intersection" action="LinePlaneIntersect" />
-        <ActionItem label="Panel-Panel Projection"  action="PanelPanelIntersection" />
-        <ActionItem label="Cross Product" action="CrossProduct" />
-        <ActionItem label="Normal to Skew Lines" action="JoinSkewLines" />
+        <EditAction label="Panel" action="panel" mods="⌘" key="P" />
+        <EditAction label="Panel/Strut Vertices" action="ShowVertices" />
+        <EditAction label="Panel Normals" action="ShowNormals" />
 
         <Divider />
         
-        <ActionItem label="Ball At Origin" action="ShowPoint/origin" />
+        <EditAction label="Centroid" action="NewCentroid" />
+        <EditAction label="Strut Midpoint" action="midpoint" />
+        <EditAction label="Line-Line Intersection"  action="StrutIntersection" />
+        <EditAction label="Line-Plane Intersection" action="LinePlaneIntersect" />
+        <EditAction label="Panel-Panel Projection"  action="PanelPanelIntersection" />
+        <EditAction label="Cross Product" action="CrossProduct" />
+        <EditAction label="Normal to Skew Lines" action="JoinSkewLines" />
 
         <Divider />
         
-        <ActionItem label="2D Convex Hull" action="ConvexHull2d" />
-        <ActionItem label="3D Convex Hull" action="ConvexHull3d" />
+        <EditAction label="Ball At Origin" action="ShowPoint/origin" />
 
         <Divider />
         
-        <ActionItem label="Parallelepiped" action="Parallelepiped" mods="⇧⌘" key="P" disabled={true} />
+        <EditAction label="2D Convex Hull" action="ConvexHull2d" />
+        <EditAction label="3D Convex Hull" action="ConvexHull3d" />
+
+        <Divider />
+        
+        <EditAction label="Parallelepiped" action="Parallelepiped" mods="⇧⌘" key="P" />
       </Menu>
     </div>
   );

--- a/online/src/app/classic/menus/editmenu.jsx
+++ b/online/src/app/classic/menus/editmenu.jsx
@@ -4,7 +4,8 @@ import Menu from "@suid/material/Menu"
 import Divider from "@suid/material/Divider";
 import { createSignal } from "solid-js";
 
-import { createActionItem } from "../components/actionitem.jsx";
+import { createMenuAction } from "../components/menuaction.jsx";
+import { subController } from "../controllers-solid.js";
 
 export const EditMenu = ( props ) =>
 {
@@ -12,7 +13,9 @@ export const EditMenu = ( props ) =>
   const open = () => Boolean( anchorEl() );
   const doClose = () => setAnchorEl( null );
 
-  const ActionItem = createActionItem( props.controller, 'editor', doClose );
+  const EditAction = createMenuAction( props.controller, doClose );
+  const undoRedoController = () => subController( props.controller, 'undoRedo' );
+  const UndoRedoAction = createMenuAction( undoRedoController(), doClose );
 
   return (
     <div>
@@ -25,33 +28,33 @@ export const EditMenu = ( props ) =>
       <Menu id="edit-menu-menu" MenuListProps={{ "aria-labelledby": "edit-menu-button" }}
         anchorEl={anchorEl()} open={open()} onClose={doClose}
       >
-        <ActionItem label="Undo"     action="undo"    mods="⌘" key="Z" controller="undoRedo" />
-        <ActionItem label="Redo"     action="redo"    mods="⌘" key="Y" controller="undoRedo" />
-        <ActionItem label="Undo All" action="undoAll" mods="⌥⌘" key="Z" controller="undoRedo" />
-        <ActionItem label="Redo All" action="redoAll" mods="⌥⌘" key="Y" controller="undoRedo" />
+        <UndoRedoAction label="Undo"     action="undo"    mods="⌘" key="Z" />
+        <UndoRedoAction label="Redo"     action="redo"    mods="⌘" key="Y" />
+        <UndoRedoAction label="Undo All" action="undoAll" mods="⌥⌘" key="Z" />
+        <UndoRedoAction label="Redo All" action="redoAll" mods="⌥⌘" key="Y" />
 
         <Divider />
 
-        <ActionItem label="Cut"    action="cut"    mods="⌘" key="X" disabled={true} />
-        <ActionItem label="Copy"   action="copy"   mods="⌘" key="C" disabled={true} />
-        <ActionItem label="Paste"  action="paste"  mods="⌘" key="V" disabled={true} />
-        <ActionItem label="Delete" action="Delete" code="Delete|Backspace" />
+        <EditAction label="Cut"    action="cut"    mods="⌘" key="X" disabled={true} />
+        <EditAction label="Copy"   action="copy"   mods="⌘" key="C" disabled={true} />
+        <EditAction label="Paste"  action="paste"  mods="⌘" key="V" disabled={true} />
+        <EditAction label="Delete" action="Delete" code="Delete|Backspace" />
 
         <Divider />
 
-        <ActionItem label="Select All"       action="SelectAll"       mods="⌘" key="A" />
-        <ActionItem label="Select Neighbors" action="SelectNeighbors" mods="⌥⌘" key="A" />
-        <ActionItem label="Invert Selection" action="InvertSelection" />
+        <EditAction label="Select All"       action="SelectAll"       mods="⌘" key="A" />
+        <EditAction label="Select Neighbors" action="SelectNeighbors" mods="⌥⌘" key="A" />
+        <EditAction label="Invert Selection" action="InvertSelection" />
 
         <Divider />
 
-        <ActionItem label="Group"   action="GroupSelection/group" mods="⌘" key="G" />
-        <ActionItem label="Ungroup" action="GroupSelection/ungroup" mods="⌥⌘" key="G" />
+        <EditAction label="Group"   action="GroupSelection/group" mods="⌘" key="G" />
+        <EditAction label="Ungroup" action="GroupSelection/ungroup" mods="⌥⌘" key="G" />
 
         <Divider />
 
-        <ActionItem label="Hide"            action="hideball"   mods="⌃" key="H" />
-        <ActionItem label="Show All Hidden" action="ShowHidden" mods="⌥⌃" key="H" />
+        <EditAction label="Hide"            action="hideball"   mods="⌃" key="H" />
+        <EditAction label="Show All Hidden" action="ShowHidden" mods="⌥⌃" key="H" />
 
       </Menu>
     </div>

--- a/online/src/app/classic/menus/filemenu.jsx
+++ b/online/src/app/classic/menus/filemenu.jsx
@@ -2,15 +2,13 @@
 import Button from "@suid/material/Button"
 import Menu from "@suid/material/Menu"
 import MenuItem from "@suid/material/MenuItem"
-import Divider from "@suid/material/Divider";
 import { createSignal } from "solid-js";
-import { controllerAction, subController } from "../controllers-solid";
 
 export const FileMenu = ( props ) =>
 {
   const [ anchorEl, setAnchorEl ] = createSignal( null );
   const open = () => Boolean( anchorEl() );
-  const handleClose = () => setAnchorEl( null ); 
+  const doClose = () => setAnchorEl( null );
 
   return (
     <div>
@@ -27,12 +25,12 @@ export const FileMenu = ( props ) =>
         id="file-menu-menu"
         anchorEl={anchorEl()}
         open={open()}
-        onClose={handleClose}
+        onClose={doClose}
         MenuListProps={{ "aria-labelledby": "file-menu-button" }}
       >
-        <MenuItem disabled={true} onClick={handleClose}>New Design</MenuItem>
-        <MenuItem disabled={true} onClick={handleClose}>Open</MenuItem>
-        <MenuItem disabled={true} onClick={handleClose}>Save</MenuItem>
+        <MenuItem disabled={true} onClick={doClose}>New Design</MenuItem>
+        <MenuItem disabled={true} onClick={doClose}>Open</MenuItem>
+        <MenuItem disabled={true} onClick={doClose}>Save</MenuItem>
       </Menu>
     </div>
   );

--- a/online/src/app/classic/menus/help.jsx
+++ b/online/src/app/classic/menus/help.jsx
@@ -1,0 +1,64 @@
+
+import Button from "@suid/material/Button"
+import Menu from "@suid/material/Menu"
+import MenuItem from "@suid/material/MenuItem"
+import Divider from "@suid/material/Divider";
+import Link from '@suid/material/Link';
+import { createSignal } from "solid-js";
+
+const createLinkItem = doClose => ( { href, label } ) => (
+  <MenuItem component={Link} href={href} target="_blank" rel="noopener" onClick={doClose}>{label}</MenuItem>
+);
+
+export const HelpMenu = ( props ) =>
+{
+  const [ anchorEl, setAnchorEl ] = createSignal( null );
+  const open = () => Boolean( anchorEl() );
+  const doClose = () => setAnchorEl( null );
+  const LinkItem = createLinkItem( doClose );
+
+  return (
+    <div>
+      <Button id="help-menu-button"
+        aria-controls={open() ? "help-menu-menu" : undefined} aria-haspopup="true" aria-expanded={open() ? "true" : undefined}
+        onClick={ (event) => setAnchorEl(event.currentTarget) }
+      >
+        Help
+      </Button>
+      <Menu id="help-menu-menu" MenuListProps={{ "aria-labelledby": "help-menu-button" }}
+        anchorEl={anchorEl()} open={open()} onClose={doClose}
+      >
+        <MenuItem disabled={true} onClick={doClose}>Quick Start...</MenuItem>
+        <MenuItem disabled={true} onClick={doClose}>Symmetry Starters...</MenuItem>
+        <MenuItem disabled={true} onClick={doClose}>3D Printing Starters...</MenuItem>
+
+        <Divider/>
+
+        <LinkItem label='vZome Home...'                 href='https://vzome.com' />
+        <LinkItem label='Sharing vZome Files Online...' href='https://vzome.github.io/vzome/sharing.html' />
+        <LinkItem label='vZome Tips on YouTube...'      href='https://www.youtube.com/c/Vzome' />
+
+        <Divider/>
+
+        <LinkItem label='Geometry Blog...'  href='https://vorth.github.io/vzome-sharing/' />
+        <LinkItem label='Facebook Page...'  href='https://www.facebook.com/vZome' />
+        <LinkItem label='Twitter Page...'   href='https://twitter.com/vZome' />
+        <LinkItem label='Discord Server...' href='https://discord.com/invite/vhyFsNAFPS' />
+
+        <Divider/>
+
+        <LinkItem label='The Direction (Orbit) Triangle...' href='https://vorth.github.io/vzome-sharing/2019/07/19/vzome-icosahedral-orbits.html' />
+        <LinkItem label='Capturing Vector Graphics...'      href='https://vzome.github.io/vzome//capture-vector-graphics.html' />
+
+        <Divider/>
+
+        <LinkItem label='GitHub Source...'                 href='https://github.com/vZome/vzome' />
+        <LinkItem label='Logo T-Shirt...'                  href='https://www.neatoshop.com/product/vZome-tetrahedron' />
+        <LinkItem label='3D-Printed Parts at Shapeways...' href='https://www.shapeways.com/shops/vzome' />
+        <LinkItem label='Models on SketchFab...'           href='https://sketchfab.com/scottvorthmann' />
+        <LinkItem label='Observable Notebooks...'          href='https://observablehq.com/collection/@vorth/vzome' />
+
+      </Menu>
+    </div>
+  );
+}

--- a/online/src/app/classic/menus/systemmenu.jsx
+++ b/online/src/app/classic/menus/systemmenu.jsx
@@ -1,0 +1,50 @@
+
+import Button from "@suid/material/Button"
+import Menu from "@suid/material/Menu"
+import Divider from "@suid/material/Divider";
+import { createSignal } from "solid-js";
+
+import { createMenuAction } from "../components/menuaction.jsx";
+import { controllerProperty, subController } from "../controllers-solid.js";
+
+export const SystemMenu = ( props ) =>
+{
+  const [ anchorEl, setAnchorEl ] = createSignal( null );
+  const open = () => Boolean( anchorEl() );
+  const doClose = () => setAnchorEl( null );
+
+  const symmetries = () => controllerProperty( props.controller, 'symmetryPerspectives', 'symmetryPerspectives', true );
+  const hasIcosa = () => symmetries() .includes( 'icosahedral' );
+  const initSystem = () => controllerProperty( props.controller, 'symmetry', 'symmetry', false );
+
+  const EditAction = createMenuAction( props.controller, doClose );
+
+  return (
+    <div>
+      <Button id="system-menu-button"
+        aria-controls={open() ? "system-menu-menu" : undefined} aria-haspopup="true" aria-expanded={open() ? "true" : undefined}
+        onClick={ (event) => setAnchorEl(event.currentTarget) }
+      >
+        System
+      </Button>
+      <Menu id="system-menu-menu" MenuListProps={{ "aria-labelledby": "system-menu-button" }}
+        anchorEl={anchorEl()} open={open()} onClose={doClose}
+      >
+        <Show when={ hasIcosa() }>
+          <EditAction label="Icosahedral System" action="setSymmetry.icosahedral" checked={ initSystem() === 'icosahedral' } disabled="true" />
+        </Show>
+        <EditAction label="Octahedral System" action="setSymmetry.octahedral" checked={ initSystem() === 'octahedral' } disabled="true" />
+
+        <Divider />
+        
+        <EditAction label="Shapes..." action="configureShapes" disabled="true" />
+        <EditAction label="Directions..." action="configureDirections" disabled="true" />
+        <EditAction label="Show Directions Graphically" action="toggleOrbitViews" disabled="true" />
+        <EditAction label="Show Strut Scales" action="toggleStrutScales" disabled="true" />
+        <EditAction label="Show Frame Labels" action="toggleFrameLabels" disabled="true" />
+        <EditAction label="Show Panel Normals" action="toggleNormals" disabled="true" />
+
+      </Menu>
+    </div>
+  );
+}

--- a/online/src/app/classic/menus/toolsmenu.jsx
+++ b/online/src/app/classic/menus/toolsmenu.jsx
@@ -4,7 +4,8 @@ import Menu from "@suid/material/Menu"
 import Divider from "@suid/material/Divider";
 import { createSignal } from "solid-js";
 
-import { createActionItem } from "../components/actionitem.jsx";
+import { createMenuAction } from "../components/menuaction.jsx";
+import { subController } from "../controllers-solid.js";
 
 export const ToolsMenu = ( props ) =>
 {
@@ -12,7 +13,10 @@ export const ToolsMenu = ( props ) =>
   const open = () => Boolean( anchorEl() );
   const doClose = () => setAnchorEl( null );
 
-  const ActionItem = createActionItem( props.controller, 'editor', doClose );
+  const EditAction = createMenuAction( props.controller, doClose );
+  const buildController = () => subController( props.controller, 'strutBuilder' );
+  const symmetryController = () => subController( buildController(), 'symmetry' );
+  const SymmetryAction = createMenuAction( symmetryController(), doClose );
 
   return (
     <div>
@@ -25,22 +29,23 @@ export const ToolsMenu = ( props ) =>
       <Menu id="tools-menu-menu" MenuListProps={{ "aria-labelledby": "tools-menu-button" }}
         anchorEl={anchorEl()} open={open()} onClose={doClose}
       >
-        <ActionItem label="Icosahedral Symmetry"         action="icosasymm" controller="symmetry" mods="⌘" key="I" disabled={true} />
-        <ActionItem label="Cubic / Octahedral Symmetry"  action="octasymm"  controller="symmetry" mods="⌥⌘" key="C" disabled={true} />
-        <ActionItem label="Tetrahedral Symmetry"         action="tetrasymm" controller="symmetry" mods="⌥⌘" key="T" disabled={true} />
-        <ActionItem label="Point Reflection"             action="pointsymm" />
+        <SymmetryAction label="Icosahedral Symmetry"         action="icosasymm" mods="⌘" key="I" />
+        <SymmetryAction label="Cubic / Octahedral Symmetry"  action="octasymm"  mods="⌥⌘" key="C" />
+        <SymmetryAction label="Tetrahedral Symmetry"         action="tetrasymm" mods="⌥⌘" key="T" />
+
+        <EditAction label="Point Reflection" action="pointsymm" />
 
         <Divider />
 
-        <ActionItem label="Replace With Panels" action="ReplaceWithShape" disabled={true} />
-
-        <Divider />
-        
-        <ActionItem label="Generate Polytope..." action="showPolytopesDialog" mods="⌥⌘" key="P" disabled={true} />
+        <SymmetryAction label="Replace With Panels" action="ReplaceWithShape" disabled={true} />
 
         <Divider />
         
-        <ActionItem label="Validate Paneled Surface" action="Validate2Manifold" disabled={true} />
+        <SymmetryAction label="Generate Polytope..." action="showPolytopesDialog" mods="⌥⌘" key="P" disabled={true} />
+
+        <Divider />
+        
+        <EditAction label="Validate Paneled Surface" action="Validate2Manifold" />
 
       </Menu>
     </div>

--- a/online/src/worker/legacy/controllers.js
+++ b/online/src/worker/legacy/controllers.js
@@ -162,19 +162,26 @@ export const newDesign = ( fieldName, clientEvents ) =>
 const createControllers = ( design, renderHistory, clientEvents ) =>
 {
   const { orbitSource, renderedModel, toolsModel, bookmarkFactory, history } = design;
-  const controller = new com.vzome.desktop.controller.DefaultController(); // this is the equivalent of DocumentController
 
-  // This one has no equivalent in Java, though I've considered it.  Too much change.
-  const editorController = new EditorController( design, clientEvents );
-  controller .addSubController( 'editor', editorController );
+  const controller = new EditorController( design, clientEvents ); // this is the equivalent of DocumentController
+  controller .setErrorChannel( {
+    reportError: ( message, args ) => {
+      console.log( 'controller error:', message, args );
+      if ( message === com.vzome.desktop.api.Controller.UNKNOWN_ERROR_CODE ) {
+        const ex = args[ 0 ];
+        clientEvents .errorReported( ex.message );
+      } else
+        clientEvents .errorReported( message )
+    },
+  } );
 
   // This has similar function to the Java equivalent, but a very different mechanism
   const pickingController = new PickingController( renderedModel );
-  editorController .addSubController( 'picking', pickingController );
+  controller .addSubController( 'picking', pickingController );
 
   // This has no desktop equivalent
   const buildPlaneController = new BuildPlaneController( renderedModel, orbitSource );
-  editorController .addSubController( 'buildPlane', buildPlaneController );
+  controller .addSubController( 'buildPlane', buildPlaneController );
 
   const undoRedoController = new com.vzome.desktop.controller.UndoRedoController( history );
   controller .addSubController( 'undoRedo', undoRedoController );

--- a/online/src/worker/legacy/core.js
+++ b/online/src/worker/legacy/core.js
@@ -404,8 +404,11 @@ const makeFloatMatrices = ( matrices ) =>
     realizedModel .show( originBall );
 
     const selection = new vzomePkg.core.editor.SelectionImpl();
-    const editor = new vzomePkg.jsweet.JsEditorModel( realizedModel, selection, fieldApp, orbitSource, symmetrySystems )
-    toolsModel.setEditorModel( editor )
+    const editor = new vzomePkg.jsweet.JsEditorModel( realizedModel, selection, fieldApp, orbitSource, symmetrySystems );
+    for ( const symmetrySystem of Object.values( symmetrySystems ) ) {
+      symmetrySystem .setEditorModel( editor );
+    }
+    toolsModel .setEditorModel( editor )
     history .setListener( { publishChanges: () => {
       editor .notifyListeners();
     } } );

--- a/online/src/worker/vzome-worker-static.js
+++ b/online/src/worker/vzome-worker-static.js
@@ -173,6 +173,8 @@ const clientEvents = report =>
 
   const propertyChanged = ( controllerPath, name, value ) => report( { type: 'CONTROLLER_PROPERTY_CHANGED', payload: { controllerPath, name, value } } );
 
+  const errorReported = message => report( { type: 'ALERT_RAISED', payload: message } );
+
   const scenesDiscovered = s => {
     scenes = s; // TODO fix this horrible hack
     report( { type: 'SCENES_DISCOVERED', payload: s } );
@@ -180,7 +182,8 @@ const clientEvents = report =>
 
   const designSerialized = xml => report( { type: 'DESIGN_XML_SAVED', payload: xml } );
 
-  return { sceneChanged, shapeDefined, instanceAdded, selectionToggled, symmetryChanged, xmlParsed, scenesDiscovered, designSerialized, propertyChanged };
+  return { sceneChanged, shapeDefined, instanceAdded, selectionToggled, symmetryChanged,
+    xmlParsed, scenesDiscovered, designSerialized, propertyChanged, errorReported, };
 }
 
 const createDesign = ( report, fieldName ) =>
@@ -364,7 +367,7 @@ onmessage = ({ data }) =>
     case 'STRUT_CREATION_TRIGGERED':
     case 'JOIN_BALLS_TRIGGERED':
     {
-      const controller = getNamedController( 'editor:buildPlane' );
+      const controller = getNamedController( 'buildPlane' );
       controller .paramActionPerformed( null, type, new JsProperties( payload ) );
 
       // TODO: this is pretty heavy-handed, sending the whole scene after every edit.


### PR DESCRIPTION
I added the missing setEditorModel() calls for symmetrySystems,
and I removed the useless DefaultController, replacing it with the
EditorController.

I've also added proper error reporting, and added the System menu,
though it is all disabled at the moment.  The Help menu is now there, too.

ReplaceWithShape (tools menu) still does not work, so it is disabled.

I've also updated the Help menu links in desktop, to avoid the old blog.