### PR TITLE
Corrections for PWA maskable icons

### DIFF
--- a/online/public/browser/manifest.json
+++ b/online/public/browser/manifest.json
@@ -10,37 +10,44 @@
     {
       "src": "./icons/maskable_icon_x48.png",
       "sizes": "48x48",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "./icons/maskable_icon_x72.png",
       "sizes": "72x72",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "./icons/maskable_icon_x96.png",
       "sizes": "96x96",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "./icons/maskable_icon_x128.png",
       "sizes": "128x128",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "./icons/maskable_icon_x192.png",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "./icons/maskable_icon_x384.png",
       "sizes": "384x384",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "./icons/maskable_icon_x512.png",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ]
 }

--- a/online/public/buildplane/manifest.json
+++ b/online/public/buildplane/manifest.json
@@ -8,39 +8,46 @@
   "theme_color": "#5FAAE5",
   "icons": [
     {
-      "src": "./icons/maskable_icon_x48.png",
+      "src": "./icons/maskable_icon_x48 (1).png",
       "sizes": "48x48",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
-      "src": "./icons/maskable_icon_x72.png",
+      "src": "./icons/maskable_icon_x72 (1).png",
       "sizes": "72x72",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
-      "src": "./icons/maskable_icon_x96.png",
+      "src": "./icons/maskable_icon_x96 (1).png",
       "sizes": "96x96",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
-      "src": "./icons/maskable_icon_x128.png",
+      "src": "./icons/maskable_icon_x128 (1).png",
       "sizes": "128x128",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
-      "src": "./icons/maskable_icon_x192.png",
+      "src": "./icons/maskable_icon_x192 (1).png",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
-      "src": "./icons/maskable_icon_x384.png",
+      "src": "./icons/maskable_icon_x384 (1).png",
       "sizes": "384x384",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
-      "src": "./icons/maskable_icon_x512.png",
+      "src": "./icons/maskable_icon_x512 (1).png",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ]
 }

--- a/online/public/classic/manifest.json
+++ b/online/public/classic/manifest.json
@@ -10,42 +10,50 @@
     {
       "src": "../icons/maskable_icon_x48.png",
       "sizes": "48x48",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "../icons/maskable_icon_x72.png",
       "sizes": "72x72",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "../icons/maskable_icon_x96.png",
       "sizes": "96x96",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "../icons/maskable_icon_x128.png",
       "sizes": "128x128",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "../icons/maskable_icon_x144.png",
       "sizes": "144x144",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "../icons/maskable_icon_x192.png",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "../icons/maskable_icon_x384.png",
       "sizes": "384x384",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "../icons/maskable_icon_x512.png",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ]
 }

--- a/online/public/manifest.json
+++ b/online/public/manifest.json
@@ -10,42 +10,50 @@
     {
       "src": "./icons/maskable_icon_x48.png",
       "sizes": "48x48",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "./icons/maskable_icon_x72.png",
       "sizes": "72x72",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "./icons/maskable_icon_x96.png",
       "sizes": "96x96",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "./icons/maskable_icon_x128.png",
       "sizes": "128x128",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "./icons/maskable_icon_x144.png",
       "sizes": "144x144",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "./icons/maskable_icon_x192.png",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "./icons/maskable_icon_x384.png",
       "sizes": "384x384",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "./icons/maskable_icon_x512.png",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ]
 }


### PR DESCRIPTION
Added the "maskable" purpose everywhere, and corrected the
filenames for the buildplane icons.