### PR TITLE
Add SnubDodecahedronField

### DIFF
--- a/core/src/main/java/com/vzome/core/algebra/AlgebraicFields.java
+++ b/core/src/main/java/com/vzome/core/algebra/AlgebraicFields.java
@@ -100,6 +100,10 @@ public class AlgebraicFields {
             coefficients = SnubDodecField.getFieldCoefficients();
             break;
 
+        case SnubDodecahedronField.FIELD_NAME:
+            coefficients = SnubDodecahedronField.getFieldCoefficients();
+            break;
+
         case SqrtPhiField.FIELD_NAME:
             coefficients = SqrtPhiField.getFieldCoefficients();
             break;

--- a/core/src/main/java/com/vzome/core/algebra/SnubDodecahedronField.java
+++ b/core/src/main/java/com/vzome/core/algebra/SnubDodecahedronField.java
@@ -1,0 +1,138 @@
+package com.vzome.core.algebra;
+
+/**
+ * @author David Hall
+ */
+public class SnubDodecahedronField extends ParameterizedField {
+    // TODO: Change this name to "SnubDodec" for backward compatibility after we merge the two classes
+    public static final String FIELD_NAME = "snubDodecahedron";
+    
+    /**
+     * 
+     * @return the coefficients of this AlgebraicField class. 
+     * This can be used to determine when two fields have compatible coefficients 
+     * without having to generate an instance of the class. 
+     */
+    public static double[] getFieldCoefficients() {
+        double PHI_VALUE = ( 1.0 + Math.sqrt( 5.0 ) ) / 2.0;
+        // specified to more precision than a double can retain so that value is as exact as possible: within one ulp().
+        final double XI_VALUE = 1.71556149969736783d; // root of x^3 -2x -PHI_VALUE 
+        return new double[] { 
+            1.0d, 
+            PHI_VALUE,
+                        XI_VALUE,
+            PHI_VALUE * XI_VALUE,
+                        XI_VALUE * XI_VALUE,
+            PHI_VALUE * XI_VALUE * XI_VALUE
+        };
+    }
+
+    @Override
+    public double[] getCoefficients() {
+        return getFieldCoefficients();
+    }
+    
+    public SnubDodecahedronField( AlgebraicNumberFactory factory ) {
+        super( FIELD_NAME, 6, factory );
+        initialize();
+    }
+
+    @Override
+    protected void initializeCoefficients() {
+        double[] temp = getCoefficients();
+        int i = 0;
+        for(double coefficient : temp) {
+            coefficients[i++] = coefficient;
+        }
+    }
+
+    @Override
+    protected void initializeMultiplicationTensor() {
+    	short[][][] mm = {
+            { // 1
+                {1, 0, 0, 0, 0, 0 },
+                {0, 1, 0, 0, 0, 0 },
+                {0, 0, 0, 0, 0, 1 },
+                {0, 0, 0, 0, 1, 1 },
+                {0, 0, 0, 1, 0, 0 },
+                {0, 0, 1, 1, 0, 0 },
+            },
+            { // phi
+                {0, 1, 0, 0, 0, 0 },
+                {1, 1, 0, 0, 0, 0 },
+                {0, 0, 0, 0, 1, 1 },
+                {0, 0, 0, 0, 1, 2 },
+                {0, 0, 1, 1, 0, 0 },
+                {0, 0, 1, 2, 0, 0 },
+            },
+            { // xi
+                {0, 0, 1, 0, 0, 0 },
+                {0, 0, 0, 1, 0, 0 },
+                {1, 0, 0, 0, 2, 0 },
+                {0, 1, 0, 0, 0, 2 },
+                {0, 0, 2, 0, 0, 1 },
+                {0, 0, 0, 2, 1, 1 },
+            },
+            { // phi * xi
+                {0, 0, 0, 1, 0, 0 },
+                {0, 0, 1, 1, 0, 0 },
+                {0, 1, 0, 0, 0, 2 },
+                {1, 1, 0, 0, 2, 2 },
+                {0, 0, 0, 2, 1, 1 },
+                {0, 0, 2, 2, 1, 2 },
+            },
+            { // xi^2
+                {0, 0, 0, 0, 1, 0 },
+                {0, 0, 0, 0, 0, 1 },
+                {0, 0, 1, 0, 0, 0 },
+                {0, 0, 0, 1, 0, 0 },
+                {1, 0, 0, 0, 2, 0 },
+                {0, 1, 0, 0, 0, 2 },
+            },
+            { // phi * xi^2
+                {0, 0, 0, 0, 0, 1 },
+                {0, 0, 0, 0, 1, 1 },
+                {0, 0, 0, 1, 0, 0 },
+                {0, 0, 1, 1, 0, 0 },
+                {0, 1, 0, 0, 0, 2 },
+                {1, 1, 0, 0, 2, 2 },
+            },
+        };
+
+    	multiplicationTensor = mm;
+    }
+
+    @Override
+    protected void initializeLabels() {
+        irrationalLabels[1] = new String[]{ "\u03C6",             "phi" };
+        irrationalLabels[2] = new String[]{       "\u03BE",           "xi" };
+        irrationalLabels[3] = new String[]{ "\u03C6\u03BE",       "phi*xi" };
+        irrationalLabels[4] = new String[]{       "\u03BE\u00B2",     "xi^2" };
+        irrationalLabels[5] = new String[]{ "\u03C6\u03BE\u00B2", "phi*xi^2" };
+    }
+
+    @Override
+    public int getNumMultipliers()
+    {
+        return 2; // only two primitive elements, phi and xi
+    }
+
+    /**
+     * scalar for an affine pentagon
+     * @return 
+     */
+    @Override
+    public AlgebraicNumber getAffineScalar()
+    {
+        return getGoldenRatio();
+    }
+
+    @Override
+    public AlgebraicNumber getGoldenRatio()
+    {
+        return getUnitTerm(1);
+    }
+    
+    // No need to override convertGoldenNumberPairs() as long as phi is the first irrational
+    
+}

--- a/core/src/test/java/com/vzome/core/algebra/AlgebraicFieldTest.java
+++ b/core/src/test/java/com/vzome/core/algebra/AlgebraicFieldTest.java
@@ -210,6 +210,7 @@ public class AlgebraicFieldTest {
         List<AlgebraicField> goldenFields = new ArrayList<>();
         goldenFields.add(new PentagonField());
         goldenFields.add(new SnubDodecField( AlgebraicNumberImpl.FACTORY ));
+        goldenFields.add(new SnubDodecahedronField( AlgebraicNumberImpl.FACTORY ));
         goldenFields.add(new SqrtPhiField( AlgebraicNumberImpl.FACTORY ));
         goldenFields.add( new PlasticPhiField( AlgebraicNumberImpl.FACTORY ) );
         

--- a/core/src/test/java/com/vzome/core/algebra/ParameterizedFieldTest.java
+++ b/core/src/test/java/com/vzome/core/algebra/ParameterizedFieldTest.java
@@ -25,8 +25,8 @@ public class ParameterizedFieldTest {
         TEST_FIELDS.add( new RootThreeField() );
         TEST_FIELDS.add( new HeptagonField() );
         TEST_FIELDS.add( new SnubDodecField( AlgebraicNumberImpl.FACTORY ) );
+        TEST_FIELDS.add( new SnubDodecahedronField( AlgebraicNumberImpl.FACTORY ) );
         TEST_FIELDS.add( new SqrtPhiField( AlgebraicNumberImpl.FACTORY ) );
-//        TEST_FIELDS.add( new SnubDodecahedronField() );
 //        TEST_FIELDS.add( new SqrtField(2) );
 //        TEST_FIELDS.add( new SqrtField(3) );
 //        TEST_FIELDS.add( new SqrtField(6) );
@@ -42,6 +42,11 @@ public class ParameterizedFieldTest {
     
     @Test
     public void testHaveSameInitialCoefficients() {
+        SnubDodecahedronField newSdField = new SnubDodecahedronField( AlgebraicNumberImpl.FACTORY );
+        SnubDodecField oldSdField = new SnubDodecField(AlgebraicNumberImpl.FACTORY); 
+        assertTrue(AlgebraicFields.haveSameInitialCoefficients(newSdField, SnubDodecField.FIELD_NAME));
+        assertTrue(AlgebraicFields.haveSameInitialCoefficients(oldSdField, SnubDodecahedronField.FIELD_NAME));
+
         PolygonField polyField = new PolygonField(5, AlgebraicNumberImpl.FACTORY ); 
         PentagonField pentField = new PentagonField(); 
         assertTrue(AlgebraicFields.haveSameInitialCoefficients(polyField, PentagonField.FIELD_NAME));


### PR DESCRIPTION
Equivalent to the legacy SnubDodecField but derived from ParameterizedField.
Now all of the legacy fields have a comparable ParameterizedField.
This class is not used anywhere yet, but it's been implemented for a long time and I wanted to get it into the code base just for completeness.
This is also a necessary step towards refactoring and merging ParameterizedField into AbstractAlgebraicField.