### PR TITLE
Dropbox chooser integrated to classic and online

### DIFF
--- a/online/public/classic/index.html
+++ b/online/public/classic/index.html
@@ -13,6 +13,8 @@
     <link rel="stylesheet" href="../App.css">
     <link rel="stylesheet" href="./classic.css">
     <link rel="manifest" href="./manifest.json">
+
+    <script type="text/javascript" src="https://www.dropbox.com/static/api/2/dropins.js" id="dropboxjs" data-app-key="vqxbnxclzvnu5oo"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/online/public/index.html
+++ b/online/public/index.html
@@ -12,6 +12,8 @@
     <title>vZome Online</title>
     <link rel="stylesheet" href="./App.css">
     <link rel="manifest" href="./manifest.json">
+    
+    <script type="text/javascript" src="https://www.dropbox.com/static/api/2/dropins.js" id="dropboxjs" data-app-key="vqxbnxclzvnu5oo"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/online/src/app/components/folder.jsx
+++ b/online/src/app/components/folder.jsx
@@ -63,9 +63,21 @@ export const OpenMenu = props =>
   const inputRef = useRef()
   const report = useDispatch();
 
+  const dropboxEnabled = window.Dropbox && window.localStorage.getItem( 'vzome.enable.dropbox' );
+
   const chooseFile = () => {
     setAnchorEl(null)
     inputRef.current.click();
+  }
+  const showDropboxChooser = () => {
+    setAnchorEl(null)
+    window.Dropbox.choose( {
+      linkType: 'direct',
+      extensions: ['.vzome'],
+      success: (files) => {
+        report( fetchDesign( files[0].link, { preview: false, debug: forDebugger } ) );
+      },
+    } );
   }
   const onFileSelected = e => {
     const selected = e.target.files && e.target.files[0]
@@ -127,6 +139,7 @@ export const OpenMenu = props =>
             onChange={onFileSelected} accept={acceptFiles} /> 
         </MenuItem>
         <MenuItem onClick={handleShowUrlDialog} >Remote vZome URL</MenuItem>
+        { dropboxEnabled && <MenuItem onClick={showDropboxChooser} >Choose from Dropbox</MenuItem> }
         <Divider />
         { models.map( (model) => (
           <MenuItem key={model.key} onClick={()=>handleSelectModel(model)}>{model.label}</MenuItem>


### PR DESCRIPTION
It is only enabled if you do:
  `localStorage.setItem( 'vzome.enable.dropbox', true )`
in the browser console