### PR TITLE
Can enable Dropbox with query param

### DIFF
--- a/online/src/app/components/folder.jsx
+++ b/online/src/app/components/folder.jsx
@@ -13,6 +13,13 @@ import Divider from '@material-ui/core/Divider';
 
 import UrlDialog from './webloader.jsx'
 
+const queryParams = new URLSearchParams( window.location.search );
+const enableDropbox = !! queryParams .get( 'enableDropbox' );
+
+if ( enableDropbox ) {
+  window.localStorage.setItem( 'vzome.enable.dropbox', true );
+}
+
 const models = [
   {
     key: "vZomeLogo",


### PR DESCRIPTION
Add `?enableDropbox=true` to enable on a mobile phone, where
you typically cannot type into a console.  It will be stored in localStorage,
per origin.