### PR TITLE
Corrected save.exports file naming defects

### DIFF
--- a/desktop/src/main/java/com/vzome/desktop/awt/DocumentController.java
+++ b/desktop/src/main/java/com/vzome/desktop/awt/DocumentController.java
@@ -16,6 +16,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
+import java.nio.file.Path;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
@@ -869,6 +870,13 @@ public class DocumentController extends DefaultGraphicsController implements Sce
                 // Sample prefs file entry: save.exports=export.dae capture.png capture.jpg export.vef
                 String exports = this .getProperty( "save.exports" );
                 if ( exports != null ) {
+                    Path filePath = file .toPath();
+                    String fileName = filePath .getFileName() .toString();
+                    int index = fileName .lastIndexOf( "." );
+                    if ( index > 0 )
+                    {
+                        fileName = fileName .substring( 0, index );
+                    }
                     for ( String captureOrExport : exports .split( " " ) ) {
                         // captureOrExport should be "capture.png" or "export.dae" or similar
                         String extension = "";
@@ -877,15 +885,17 @@ public class DocumentController extends DefaultGraphicsController implements Sce
                             switch (cmd[0]) {
                             case "capture":
                             case "export2d":
-                            case "export":
                                 extension = cmd[1];
+                                break;
+                            case "export":
+                                extension = this .getProperty( "exportExtension." + cmd[1] );
                                 break;
                             }
                         }
-                        if(extension == "") {
+                        if ( extension == "" ) {
                             mErrors.reportError( UNKNOWN_PROPERTY + " save.exports=" + captureOrExport, null );
                         } else {
-                            File exportFile = new File( dir, file .getName() + "." + extension );
+                            File exportFile = new File( dir, fileName + "." + extension );
                             doFileAction( captureOrExport, exportFile );
                         }
                     }

--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
@@ -981,14 +981,6 @@ public class DocumentFrame extends JFrame implements PropertyChangeListener, Con
                 else if ( command .startsWith( "export." ) ) {
                     String ext = command .substring( "export." .length() );
                     ext = controller .getProperty( "exportExtension." + ext );
-                    switch ( ext ) {
-                    case "vrml": ext = "wrl"; break;
-                    case "size": ext = "txt"; break;
-                    case "partslist": ext = "txt"; break;
-                    case "partgeom": ext = "vef"; break;
-                    default:
-                        break;
-                    }
                     actionListener = new ControllerFileAction( fileDialog, false, command, ext, controller );
                 }
                 else {


### PR DESCRIPTION
Now the ".vZome" extension is correctly stripped off, and the
correct extension is applied based on the exporter.