### PR TITLE
Updated to JOGL 2.4.0 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,15 +44,8 @@ subprojects {
     // For EGit
     maven { url 'https://repo.eclipse.org/content/groups/releases' }
 
-    ivy { // not really an Ivy repo, but this pattern lets us automate the bare JAR downloads for JOGL
-      url "https://jogamp.org/deployment"
-      metadataSources {
-        artifact();
-      }
-      patternLayout {
-        artifact "[revision]/jar/[artifact].[ext]"
-      }
-    }
+    maven { url 'https://jogamp.org/deployment/maven' }
+
     ivy { // not really an Ivy repo, but this pattern lets us automate the bare JAR download for vecmath
       url "https://jogamp.org/deployment"
       metadataSources {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     implementation     group: 'org.antlr',         name: 'antlr4',            version:'4.7.1'
     implementation     group: 'java3d',            name: 'vecmath',           version:'1.6.0-final'
 //    implementation     group: 'org.python',        name: 'jython',            version:'2.7.1b3'
-    implementation     group: 'org.jogamp', name: 'jogl-all', version:'v2.4.0-rc-20200307'
+    implementation     group: 'org.jogamp.jogl', name: 'jogl-all', version:'2.4.0'
 
     implementation group: 'antlr',             name: 'antlr',             version:'2.7.7'
 

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -87,23 +87,11 @@ dependencies {
 
     implementation group: 'java3d', name: 'vecmath', version:'1.6.0-final'
 
-    implementation group: 'org.jogamp', name: 'gluegen-rt', version:'v2.4.0-rc-20210111'
-    implementation group: 'org.jogamp', name: 'gluegen-rt-natives-linux-aarch64', version:'v2.4.0-rc-20210111'
-    implementation group: 'org.jogamp', name: 'gluegen-rt-natives-linux-amd64', version:'v2.4.0-rc-20210111'
-    implementation group: 'org.jogamp', name: 'gluegen-rt-natives-linux-armv6hf', version:'v2.4.0-rc-20210111'
-    implementation group: 'org.jogamp', name: 'gluegen-rt-natives-linux-i586', version:'v2.4.0-rc-20210111'
-    implementation group: 'org.jogamp', name: 'gluegen-rt-natives-macosx-universal', version:'v2.4.0-rc-20210111'
-    implementation group: 'org.jogamp', name: 'gluegen-rt-natives-windows-amd64', version:'v2.4.0-rc-20210111'
-    implementation group: 'org.jogamp', name: 'gluegen-rt-natives-windows-i586', version:'v2.4.0-rc-20210111'
-
-    implementation group: 'org.jogamp', name: 'jogl-all', version:'v2.4.0-rc-20210111'
-    implementation group: 'org.jogamp', name: 'jogl-all-natives-linux-aarch64', version:'v2.4.0-rc-20210111'
-    implementation group: 'org.jogamp', name: 'jogl-all-natives-linux-amd64', version:'v2.4.0-rc-20210111'
-    implementation group: 'org.jogamp', name: 'jogl-all-natives-linux-armv6hf', version:'v2.4.0-rc-20210111'
-    implementation group: 'org.jogamp', name: 'jogl-all-natives-linux-i586', version:'v2.4.0-rc-20210111'
-    implementation group: 'org.jogamp', name: 'jogl-all-natives-macosx-universal', version:'v2.4.0-rc-20210111'
-    implementation group: 'org.jogamp', name: 'jogl-all-natives-windows-amd64', version:'v2.4.0-rc-20210111'
-    implementation group: 'org.jogamp', name: 'jogl-all-natives-windows-i586', version:'v2.4.0-rc-20210111'
+    // VERY important: as long as we are using a release of JOGL, not a release candidate,
+    //  we can use the documented Maven dependency approach:
+    //     https://jogamp.org/wiki/index.php?title=Maven
+    implementation group: 'org.jogamp.gluegen', name: 'gluegen-rt-main', version:'2.4.0'
+    implementation group: 'org.jogamp.jogl', name: 'jogl-all-main', version:'2.4.0'
 
     implementation group: 'javax.media.jai', name: 'com.springsource.javax.media.jai.core', version:'1.1.3'
     implementation group: 'org.eclipse.lsp4j', name: 'org.eclipse.lsp4j.debug', version: '0.8.1'


### PR DESCRIPTION
Since this is now published on a real Maven repo, unlike the release
candidates, we can use the documented "-main" packages.  Maybe
we could have before, too... not sure.