### PR TITLE
Fix Java compiler [static] warning

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/render/jogl/JoglOpenGlShim.java
+++ b/desktop/src/main/java/org/vorthmann/zome/render/jogl/JoglOpenGlShim.java
@@ -34,7 +34,7 @@ public class JoglOpenGlShim implements OpenGlShim
     {
         this.gl2 = gl2;
         if(!versionIsLogged) {
-        	LOGGER.config("OpenGL version: " + gl2.glGetString(gl2.GL_VERSION) + "\n" 
+        	LOGGER.config("OpenGL version: " + gl2.glGetString(GL.GL_VERSION) + "\n" 
         			+ "    GLSL: " + getGLSLVersionString());
         	// DJH: FWIW, on my Windows 10 computer, getGLSLVersionString() has a trailing newline.
         	// I don't know if that's typical on other machines, 


### PR DESCRIPTION
Warning: static variable should be qualified by type name.
This warning was caused by my most recent commit of the same file.