### PR TITLE
Defect fixes

### DIFF
--- a/desktop/src/main/java/com/vzome/desktop/controller/SymmetryController.java
+++ b/desktop/src/main/java/com/vzome/desktop/controller/SymmetryController.java
@@ -271,6 +271,7 @@ public class SymmetryController extends DefaultController
                 String styleName =  action .substring( "setStyle." .length() );
                 this .symmetrySystem .setStyle( styleName );
                 this .renderedModel .setShapes( this .symmetrySystem .getShapes() );
+                firePropertyChange( "renderingStyle", null, styleName );
             }
             else {
                 boolean handled = this .symmetrySystem .doAction( action );

--- a/online/src/app/classic/classic.jsx
+++ b/online/src/app/classic/classic.jsx
@@ -67,6 +67,7 @@ export const SymmetryProvider = (props) =>
   const [ showOrbitsDialog, setShowOrbitsDialog ] = createSignal( false );
   const [ showPolytopesDialog, setShowPolytopesDialog ] = createSignal( false );
   const api = {
+    symmetryDefined: () => !!symmetry(),
     symmetryController: () => symmController(),
     showShapesDialog: () => setShowShapesDialog( true ),
     showOrbitsDialog: () => setShowOrbitsDialog( true ),
@@ -81,11 +82,13 @@ export const SymmetryProvider = (props) =>
 
       {props.children}
 
-      <ShapesDialog controller={symmController()} open={showShapesDialog()} close={ ()=>setShowShapesDialog(false) } />
+      <Show when={!!symmetry()}>
+        <ShapesDialog controller={symmController()} open={showShapesDialog()} close={ ()=>setShowShapesDialog(false) } />
 
-      <OrbitsDialog controller={symmController()} open={showOrbitsDialog()} close={ ()=>setShowOrbitsDialog(false) } />
+        <OrbitsDialog controller={symmController()} open={showOrbitsDialog()} close={ ()=>setShowOrbitsDialog(false) } />
 
-      <PolytopesDialog controller={symmController()} open={showPolytopesDialog()} close={ ()=>setShowPolytopesDialog(false) } />
+        <PolytopesDialog controller={symmController()} open={showPolytopesDialog()} close={ ()=>setShowPolytopesDialog(false) } />
+      </Show>
 
     </SymmetryContext.Provider>
   );

--- a/online/src/app/classic/components/length.jsx
+++ b/online/src/app/classic/components/length.jsx
@@ -88,7 +88,10 @@ export const StrutLengthPanel = props =>
 
   const [ scale, setScale ] = createSignal(0); // TODO should be realScale()?
   createEffect( () => {
-    setScale( realScale() );
+    if ( orbit() ) {
+      const value = realScale()
+      value && setScale( value );
+    }
   });
 
   const changeScale = (change) => (evt) =>
@@ -125,6 +128,7 @@ export const StrutLengthPanel = props =>
       }} onClick={ predefinedScale( props.scale, props.action ) } >{props.label}</Button>;
 
   return (
+    <Show when={orbit()}>
     <div id='strut-length' class='grid-rows-fr-min' >
       <div id='change-size' class='grid-cols-2-1' >
         <div id='scales-and-slider' class='grid-rows-min-1' style={{ 'background-color': backgroundColor() }}>
@@ -175,5 +179,6 @@ export const StrutLengthPanel = props =>
         <div style={{ 'min-height': '22px', 'margin-left': '1em' }}>=  <span class='bold'>{lengthText()}</span></div>
       </div>
     </div>
+    </Show>
   );
 }

--- a/online/src/app/classic/components/orbits.jsx
+++ b/online/src/app/classic/components/orbits.jsx
@@ -10,20 +10,22 @@ import { OrbitPanel } from "./orbitpanel.jsx";
 
 const OrbitsDialog = props =>
 {
-  const allOrbits = () => controllerProperty( props.controller, 'orbits', 'orbits', true );
   const availableOrbits = () => subController( props.controller, 'availableOrbits' );
-  const orbits = () => controllerProperty( availableOrbits(), 'orbits', 'orbits', true );
-  const snapOrbits = () => subController( props.controller, 'snapOrbits' );
-  const lastSelected = () => controllerProperty( buildOrbits(), 'selectedOrbit', 'orbits', false );
+  const snapOrbits      = () => subController( props.controller, 'snapOrbits' );
+
+  const allOrbits    = () => controllerProperty( props.controller, 'orbits', 'orbits', true );
+  const orbits       = () => controllerProperty( availableOrbits(), 'orbits', 'orbits', true );
+  const lastAvailable = () => controllerProperty( availableOrbits(), 'selectedOrbit', 'orbits', false );
+  const lastSnap = () => controllerProperty( snapOrbits(), 'selectedOrbit', 'orbits', false );
 
   return (
     <Dialog onClose={ () => props.close() } open={props.open} maxWidth='md' fullWidth='true'>
       <DialogTitle id="orbits-dialog">Direction Configuration</DialogTitle>
       <DialogContent>
         <div style={{ display: 'grid', 'grid-template-columns': '1fr 1fr', 'min-width': '550px' }}>
-          <OrbitPanel orbits={allOrbits()} controller={availableOrbits()} lastSelected={lastSelected()}
+          <OrbitPanel orbits={allOrbits()} controller={availableOrbits()} lastSelected={lastAvailable()}
             label="available directions" style={{ height: '100%' }} />
-          <OrbitPanel orbits={orbits()} controller={snapOrbits()} lastSelected={lastSelected()}
+          <OrbitPanel orbits={orbits()} controller={snapOrbits()} lastSelected={lastSnap()}
             label="snap directions" style={{ height: '100%' }} />
         </div>
       </DialogContent>

--- a/online/src/app/classic/components/shapes.jsx
+++ b/online/src/app/classic/components/shapes.jsx
@@ -15,7 +15,7 @@ import { controllerAction, controllerProperty } from "../../../workerClient/cont
 export const ShapesDialog = props =>
 {
   const styles = () => controllerProperty( props.controller, 'styles', 'styles', true );
-  const currStyle = () => controllerProperty( props.controller, 'renderingStyle', 'renderingStyle', false );
+  const currStyle = () => controllerProperty( props.controller, 'renderingStyle', 'renderingStyle', false ) || '';
 
   const handleChange = event =>{
     controllerAction( props.controller, `setStyle.${event.target.value}` );

--- a/online/src/app/classic/components/strutbuilder.jsx
+++ b/online/src/app/classic/components/strutbuilder.jsx
@@ -1,5 +1,5 @@
 
-import { createSignal } from "solid-js";
+import { Show, createSignal } from "solid-js";
 
 import IconButton from '@suid/material/IconButton'
 import SettingsIcon from '@suid/icons-material/Settings'
@@ -13,7 +13,7 @@ import { useSymmetry } from "../classic.jsx";
 
 export const StrutBuildPanel = () =>
 {
-  const { showOrbitsDialog, symmetryController } = useSymmetry();
+  const { showOrbitsDialog, symmetryController, symmetryDefined } = useSymmetry();
   const availableOrbits = () => subController( symmetryController(), 'availableOrbits' );
   const buildOrbits = () => subController( symmetryController(), 'buildOrbits' );
   const orbits = () => controllerProperty( availableOrbits(), 'orbits', 'orbits', true );
@@ -37,6 +37,7 @@ export const StrutBuildPanel = () =>
 
   return(
     <div id="build" style={{ display: 'grid', 'grid-template-rows': '1fr min-content', height: '100%' }}>
+      <Show when={symmetryDefined()}>
       <OrbitPanel orbits={orbits()} controller={buildOrbits()} lastSelected={lastSelected()}
           label="build directions" style={{ height: '100%' }} >
         <IconButton color="inherit" aria-label="settings"
@@ -57,6 +58,7 @@ export const StrutBuildPanel = () =>
         </Menu>
       </OrbitPanel>
       <StrutLengthPanel controller={buildOrbits()} />
+      </Show>
     </div>
   );
 }

--- a/online/src/app/classic/components/toolbars.jsx
+++ b/online/src/app/classic/components/toolbars.jsx
@@ -31,15 +31,14 @@ const ToolFactoryButton = props =>
 
 export const ToolFactoryBar = props =>
 {
-  const { symmetryController } = useSymmetry();
-  const symmFactoryNames = () => {
-    return controllerProperty( symmetryController(), 'symmetryToolFactories', 'symmetryToolFactories', true );
-  }
+  const { symmetryController, symmetryDefined } = useSymmetry();
+  const symmFactoryNames = () => controllerProperty( symmetryController(), 'symmetryToolFactories', 'symmetryToolFactories', true );
   const transFactoryNames = () => controllerProperty( symmetryController(), 'transformToolFactories', 'transformToolFactories', true );
   const mapFactoryNames = () => controllerProperty( symmetryController(), 'linearMapToolFactories', 'linearMapToolFactories', true );
 
   return (
     <div id='factory-bar' class='toolbar'>
+      <Show when={symmetryDefined()}>
       <For each={symmFactoryNames()}>{ factoryName =>
         <ToolFactoryButton factoryName={factoryName}/>
       }</For>
@@ -51,6 +50,7 @@ export const ToolFactoryBar = props =>
       <For each={mapFactoryNames()}>{ factoryName =>
         <ToolFactoryButton factoryName={factoryName}/>
       }</For>
+      </Show>
     </div>
   )
 }
@@ -73,7 +73,7 @@ const ToolButton = props =>
 
 export const ToolBar = props =>
 {
-  const { symmetryController } = useSymmetry();
+  const { symmetryController, symmetryDefined } = useSymmetry();
   const symmToolNames = () => controllerProperty( symmetryController(), 'builtInSymmetryTools', 'builtInSymmetryTools', true );
   const transToolNames = () => controllerProperty( symmetryController(), 'builtInTransformTools', 'builtInTransformTools', true );
   const customToolNames = () => controllerProperty( props.toolsController, 'customTools', 'customTools', true );
@@ -91,17 +91,19 @@ export const ToolBar = props =>
       <CommandButton ctrlr={props.editorController} cmdName='panel' hoverText='Make a panel polygon'/>
       <CommandButton ctrlr={props.editorController} cmdName='NewCentroid' hoverText='Construct centroid of points'/>
       <ToolbarSpacer/>
-      <For each={symmToolNames()}>{ toolName =>
-        <ToolButton controller={subController( props.toolsController, toolName )}/>
-      }</For>
-      <ToolbarSpacer/>
-      <For each={transToolNames()}>{ toolName =>
-        <ToolButton controller={subController( props.toolsController, toolName )}/>
-      }</For>
-      <ToolbarSpacer/>
-      <For each={customToolNames()}>{ toolName =>
-        <ToolButton controller={subController( props.toolsController, toolName )}/>
-      }</For>
+      <Show when={symmetryDefined()}>
+        <For each={symmToolNames()}>{ toolName =>
+          <ToolButton controller={subController( props.toolsController, toolName )}/>
+        }</For>
+        <ToolbarSpacer/>
+        <For each={transToolNames()}>{ toolName =>
+          <ToolButton controller={subController( props.toolsController, toolName )}/>
+        }</For>
+        <ToolbarSpacer/>
+        <For each={customToolNames()}>{ toolName =>
+          <ToolButton controller={subController( props.toolsController, toolName )}/>
+        }</For>
+      </Show>
     </div>
   )
 }
@@ -122,13 +124,15 @@ const BookmarkButton = props =>
 
 export const BookmarkBar = props =>
 {
-  const { symmetryController } = useSymmetry();
+  const { symmetryController, symmetryDefined } = useSymmetry();
   const bookmarkNames = () => controllerProperty( props.toolsController, 'customBookmarks', 'customBookmarks', true );
 
   return (
     <div id='tools-bar' class='toolbar-vert'>
-      <ToolbarSpacer/>
-      <ToolFactoryButton factoryName='bookmark' controller={symmetryController()}/>
+      <Show when={symmetryDefined()}>
+        <ToolbarSpacer/>
+        <ToolFactoryButton factoryName='bookmark' controller={symmetryController()}/>
+      </Show>
       <ToolbarSpacer/>
       <BookmarkButton controller={subController( props.toolsController, 'bookmark.builtin/ball at origin' )}/>
       <For each={bookmarkNames()}>{ toolName =>

--- a/online/src/workerClient/controllers-solid.js
+++ b/online/src/workerClient/controllers-solid.js
@@ -211,7 +211,8 @@ const subController = ( parent, key ) =>
 
 const controllerProperty = ( controller, propName, changeName=propName, isList=false ) =>
 {
-  if ( ! controller[ propName ] ) {
+  // We don't want this to happen just because the property is already defined but false
+  if ( typeof controller[ propName ] === 'undefined' ) {
     // The property has never been requested, so we have to make the initial request
     const controllerPath = controller.__path .join( ':' );
     createEffect( () => {


### PR DESCRIPTION
The orbits config dialog was broken, missing a controller definition.

The shapes dialog was initially uncontrolled, and also not getting change events.

The useSymmetry() context now includes "symmetryDefined()", so UIs can avoid trying
to get properties from "symmetry.undefined", and so on.

I fixed some wrong properties in the orbits control dialog.

I corrected  a nasty bug in controller-solid.js, wherein controllerProperty() was treating
a false-valued property like an undefined one!  This caused an infinite loop when
I hit "none" on the availableOrbits panel.