### PR TITLE
Scene attribute on web component

### DIFF
--- a/online/public/test/index.html
+++ b/online/public/test/index.html
@@ -6,17 +6,21 @@
     <link rel="stylesheet" href="./vzome-viewer.css">
     <script type="module">
       import "/modules/vzome-viewer.js"; // registers the custom element
+
+      const viewer = document.querySelector( "#vZomeLogo" );
+      viewer .addEventListener( "vzome-scenes-discovered", (e) => console.log( 'Scenes:', JSON.stringify( e.detail ) ) );
+
     </script>
   </head>
   <body>
     <article>
       <section>
-        <vzome-viewer src="./models/orangePurpleChiral.vZome" show-scenes="false" >
+        <vzome-viewer src="./models/orangePurpleChiral.vZome" show-scenes="true" scene="5-fold axis" id="orangePurpleChiral" >
           <img src="./models/orangePurpleChiral.png" >
         </vzome-viewer>
       </section>
       <section>
-        <vzome-viewer src="./models/vZomeLogo.vZome" show-scenes="true" >
+        <vzome-viewer src="./models/vZomeLogo.vZome" show-scenes="true" id="vZomeLogo" >
         </vzome-viewer>
       </section>
       <section>

--- a/online/src/viewer/solid/index.jsx
+++ b/online/src/viewer/solid/index.jsx
@@ -48,6 +48,13 @@ const DesignViewer = ( props ) =>
     //  Note that this does NOT help with window resize.
     setFullScreen( v => !v );
   }
+  const showSceneMenu = () =>
+  {
+    const { showScenes, sceneTitle } = props.config;
+    // Only show the menu when the scene is not being controlled explicitly,
+    //  and when more than one scene has been discovered.
+    return (typeof sceneTitle === 'undefined' ) && showScenes && state.scenes && state.scenes[1];
+  }
 
   const showSpinner = () => {
     return props.config?.useSpinner && state.waiting;
@@ -70,7 +77,7 @@ const DesignViewer = ( props ) =>
         <SceneCanvas id='scene-canvas' scene={state.scene} height={props.height} width={props.width} />
       </Show>
 
-      <Show when={props.config?.showScenes && state.scenes && state.scenes[1]}>
+      <Show when={showSceneMenu()}>
         <SceneMenu root={rootRef} />
       </Show>
 

--- a/online/src/wc/vzome-viewer.js
+++ b/online/src/wc/vzome-viewer.js
@@ -26,6 +26,11 @@ export class VZomeViewer extends HTMLElement
       onWorkerMessage: data => {
         switch ( data.type ) {
 
+          case 'SCENES_DISCOVERED':
+            const titles = data.payload .map( (scene,i) => scene.title || `#${i}` );
+            this .dispatchEvent( new CustomEvent( 'vzome-scenes-discovered', { detail: titles } ) );
+            break;
+
           case 'SCENE_RENDERED':
             this .dispatchEvent( new Event( 'vzome-design-rendered' ) );
             break;
@@ -46,6 +51,11 @@ export class VZomeViewer extends HTMLElement
     if ( this.hasAttribute( 'show-scenes' ) ) {
       const showScenes = this.getAttribute( 'show-scenes' ) === 'true';
       this.#config = { ...this.#config, showScenes };
+    }
+
+    if ( this.hasAttribute( 'scene' ) ) {
+      const sceneTitle = this.getAttribute( 'scene' );
+      this.#config = { ...this.#config, sceneTitle };
     }
 
     if ( this.hasAttribute( 'src' ) ) {
@@ -110,6 +120,20 @@ export class VZomeViewer extends HTMLElement
   get src()
   {
     return this.getAttribute("src");
+  }
+
+  set scene( newScene )
+  {
+    if (newScene === null) {
+      this.removeAttribute("scene");
+    } else {
+      this.setAttribute("scene", newScene);
+    }
+  }
+
+  get scene()
+  {
+    return this.getAttribute("scene");
   }
 
   set showScenes( newValue )


### PR DESCRIPTION
This will allow programmatic scene selection.  Scene titles are discoverable by subscribing
to the "vzome-scenes-discovered" CustomEvent, emitted by the viewer element.
See `online/public/test/index.html` for sample code.

A scene index, rather than a title, can be selected as "#6" for index 6, zero-based.

Invalid title or index will result in a console warning message, and display of the default scene.

The `show-scenes` attribute is irrelevant when the scene attribute is set; the viewer is
thus scene-controlled and the scenes menu won't be displayed.