### PR TITLE
Corrected scene attr tracking for web component

### DIFF
--- a/online/public/test/index.html
+++ b/online/public/test/index.html
@@ -8,7 +8,12 @@
       import "/modules/vzome-viewer.js"; // registers the custom element
 
       const viewer = document.querySelector( "#vZomeLogo" );
-      viewer .addEventListener( "vzome-scenes-discovered", (e) => console.log( 'Scenes:', JSON.stringify( e.detail ) ) );
+      viewer .addEventListener( "vzome-scenes-discovered", (e) => {
+        setTimeout( () => {
+          console.log( 'Scenes:', JSON.stringify( e.detail ) );
+          viewer.scene = e.detail[ 3 ];
+        }, 3000 )
+      });
 
     </script>
   </head>

--- a/online/src/viewer/solid/scenes.jsx
+++ b/online/src/viewer/solid/scenes.jsx
@@ -14,13 +14,13 @@ export const SceneMenu = (props) =>
 {
   const { state, postMessage } = useWorkerClient();
   const sceneTitles = createMemo( () => state.scenes .map( (scene,index) =>
-    scene.title?.trim() || (( index === 0 )? "default scene" : `scene ${index}`) ) );
+    scene.title?.trim() || (( index === 0 )? "default scene" : `#${index}`) ) );
   const [ sceneTitle, setSceneTitle ] = createSignal( sceneTitles()[0] );
 
   const handleChange = (sceneTitle) =>
   {
     setSceneTitle( sceneTitle );
-    postMessage( selectScene( sceneTitles() .indexOf( sceneTitle ) ) );
+    postMessage( selectScene( sceneTitle ) );
   }
 
   return (

--- a/online/src/wc/vzome-viewer.js
+++ b/online/src/wc/vzome-viewer.js
@@ -1,7 +1,7 @@
 
 import { vZomeViewerCSS } from "./vzome-viewer.css";
 
-import { fetchDesign, createWorker, createWorkerStore } from '../workerClient/index.js';
+import { fetchDesign, createWorker, createWorkerStore, selectScene } from '../workerClient/index.js';
 
 export class VZomeViewer extends HTMLElement
 {
@@ -83,7 +83,7 @@ export class VZomeViewer extends HTMLElement
 
   static get observedAttributes()
   {
-    return [ "src", "show-scenes" ];
+    return [ "src", "show-scenes", "scene" ];
   }
 
   attributeChangedCallback( attributeName, _oldValue, _newValue )
@@ -98,6 +98,14 @@ export class VZomeViewer extends HTMLElement
       }
       break;
 
+    case "scene":
+      if ( _newValue !== this.#config.sceneTitle ) {
+        this.#config = { ...this.#config, sceneTitle: _newValue };
+        // TODO: control the config prop on the viewer component, so the scenes menu behaves right
+        this.#store.postMessage( selectScene( _newValue ) );
+      }
+      break;
+  
     case "show-scenes":
       const showScenes = _newValue === 'true';
       if ( showScenes !== this.#config.showScenes ) {

--- a/online/src/worker/vzome-worker-static.js
+++ b/online/src/worker/vzome-worker-static.js
@@ -295,7 +295,7 @@ onmessage = ({ data }) =>
       break;
 
     case 'SCENE_SELECTED': {
-      const index = payload;
+      const index = getSceneIndex( payload, scenes );
       const { nodeId, camera } = scenes[ index ];
       let scene;
       if ( nodeId ) { // XML was parsed by the legacy module

--- a/online/src/workerClient/actions.js
+++ b/online/src/workerClient/actions.js
@@ -1,7 +1,7 @@
 
 const workerAction = ( type, payload ) => ({ type, payload, meta: 'WORKER' } );
 
-export const selectScene = index => workerAction( 'SCENE_SELECTED', index );
+export const selectScene = title => workerAction( 'SCENE_SELECTED', title );
 
 export const selectEditBefore = nodeId => workerAction( 'EDIT_SELECTED', { before: nodeId } );
 


### PR DESCRIPTION
The attr change was not being observed.

To make this work, I switched SELECT_SCENE to take a title not an index.  Obviously,
anonymous scenes must be selected with "#n".

There is still an issue with the scenes menu not disappearing when the scene attr is set.
See vzome-viewer.js, line 104.