### PR TITLE
Fixing the use of XML entities in scene titles

### DIFF
--- a/online/src/wc/vzome-viewer.js
+++ b/online/src/wc/vzome-viewer.js
@@ -2,6 +2,7 @@
 import { vZomeViewerCSS } from "./vzome-viewer.css";
 
 import { fetchDesign, createWorker, createWorkerStore, selectScene } from '../workerClient/index.js';
+import { decodeEntities } from "../workerClient/actions";
 
 export class VZomeViewer extends HTMLElement
 {
@@ -27,7 +28,7 @@ export class VZomeViewer extends HTMLElement
         switch ( data.type ) {
 
           case 'SCENES_DISCOVERED':
-            const titles = data.payload .map( (scene,i) => scene.title || `#${i}` );
+            const titles = data.payload .map( (scene,i) =>  scene.title ? decodeEntities( scene.title ) : `#${i}` );
             this .dispatchEvent( new CustomEvent( 'vzome-scenes-discovered', { detail: titles } ) );
             break;
 

--- a/online/src/workerClient/actions.js
+++ b/online/src/workerClient/actions.js
@@ -1,7 +1,27 @@
 
+// This is necessary as long as the worker uses tXml, and they haven't fixed issue 44:
+//   https://github.com/TobiasNickel/tXml/issues/44
+// I'm fixing it here simply because I have access to the DOM, which is not supported in the worker.
+export const decodeEntities = (html) =>
+{
+  var txt = document.createElement("textarea");
+  txt.innerHTML = html;
+  return txt.value;
+}
+export const encodeEntities = (title) =>
+{
+  var text = document.createTextNode(title);
+  var p = document.createElement('p');
+  p.appendChild(text);
+  return p.innerHTML;
+}
+
 const workerAction = ( type, payload ) => ({ type, payload, meta: 'WORKER' } );
 
-export const selectScene = title => workerAction( 'SCENE_SELECTED', title );
+export const selectScene = title => 
+{
+  return workerAction( 'SCENE_SELECTED', encodeEntities( title ) );
+}
 
 export const selectEditBefore = nodeId => workerAction( 'EDIT_SELECTED', { before: nodeId } );
 

--- a/online/src/workerClient/controllers-solid.js
+++ b/online/src/workerClient/controllers-solid.js
@@ -2,7 +2,7 @@
 import { createEffect } from "solid-js";
 import { createStore, reconcile } from "solid-js/store";
 
-import { initialState, newDesign, requestControllerProperty, doControllerAction, setControllerProperty } from './actions.js';
+import { initialState, newDesign, requestControllerProperty, doControllerAction, setControllerProperty, decodeEntities } from './actions.js';
 
 const createWorkerStore = ( worker ) =>
 {
@@ -77,7 +77,10 @@ const createWorkerStore = ( worker ) =>
       }
 
       case 'SCENES_DISCOVERED': {
-        setState( 'scenes', data.payload );
+        const scenes = data.payload .map( scene => {
+          return { ...scene, title: decodeEntities( scene.title ) }
+        });
+        setState( 'scenes', scenes );
         break;
       }
   


### PR DESCRIPTION
Since the user can enter any text into the article page titles in desktop vZome, the
serialized XML may contain entities that encode those characters, e.g. "&" becomes "&amp;".
The XML parser normally reverses this, but the `txml` parser I'm using in the worker does
not!  This will be even more important when other languages are used.

The fix is simple, and is done in the main context, where I can leverage the DOM parsing
and decoding of entities.  I do have to do the decoding twice, once for each worker
subscriber, and I have to encode when sending SCENE_SELECTED.