### PR TITLE
Corrected the defect in resource paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,5 @@ online/meta.json
 online/public/modules/
 
 online/public/resources/
+
+online/public/classic/resources/

--- a/cicd/build-online.bash
+++ b/cicd/build-online.bash
@@ -25,9 +25,12 @@ yarn install || exit $?
 rm -rf dist || exit $?
 yarn run build || exit $?
 
-rm -rf public/resources || exit $?
-mkdir -p public/resources || exit $?
-cp -R ../desktop/src/main/resources/* public/resources || exit $?
+# Remove the detritus of earlier builds (& dev server)
+rm -rf public/modules || exit $?
+rm -rf public/classic/resources || exit $?
+
+mkdir -p public/classic/resources || exit $?
+cp -R ../desktop/src/main/resources/* public/classic/resources || exit $?
 
 pushd dist
 
@@ -38,5 +41,5 @@ banner 'Creating the online.tgz archive'
   echo ${REVISION} > modules/revision.txt && \
   tar czvf online.tgz app modules
 
-banner 'finished building the vZome Online app and web component'
+banner 'finished building the vZome Online apps and web component'
 

--- a/online/src/app/classic/components/length.jsx
+++ b/online/src/app/classic/components/length.jsx
@@ -136,10 +136,10 @@ export const StrutLengthPanel = props =>
           <div id='up-down-slider' class='grid-cols-min-1 orbit-scale'>
             <div id='up-down' class='grid-rows-1-1 pad-4px' >
               <button aria-label='scale-up' class='scale-button' onClick={scaleUp}>
-                <img src='/resources/org/vorthmann/zome/ui/scaleUp.gif'/>
+                <img src='./resources/org/vorthmann/zome/ui/scaleUp.gif'/>
               </button>
               <button aria-label='scale-down' class='scale-button' onClick={scaleDown}>
-                <img src='/resources/org/vorthmann/zome/ui/scaleDown.gif'/>
+                <img src='./resources/org/vorthmann/zome/ui/scaleDown.gif'/>
               </button>
             </div>
             <div id='scale-slider' class='scale-slider' >

--- a/online/src/app/classic/components/toolbars.jsx
+++ b/online/src/app/classic/components/toolbars.jsx
@@ -10,7 +10,7 @@ const ToolbarSpacer = () => ( <div style={{ 'min-width': '10px', 'min-height': '
 const ToolbarButton = props =>
 (
   <button aria-label={props.label} class='toolbar-button' onClick={props.onClick} onContextMenu={props.onContextMenu} disabled={props.disabled}>
-    <img src={ `/resources/icons/tools/${props.image}.png`} class='toolbar-image'/>
+    <img src={ `./resources/icons/tools/${props.image}.png`} class='toolbar-image'/>
   </button>
 )
 

--- a/online/src/app/classic/components/toolconfig.jsx
+++ b/online/src/app/classic/components/toolconfig.jsx
@@ -65,7 +65,7 @@ export const ToolConfig = (props) =>
       <div class='tool-config-icon-label' onKeydown={handleKeyDown} >
         <button aria-label={props.label} class='toolbar-button' onClick={handleToolClick} disabled={props.disabled}
             style={{ padding: '0.5em' }}>
-          <img src={ `/resources/icons/tools/${props.image}.png`} class='toolbar-image'/>
+          <img src={ `./resources/icons/tools/${props.image}.png`} class='toolbar-image'/>
         </button>
         { !!props.predefined?
           <Typography sx={{ margin: 'auto' }}>{props.label}</Typography>

--- a/online/src/worker/vzome-worker-static.js
+++ b/online/src/worker/vzome-worker-static.js
@@ -203,7 +203,7 @@ const fetchTrackballScene = ( url, report ) =>
       reportTrackballScene( payload );
     }
   }
-  Promise.all( [ import( './legacy/dynamic.js' ), fetchUrlText( new URL( `/resources/${url}`, baseURL ) ) ] )
+  Promise.all( [ import( './legacy/dynamic.js' ), fetchUrlText( new URL( `./resources/${url}`, baseURL ) ) ] )
     .then( ([ module, xml ]) => {
       module .loadDesign( xml, false, clientEvents( justTheScene ) );
     } )


### PR DESCRIPTION
The path has to be "./resources/...", always relative to window.location, even
within the worker, where window.location must be passed in.

I also fixed a defect in build-online.bash, which was not cleaning up dev modules.
