### PR TITLE
Fixing bugs in non-classic apps

### DIFF
--- a/online/src/app/buildplane/buildplane.jsx
+++ b/online/src/app/buildplane/buildplane.jsx
@@ -175,7 +175,7 @@ const Hinge = ( { state, buildPlanes, actions } ) =>
 const BuildPlane = ( { worker }, toolRef ) =>
 {
   const { sendToWorker, subscribe } = worker;
-  const [ state, dispatch ] = useReducer( reducer, initialState() ); // dedicated local store
+  const [ state, dispatch ] = useReducer( reducer, initialState ); // dedicated local store
   useEffect( () => {
     // Connect the worker store to the local store, to listen to worker events
     subscribe( {

--- a/online/src/app/classic/components/appbar.jsx
+++ b/online/src/app/classic/components/appbar.jsx
@@ -7,43 +7,15 @@ import Box from '@suid/material/Box'
 
 import { OpenMenu } from './folder.jsx'
 import { VZomeLogo } from './logo.jsx'
-import { FileMenu } from '../menus/filemenu.jsx';
-import { EditMenu } from '../menus/editmenu.jsx';
-import { ConstructMenu } from '../menus/constructmenu.jsx';
-import { ToolsMenu } from '../menus/toolsmenu.jsx';
-import { SystemMenu } from '../menus/systemmenu.jsx';
-import { HelpMenu } from '../menus/help.jsx';
 import { AboutDialog } from './about.jsx';
-import { DiskIcon, WorldIcon } from '../../framework/icons.jsx';
-import { useWorkerClient } from '../../../workerClient/context.jsx'
-import { controllerProperty } from '../../../workerClient/controllers-solid.js'
 
-const Persistence = () =>
-{
-  const { state, rootController } = useWorkerClient();
-  const edited = () => controllerProperty( rootController(), 'edited' ) === 'true';
-  return (
-    <div class='persistence' >
-      <Show when={state?.designName} >
-        <div class='persistence-box' >
-          <div class={ edited()? 'persistence-icon' : 'persistence-icon-saved' }>
-            <Show when={state?.fileHandle} fallback={
-              <WorldIcon/>
-            }>
-              <DiskIcon/>
-            </Show>
-          </div>
-          <div class='persistence-title' >{state?.designName}</div>
-        </div>
-      </Show>
-    </div>
-  )
-}
+export const Spacer = () => <div style={{ flex: '1 1 auto' }}></div>
 
 // export const VZomeAppBar = ( { oneDesign, pathToRoot='.', forDebugger=false, title, about } ) =>
 export const VZomeAppBar = ( props ) =>
 {
-  const merged = mergeProps( { showOpen: false, menuBar: false, pathToRoot: '.', forDebugger: false }, props );
+  const spacer = <Spacer/>;
+  const merged = mergeProps( { spacer, showOpen: false, pathToRoot: '.', forDebugger: false }, props );
 
   return (
     <div id="appbar" >
@@ -53,16 +25,8 @@ export const VZomeAppBar = ( props ) =>
           <Typography variant="h5" sx={{ paddingLeft: '12px', paddingRight: '40px' }}>
             vZome Online <Box component="span" fontStyle="oblique">{props.title}</Box>
           </Typography>
-          <Show when={merged.menuBar}>
-            <FileMenu/>
-            <EditMenu/>
-            <ConstructMenu/>
-            <ToolsMenu/>
-            <SystemMenu/>
-            <HelpMenu/>
-          </Show>
-          <Persistence/>
-          <Show when={merged.showOpen}>
+          {merged.spacer}
+          <Show when={merged.showOpen} >
             <OpenMenu pathToRoot={merged.pathToRoot} forDebugger={merged.forDebugger} />
           </Show>
           <AboutDialog title={props.title} about={props.about} />

--- a/online/src/app/classic/components/camera.jsx
+++ b/online/src/app/classic/components/camera.jsx
@@ -1,16 +1,21 @@
 
+import { createEffect } from 'solid-js';
 import { SceneCanvas } from '../../../viewer/solid/scenecanvas.jsx';
 import { useWorkerClient } from '../../../workerClient/index.js';
+import { controllerAction } from '../../../workerClient/controllers-solid.js';
 
 export const CameraControls = props =>
 {
-  const { state } = useWorkerClient();
+  const { state, rootController, isWorkerReady } = useWorkerClient();
   const bkgdColor = () => state.scene ?.lighting ?.backgroundColor;
 
   const scene = () => {
     const symmScene = state.trackballScene;
     return ({ ...symmScene, lighting: { ...symmScene?.lighting, backgroundColor: bkgdColor() } } );
   }
+
+  // A special action that will result in state.trackballScene being set
+  createEffect( () => isWorkerReady() && controllerAction( rootController(), 'connectTrackballScene' ) );
 
   return (
     <div id='camera-controls' style={{ display: 'grid', 'grid-template-rows': 'min-content min-content' }}>

--- a/online/src/app/classic/index.jsx
+++ b/online/src/app/classic/index.jsx
@@ -3,10 +3,41 @@ import { ErrorBoundary } from "solid-js";
 
 import Typography from '@suid/material/Typography'
 import Link from '@suid/material/Link'
+import { DiskIcon, WorldIcon } from '../framework/icons.jsx';
+import { FileMenu } from './menus/filemenu.jsx';
+import { EditMenu } from './menus/editmenu.jsx';
+import { ConstructMenu } from './menus/constructmenu.jsx';
+import { ToolsMenu } from './menus/toolsmenu.jsx';
+import { SystemMenu } from './menus/systemmenu.jsx';
+import { HelpMenu } from './menus/help.jsx';
 
+import { useWorkerClient } from '../../workerClient/context.jsx'
+import { controllerProperty } from '../../workerClient/controllers-solid.js'
 import { VZomeAppBar } from './components/appbar.jsx';
 import { ClassicEditor, SymmetryProvider } from './classic.jsx';
 import { WorkerStateProvider } from '../../workerClient/index.js';
+
+const Persistence = () =>
+{
+  const { state, rootController } = useWorkerClient();
+  const edited = () => controllerProperty( rootController(), 'edited' ) === 'true';
+  return (
+    <div class='persistence' >
+      <Show when={state?.designName} >
+        <div class='persistence-box' >
+          <div class={ edited()? 'persistence-icon' : 'persistence-icon-saved' }>
+            <Show when={state?.fileHandle} fallback={
+              <WorldIcon/>
+            }>
+              <DiskIcon/>
+            </Show>
+          </div>
+          <div class='persistence-title' >{state?.designName}</div>
+        </div>
+      </Show>
+    </div>
+  )
+}
 
 const Classic = () =>
 {
@@ -15,6 +46,15 @@ const Classic = () =>
       <WorkerStateProvider>
         <SymmetryProvider>
           <VZomeAppBar menuBar={true}
+            spacer={ <>
+              <FileMenu/>
+              <EditMenu/>
+              <ConstructMenu/>
+              <ToolsMenu/>
+              <SystemMenu/>
+              <HelpMenu/>
+              <Persistence/>
+            </>}
             about={ <>
               <Typography gutterBottom>
                 vZome Online Classic is a work in progress, still at the proof-of-concept stage.  It will be part of a web-based modeling tool

--- a/online/src/viewer/solid/ltcanvas.jsx
+++ b/online/src/viewer/solid/ltcanvas.jsx
@@ -99,7 +99,7 @@ const LightedCameraControls = (props) =>
       <PerspectiveCamera fov={fov()} aspect={props.aspect} position={position()} up={props.sceneCamera?.up} >
         <Lighting {...(lights())} />
       </PerspectiveCamera>
-      <TrackballControls onEnd={trackballEnd} rotationOnly={props.rotationOnly}
+      <TrackballControls onEnd={props.rotationOnly? undefined : trackballEnd} rotationOnly={props.rotationOnly}
           staticMoving='true' rotateSpeed={4.5} zoomSpeed={3} panSpeed={1} target={props.sceneCamera?.lookAt} />
     </>
   );

--- a/online/src/worker/vzome-worker-static.js
+++ b/online/src/worker/vzome-worker-static.js
@@ -227,7 +227,6 @@ const createDesign = ( report, fieldName ) =>
     .then( module => {
       report( { type: 'CONTROLLER_CREATED' } ); // do we really need this for previewing?
       designWrapper = module .newDesign( fieldName, clientEvents( report ) );
-      connectTrackballScene( report );
     } )
 
     .catch( error => {
@@ -244,7 +243,6 @@ const openDesign = ( xmlLoading, report, debug, sceneTitle, preview ) =>
     .then( ([ module, xml ]) => {
       report( { type: 'CONTROLLER_CREATED' } ); // do we really need this for previewing?
       designWrapper = module .loadDesign( xml, debug, clientEvents( captureScenes( report ) ), sceneTitle );
-      !preview && connectTrackballScene( report );
     } )
 
     .catch( error => {
@@ -384,6 +382,10 @@ onmessage = ({ data }) =>
     case 'ACTION_TRIGGERED':
     {
       const { controllerPath, action, parameters } = payload;
+      if ( action === 'connectTrackballScene' ) {
+        connectTrackballScene( postMessage );
+        return;
+      }
       try {
         designWrapper .doAction( controllerPath, action, parameters );
         const { shapes, embedding } = designWrapper .getScene( '--END--', true ); // never send camera or lighting!


### PR DESCRIPTION
Appbar layout was assuming classic, broken for online, browser, buildplane, etc.
I moved the menus & persistence title to an injected "spacer" slot for appbar.
Apps are now working, except for issues below.

The architecture for connectTrackballScene is finally right, using a special
controller action triggered in an effect from the Camera component.

Spurious trackball change events causing width=NaN is fixed, by making sure
that the callback only happens in the main LightedTrackballCanvas.

- no alert showing in apps
- open-change-save-reopen bug, losing parts of history