### PR TITLE
Saving designs temporarily disabled

### DIFF
--- a/online/src/app/classic/components/nosave.jsx
+++ b/online/src/app/classic/components/nosave.jsx
@@ -1,0 +1,34 @@
+
+import Dialog from '@suid/material/Dialog';
+import DialogActions from '@suid/material/DialogActions';
+import DialogContent from '@suid/material/DialogContent';
+import DialogContentText from '@suid/material/DialogContentText';
+import DialogTitle from '@suid/material/DialogTitle';
+import Button from '@suid/material/Button';
+
+export const NoSave = ( props ) =>
+{
+  const handleCancel = () =>
+  {
+    props.close();
+  }
+
+  return (
+    <Dialog open={props.show} onClose={handleCancel} aria-labelledby="form-dialog-title" >
+      <DialogTitle id="form-dialog-title">Save Not Supported</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          There is a bug in file saving, causing garbling of the command history.
+          Save is therefore disabled.  The bug will be fixed soon.
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleCancel} color="primary">
+          Cancel
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+} 
+
+

--- a/online/src/app/classic/menus/filemenu.jsx
+++ b/online/src/app/classic/menus/filemenu.jsx
@@ -8,6 +8,7 @@ import { UrlDialog } from '../components/webloader.jsx'
 import { fetchDesign, openDesignFile, newDesign, importMeshFile } from "../../../workerClient/index.js";
 import { useWorkerClient } from "../../../workerClient/index.js";
 import { Guardrail } from "../components/guardrail.jsx";
+import { NoSave } from "../components/nosave.jsx";
 
 const NewDesignItem = props =>
 {
@@ -26,6 +27,7 @@ export const FileMenu = () =>
   const [ showDialog, setShowDialog ] = createSignal( false );
   const fields = () => controllerProperty( rootController(), 'fields', 'fields', true );
   const [ showGuardrail, setShowGuardrail ] = createSignal( false );
+  const [ showNoSave, setShowNoSave ] = createSignal( true );
   const edited = () => controllerProperty( rootController(), 'edited' ) === 'true';
 
   // Since the initial render of the menu doesn't fetch these properties,
@@ -142,6 +144,7 @@ export const FileMenu = () =>
     <Menu label="File" dialogs={<>
       <UrlDialog show={showDialog()} setShow={setShowDialog} openDesign={openUrl} />
 
+      <NoSave show={showNoSave()} close={()=>setShowNoSave(false)} />
       <Guardrail show={showGuardrail()} close={closeGuardrail} />
     </>}>
         <SubMenu label="New Design...">
@@ -157,8 +160,8 @@ export const FileMenu = () =>
         <Divider/>
 
         <MenuAction label="Close" disabled={true} />
-        <MenuAction label="Save..." onClick={ () => doSave() } mods="⌘" key="S" />
-        <MenuAction label="Save As..." onClick={ () => doSave( true ) } />
+        <MenuAction label="Save..." onClick={ () => doSave() } mods="⌘" key="S" disabled={true} />
+        <MenuAction label="Save As..." onClick={ () => doSave( true ) } disabled={true} />
         <MenuAction label="Save Template..." disabled={true} />
 
         <Divider/>


### PR DESCRIPTION
Edit history is not serialized correctly.  Every classic design saved already is suspect,
so we don't want to make more of them.
