### PR TITLE
Fixed interpreter branch history bug

### DIFF
--- a/online/src/app/classic/components/beta.jsx
+++ b/online/src/app/classic/components/beta.jsx
@@ -6,7 +6,7 @@ import DialogContentText from '@suid/material/DialogContentText';
 import DialogTitle from '@suid/material/DialogTitle';
 import Button from '@suid/material/Button';
 
-export const NoSave = ( props ) =>
+export const Beta = ( props ) =>
 {
   const handleCancel = () =>
   {
@@ -15,16 +15,17 @@ export const NoSave = ( props ) =>
 
   return (
     <Dialog open={props.show} onClose={handleCancel} aria-labelledby="form-dialog-title" >
-      <DialogTitle id="form-dialog-title">Save Not Supported</DialogTitle>
+      <DialogTitle id="form-dialog-title">Beta Version</DialogTitle>
       <DialogContent>
         <DialogContentText>
-          There is a bug in file saving, causing garbling of the command history.
-          Save is therefore disabled.  The bug will be fixed soon.
+          vZome Online is still a beta release.
+          You can open most existing vZome design files, but not all of them.
+          If you open an existing file, never save back to the same file, to avoid corrupting it.
         </DialogContentText>
       </DialogContent>
       <DialogActions>
         <Button onClick={handleCancel} color="primary">
-          Cancel
+          Continue
         </Button>
       </DialogActions>
     </Dialog>

--- a/online/src/worker/legacy/controllers/index.js
+++ b/online/src/worker/legacy/controllers/index.js
@@ -1,7 +1,7 @@
 
 import { com } from '../core-java.js';
 import { documentFactory, parse } from '../core.js'
-import { interpret, RenderHistory, Step } from '../interpreter.js';
+import { EditCursor, interpret, RenderHistory, Step } from '../interpreter.js';
 import { ControllerWrapper } from './wrapper.js';
 import { getSceneIndex } from '../../vzome-worker-static.js';
 import { renderedModelTransducer, resolveBuildPlanes } from '../scenes.js';
@@ -69,12 +69,13 @@ export const loadDesign = ( xml, debug, clientEvents, sceneTitle ) =>
   clientEvents .xmlParsed( xmlTree );
   clientEvents .scenesDiscovered( scenes );
 
-  // the next step may take several seconds, which is why we already reported PARSE_COMPLETED
   const renderHistory = new RenderHistory( design );
   const renderingChanges = renderedModelTransducer( renderHistory.getShapes(), clientEvents );
+  const editCursor = new EditCursor( design );
 
   if ( ! debug ) {
-    interpret( Step.DONE, renderHistory, [] );
+    // interpretation may take several seconds, which is why we already reported PARSE_COMPLETED
+    interpret( Step.DONE, editCursor, renderHistory, [] );
   } // else in debug mode, we'll interpret incrementally
 
   // TODO: define a better contract for before/after.

--- a/online/src/worker/legacy/core.js
+++ b/online/src/worker/legacy/core.js
@@ -513,17 +513,13 @@ const makeFloatMatrices = ( matrices ) =>
     toolsXml && toolsModel.loadFromXml( toolsXml )
     // xml && console.log( xml .serialize( "" ) );
 
-    const interpretEdit = ( xmlElement, mesh ) =>
+    const interpretEdit = ( xmlElement, context ) =>
     {
       const wrappedElement = new JavaDomElement( xmlElement )
-      // Note that we do not do editor.setAdapter() yet.  This means that we cannot
-      //  deal with edits that have side-effects in their constructors!
       const edit = editFactory( editor, toolFactories, toolsModel )( wrappedElement )
       if ( ! edit )   // Null edit only happens for expected cases (e.g. "Shapshot"); others become CommandEdit.
         return null  //  Not indicating failure, just indicating nothing to record in history
-      // const { shown, selected, hidden, groups } = mesh
-      // editor.setAdapter( new Adapter( shown, selected, hidden, groups ) );
-      edit.loadAndPerform( wrappedElement, format, editContext )
+      edit.loadAndPerform( wrappedElement, format, context )
 
       checkSideEffects( edit, wrappedElement );
 

--- a/online/src/worker/legacy/edit.js
+++ b/online/src/worker/legacy/edit.js
@@ -1,5 +1,5 @@
 
-export class LegacyEdit
+export class ParsedEdit
 {
   constructor( txmlElement, parent, interpretEdit )
   {
@@ -11,7 +11,7 @@ export class LegacyEdit
     if ( kids.length === 1 && ( typeof kids[ 0 ] === 'string' ) )
       this.children = [];
     else
-      this.children = kids .map( child => new LegacyEdit( child, this, interpretEdit ) );
+      this.children = kids .map( child => new ParsedEdit( child, this, interpretEdit ) );
   }
 
   // these are for the interpreter
@@ -39,17 +39,9 @@ export class LegacyEdit
     return this.parentEdit.children[ next ];
   }
 
-  perform( mesh )
+  perform( context )
   {
-    this.legacyEdit = this.interpret.call( this, this.nativeElement, mesh );
-  }
-
-  undoChildren()
-  {
-    for ( let index = this.children.length-1; index >= 0; index--) {
-      const edit = this.children[ index ] .legacyEdit;
-      edit && edit .undo();
-    }
+    this.legacyEdit = this.interpret.call( this, this.nativeElement, context );
   }
 
   // these are for the debugger UI
@@ -57,6 +49,11 @@ export class LegacyEdit
   name()
   {
     return this.nativeElement.tagName;
+  }
+
+  toString()
+  {
+    return this.name();
   }
 
   getAttributeNames()

--- a/online/src/worker/legacy/parser.js
+++ b/online/src/worker/legacy/parser.js
@@ -1,5 +1,5 @@
 
-import { LegacyEdit } from './edit.js';
+import { ParsedEdit } from './edit.js';
 import * as txml from 'txml/dist/txml.mjs';
 import { JavaDomElement } from './dom.js';
 
@@ -124,7 +124,7 @@ export const createParser = ( documentFactory ) => ( xmlText ) =>
 
   const historyElement = vZomeRoot.getChildElement( "EditHistory" ) || vZomeRoot.getChildElement( "editHistory" ) || vZomeRoot.getChildElement( "EditHistoryDetails" );
   const xmlTree = assignIds( historyElement.nativeElement );
-  const edits = new LegacyEdit( xmlTree, null, design.interpretEdit );
+  const edits = new ParsedEdit( xmlTree, null, design.interpretEdit );
   const targetEditId = `:${edits.getAttribute( "editNumber" )}:`
   const firstEdit = edits.firstChild()
 


### PR DESCRIPTION
The interpreter was simply not adding branches to the history, since it wasn't built
to faithfully reproduce the history for saving again.

I split EditCursor out of RenderHistory, since they really are different functions.
I still want to merge interpret() and EditCursor into "Interpreter", but that can wait.
The EditCursor already cleans up the interpreter step() function a fair bit.

RenderHistory is no longer able to perform interpret() in order to render a scene
that was not captured yet, as when the debugger is in use.  I'll have to do more
refactoring to make that work, and it needs more thought.

RenderHistory could be optimized (for non-debugger use) to only capture scenes
for snapshots and the targetEdit state.

I renamed LegacyEdit as ParsedEdit.

I added a Beta Version warning dialog.

I disabled the handle recording after open, so people don't corrupt existing files
in the event of a save bug.  I also fixed the file name after saveAs, to match the handle.