### PR TITLE
Better error handling on open / openURL

### DIFF
--- a/online/src/worker/legacy/core.js
+++ b/online/src/worker/legacy/core.js
@@ -515,6 +515,8 @@ const makeFloatMatrices = ( matrices ) =>
 
     const interpretEdit = ( xmlElement, context ) =>
     {
+      if ( xmlElement .tagName === 'RunZomicScript' )
+        throw new Error( 'Zomic script commands are not yet supported in Online.' );
       const wrappedElement = new JavaDomElement( xmlElement )
       const edit = editFactory( editor, toolFactories, toolsModel )( wrappedElement )
       if ( ! edit )   // Null edit only happens for expected cases (e.g. "Shapshot"); others become CommandEdit.


### PR DESCRIPTION
The design name is only set when the interpreter has succeeded.

I added a specific error for RunZomicScript commands.
