### PR TITLE
Fix export-menu click problem

### DIFF
--- a/online/src/viewer/solid/export.jsx
+++ b/online/src/viewer/solid/export.jsx
@@ -1,7 +1,7 @@
 
 import { DropdownMenu } from "@kobalte/core";
 
-import { saveFileAs, serializeVZomeXml, useWorkerClient } from "../../workerClient";
+import { saveFileAs, useWorkerClient } from "../../workerClient";
 
 export const ExportMenu = (props) =>
 {
@@ -20,7 +20,7 @@ export const ExportMenu = (props) =>
   }
 
   return (
-    <DropdownMenu.Root modal={false}>
+    <DropdownMenu.Root modal={true}>
       <DropdownMenu.Trigger class="exports__trigger corner__icon__button">
         <svg focusable="false" viewBox="0 0 24 24" aria-hidden="true">
           <path d="M16.59 9H15V4c0-.55-.45-1-1-1h-4c-.55 0-1 .45-1 1v5H7.41c-.89 0-1.34 1.08-.71 1.71l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.63-.63.19-1.71-.7-1.71zM5 19c0 .55.45 1 1 1h12c.55 0 1-.45 1-1s-.45-1-1-1H6c-.55 0-1 .45-1 1z"></path>


### PR DESCRIPTION
By making it modal, now the menu responds correctly to clicks, even for multiple
instances on a page.  The only downside is that the scrollbar for the page disappears,
so everything jumps by 15px.
