### PR TITLE
Adding MathML support

### DIFF
--- a/core/src/main/java/com/vzome/core/algebra/AbstractAlgebraicField.java
+++ b/core/src/main/java/com/vzome/core/algebra/AbstractAlgebraicField.java
@@ -892,4 +892,49 @@ public abstract class AbstractAlgebraicField implements AlgebraicField
         }
         return new AlgebraicSeries( this, power );
     }
+
+    public String getMathML( BigRational[] factors )
+    {
+        StringBuffer buf = new StringBuffer();
+        int first = 0;
+        for ( int i = 0; i < factors.length; i++ )
+        {
+            BigRational factor = factors[ i ];
+            if ( factor .isZero() ) {
+                ++ first;
+                continue;
+            }
+            
+            if ( factor .isNegative() )
+            {
+                factor = factor .negate();
+                buf .append( "<mo>-</mo>" );
+            }
+            else if ( i > first )
+            {
+                buf .append( "<mo>+</mo>" );
+            }
+            
+            if ( i == 0 )
+                buf .append( factor .getMathML() );
+            else
+            {
+                if ( ! factor .isOne() )
+                {
+                    buf .append( factor .getMathML() );
+                }
+                String multiplier = this .getIrrational( i, DEFAULT_FORMAT );
+                buf .append( "<mi>" );
+                buf .append( multiplier );
+                buf .append( "</mi>" );
+            }
+        }
+        if ( first == factors.length )
+            // all factors were zero
+            return "<mn>0</mn>";
+        else if ( factors.length - first > 1 )
+            return "<mrow>" + buf .toString() + "</mrow>";
+        else
+            return buf .toString();
+    }
 }

--- a/core/src/main/java/com/vzome/core/algebra/AlgebraicNumberImpl.java
+++ b/core/src/main/java/com/vzome/core/algebra/AlgebraicNumberImpl.java
@@ -592,4 +592,10 @@ public class AlgebraicNumberImpl implements AlgebraicNumber
             }
         }
     }
+
+    @Override
+    public String getMathML()
+    {
+        return field .getMathML( factors );
+    }
 }

--- a/core/src/main/java/com/vzome/core/algebra/BigRationalImpl.java
+++ b/core/src/main/java/com/vzome/core/algebra/BigRationalImpl.java
@@ -614,13 +614,24 @@ public class BigRationalImpl implements Comparable<BigRationalImpl>, BigRational
 
     private static String toString(BigRationalImpl that)
     {
-        return (that.bigNum == null) 
-                ? that.den == 1
-                ? Long.toString(that.num)
-                        : that.num + "/" + that.den
-                        : that.bigDen .equals( BigInteger.ONE )
-                        ? that.bigNum.toString()
-                                : that.bigNum + "/" + that.bigDen;
+        return ( that.bigNum == null )?
+                that.den == 1 ?
+                    Long.toString(that.num)
+                   :that.num + "/" + that.den
+               :that.bigDen .equals( BigInteger.ONE )?
+                    that.bigNum.toString()
+                   :that.bigNum + "/" + that.bigDen;
+    }
+
+    public String getMathML()
+    {
+        return ( this.bigNum == null )?
+                this.den == 1 ?
+                    "<mn>" + Long.toString(this.num) + "</mn>"
+                   :"<mfrac><mn>" + this.num + "</mn><mn>" + this.den + "</mn></mfrac>"
+               :this.bigDen .equals( BigInteger.ONE )?
+                    "<mn>" + this.bigNum.toString() + "</mn>"
+                   :"<mfrac><mn>" + this.bigNum + "</mn><mn>" + this.bigDen + "</mn></mfrac>";
     }
 
     /**

--- a/core/src/main/java/com/vzome/core/algebra/Fields.java
+++ b/core/src/main/java/com/vzome/core/algebra/Fields.java
@@ -33,6 +33,8 @@ public class Fields
         boolean isOne();
 
         double evaluate();
+        
+        String getMathML();
     }
 
     public static final int rows(Object[][] matrix) {

--- a/core/src/test/java/com/vzome/core/algebra/AlgebraicNumberTest.java
+++ b/core/src/test/java/com/vzome/core/algebra/AlgebraicNumberTest.java
@@ -32,16 +32,19 @@ public class AlgebraicNumberTest
             AlgebraicNumber zero = field.zero();
             assertTrue(zero.isZero());
             assertFalse(zero.isOne());
+            assertEquals( "<mn>0</mn>", zero .getMathML() );
         }
         {
             AlgebraicNumber one = field.one();
             assertFalse(one.isZero());
             assertTrue(one.isOne());
+            assertEquals( "<mn>1</mn>", one .getMathML() );
         }
         {
             AlgebraicNumber phi = field.createAlgebraicNumber(new int[]{0, 1});
             assertFalse(phi.isZero());
             assertFalse(phi.isOne());
+            assertEquals( "<mi>φ</mi>", phi .getMathML() );
         }
     }
 
@@ -90,6 +93,7 @@ public class AlgebraicNumberTest
         assertEquals("-7/5 +3/5*phi", n1.toString(EXPRESSION_FORMAT));
         assertEquals("-7/5 3/5", n1.toString(ZOMIC_FORMAT));
         assertEquals("(3/5,-7/5)", n1.toString(VEF_FORMAT)); // irrational is listed first in VEF format
+        assertEquals( "<mrow><mo>-</mo><mfrac><mn>7</mn><mn>5</mn></mfrac><mo>+</mo><mfrac><mn>3</mn><mn>5</mn></mfrac><mi>φ</mi></mrow>", n1 .getMathML() );
     }
 
     @Test
@@ -340,24 +344,28 @@ public class AlgebraicNumberTest
         assertEquals( "11/3 +5/2*phi", number.toString( AlgebraicField.EXPRESSION_FORMAT ) );
         assertEquals( "11/3 5/2", number.toString( AlgebraicField.ZOMIC_FORMAT ) );
         assertEquals( "(5/2,11/3)", number.toString( AlgebraicField.VEF_FORMAT ) );
-        
+        assertEquals( "<mrow><mfrac><mn>11</mn><mn>3</mn></mfrac><mo>+</mo><mfrac><mn>5</mn><mn>2</mn></mfrac><mi>φ</mi></mrow>", number .getMathML() );
+
         number = field .createRational( 0 );
 
         assertEquals( "0", number.toString( AlgebraicField.DEFAULT_FORMAT ) );
         assertEquals( "0", number.toString( AlgebraicField.EXPRESSION_FORMAT ) );
         assertEquals( "0 0", number.toString( AlgebraicField.ZOMIC_FORMAT ) );
         assertEquals( "(0,0)", number.toString( AlgebraicField.VEF_FORMAT ) );
-        
+        assertEquals( "<mn>0</mn>", number .getMathML() );
+
         number = field .createAlgebraicNumber( new int[]{1, 0} );
 
         assertEquals( "1", number.toString( AlgebraicField.DEFAULT_FORMAT ) );
         assertEquals( "1", number.toString( AlgebraicField.EXPRESSION_FORMAT ) );
+        assertEquals( "<mn>1</mn>", number .getMathML() );
         
         number = field .createAlgebraicNumber( new int[]{0, 1} );
 
         assertEquals( "\u03C6", number.toString( AlgebraicField.DEFAULT_FORMAT ) );
         assertEquals( "phi", number.toString( AlgebraicField.EXPRESSION_FORMAT ) );
-        
+        assertEquals( "<mi>φ</mi>", number .getMathML() );
+
         field = new HeptagonField();
         number = field .createAlgebraicNumber( new int[]{ 6, 11, 14 } );
         
@@ -365,7 +373,8 @@ public class AlgebraicNumberTest
         assertEquals( "6 +11*rho +14*sigma", number.toString( AlgebraicField.EXPRESSION_FORMAT ) );
         assertEquals( "6 11 14", number.toString( AlgebraicField.ZOMIC_FORMAT ) );
         assertEquals( "(14,11,6)", number.toString( AlgebraicField.VEF_FORMAT ) );
-        
+        assertEquals( "<mrow><mn>6</mn><mo>+</mo><mn>11</mn><mi>ρ</mi><mo>+</mo><mn>14</mn><mi>σ</mi></mrow>", number .getMathML() );
+
         field = new SnubDodecField( AlgebraicNumberImpl.FACTORY );
         number = field .createAlgebraicNumber( new int[]{ -12, 8, 2, -1, 6, -4 } );
         
@@ -373,21 +382,25 @@ public class AlgebraicNumberTest
         assertEquals( "-12 +8*phi +2*xi -phi*xi +6*xi^2 -4*phi*xi^2", number.toString( AlgebraicField.EXPRESSION_FORMAT ) );
         assertEquals( "-12 8 2 -1 6 -4", number.toString( AlgebraicField.ZOMIC_FORMAT ) );
         assertEquals( "(-4,6,-1,2,8,-12)", number.toString( AlgebraicField.VEF_FORMAT ) );
+        assertEquals( "<mrow><mo>-</mo><mn>12</mn><mo>+</mo><mn>8</mn><mi>φ</mi><mo>+</mo><mn>2</mn><mi>ξ</mi><mo>-</mo><mi>φξ</mi><mo>+</mo><mn>6</mn><mi>ξ²</mi><mo>-</mo><mn>4</mn><mi>φξ²</mi></mrow>", number .getMathML() );
 
         number = field .createAlgebraicNumber( new int[]{0, 0, 0, 0, 0, 0} );
         
         assertEquals( "0", number.toString( AlgebraicField.DEFAULT_FORMAT ) );
         assertEquals( "0", number.toString( AlgebraicField.EXPRESSION_FORMAT ) );
+        assertEquals( "<mn>0</mn>", number .getMathML() );
 
         number = field .createAlgebraicNumber( new int[]{0, 0, 1, 0, 0, 0} );
         
         assertEquals( "\u03BE", number.toString( AlgebraicField.DEFAULT_FORMAT ) );
         assertEquals( "xi", number.toString( AlgebraicField.EXPRESSION_FORMAT ) );
+        assertEquals( "<mi>ξ</mi>", number .getMathML() );
 
         number = field .createAlgebraicNumber( new int[]{0, 1, 0, 0, 0, 1} );
         
         assertEquals( "\u03C6 +\u03C6\u03BE\u00B2", number.toString( AlgebraicField.DEFAULT_FORMAT ) );
         assertEquals( "phi +phi*xi^2", number.toString( AlgebraicField.EXPRESSION_FORMAT ) );
+        assertEquals( "<mrow><mi>φ</mi><mo>+</mo><mi>φξ²</mi></mrow>", number .getMathML() );
     }
 
     @Test

--- a/desktop/src/main/java/com/vzome/desktop/controller/LengthController.java
+++ b/desktop/src/main/java/com/vzome/desktop/controller/LengthController.java
@@ -344,7 +344,14 @@ public class LengthController extends DefaultController
             result = applyScales( result );
             return readable( result );
         }
-    
+        
+        case "lengthMathML":
+        {
+            AlgebraicNumber result = this .unitFactor;
+            result = applyScales( result );
+            return result .getMathML();
+        }
+
         case "scaleFactorHtml":
         {
             String html = "";

--- a/online/src/app/classic/components/length.jsx
+++ b/online/src/app/classic/components/length.jsx
@@ -1,5 +1,5 @@
 
-import { Show, createEffect, createSignal, Switch as Case, Match } from 'solid-js';
+import { Show, createEffect, createSignal, Switch as Case, Match, createMemo } from 'solid-js';
 
 import Button from '@suid/material/Button';
 import Switch from '@suid/material/Switch';
@@ -106,7 +106,12 @@ export const StrutLengthPanel = props =>
   const realScale = () => controllerProperty( lengthController(), 'scale', 'length', false );
   const unitText = () => controllerProperty( lengthController(), 'unitText', 'length', false );
   const scaleFactorHtml = () => controllerProperty( lengthController(), 'scaleFactorHtml', 'length', false );
-  const lengthText = () => controllerProperty( lengthController(), 'lengthText', 'length', false );
+  const lengthText = () => controllerProperty( lengthController(), 'lengthMathML', 'length', false );
+  const mathML = createMemo( () => {
+    const el = <math></math>;
+    el .innerHTML = lengthText();
+    return el;
+  })
 
   const [ scale, setScale ] = createSignal(0); // TODO should be realScale()?
   createEffect( () => {
@@ -198,7 +203,7 @@ export const StrutLengthPanel = props =>
       <div id='length-display' style={{ 'background-color': 'whitesmoke', 'margin-left': '1em' }}>
         <div style={{ 'min-height': '22px' }}><span>unit  = </span><span class='bold'>{unitText()}</span></div>
         <div style={{ 'min-height': '22px' }}>{scaleFactorHtml()} unit</div>
-        <div style={{ 'min-height': '22px', 'margin-left': '1em' }}>=  <span class='bold'>{lengthText()}</span></div>
+        <div style={{ 'min-height': '30px', 'margin-left': '1em' }}>=  <span class='bold'>{mathML()}</span></div>
       </div>
     </div>
     </Show>

--- a/online/src/worker/fields/golden.js
+++ b/online/src/worker/fields/golden.js
@@ -78,11 +78,12 @@ const createQuaternions = ({ scalarmul, quatmul }) =>
   return vZomeIcosahedralQuaternions
 }
 
-const baseField = createField( { name: 'golden', order: 2, times, embed, reciprocal } )
+const getIrrational = () => 'φ';
+
+const baseField = createField( { name: 'golden', order: 2, times, embed, reciprocal, getIrrational } )
 
 const field = {
   ...baseField,
-  getIrrational: () => 'φ',
   goldenRatio: [ 0n, 1n, 1n ],
   quaternions: createQuaternions( baseField ),
   goldenSeries: goldenSeries( baseField )

--- a/online/src/worker/fields/heptagon.js
+++ b/online/src/worker/fields/heptagon.js
@@ -33,6 +33,6 @@ function embed( a )
 
 const getIrrational = (i) => (i===1)? '𝜌' : '𝜎';
 
-const field = { ...createField( { name: 'heptagon', order: 3, times, embed, reciprocal } ), getIrrational }
+const field = createField( { name: 'heptagon', order: 3, times, embed, reciprocal, getIrrational } );
 
 export default field

--- a/online/src/worker/fields/root2.js
+++ b/online/src/worker/fields/root2.js
@@ -23,6 +23,6 @@ function embed( a )
 
 const getIrrational = () => '√2';
 
-const field = { ...createField( { name: 'rootTwo', order: 2, times, embed, reciprocal } ), getIrrational }
+const field = createField( { name: 'rootTwo', order: 2, times, embed, reciprocal, getIrrational } );
 
 export default field

--- a/online/src/worker/fields/root3.js
+++ b/online/src/worker/fields/root3.js
@@ -23,6 +23,6 @@ function embed( a )
 
 const getIrrational = () => '√3';
 
-const field = { ...createField( { name: 'rootThree', order: 2, times, embed, reciprocal } ), getIrrational }
+const field = createField( { name: 'rootThree', order: 2, times, embed, reciprocal, getIrrational } );
 
 export default field

--- a/online/src/worker/java/com/vzome/jsweet/JsAlgebraicField.java
+++ b/online/src/worker/java/com/vzome/jsweet/JsAlgebraicField.java
@@ -110,6 +110,12 @@ public class JsAlgebraicField implements AlgebraicField
         return (String) f.$apply( any( factors ), any( format ) );
     }
 
+    public String getMathML( int[] v1 )
+    {
+        Function f = (Function) this.delegate .$get( "toString" );
+        return (String) f.$apply( any( v1 ), any( 4 ) );
+    }
+
     @Override
     public AlgebraicNumber zero()
     {

--- a/online/src/worker/java/com/vzome/jsweet/JsAlgebraicNumber.java
+++ b/online/src/worker/java/com/vzome/jsweet/JsAlgebraicNumber.java
@@ -172,6 +172,12 @@ public class JsAlgebraicNumber implements AlgebraicNumber
     }
 
     @Override
+    public String getMathML()
+    {
+      return this.field .getMathML( this.factors );
+    }
+
+    @Override
     public int compareTo( AlgebraicNumber other )
     {
         if ( this == other ) {

--- a/online/src/worker/legacy/jsweet2js.js
+++ b/online/src/worker/legacy/jsweet2js.js
@@ -231,6 +231,11 @@ class JavaAlgebraicNumber
     this.getNumberExpression( buf, format );
     return buf .toString();
   }
+
+  getMathML()
+  {
+    return this.legacyField .getMathML( this.bigRationals );
+  }
 }
 JavaAlgebraicNumber.__interfaces = [ "com.vzome.core.algebra.AlgebraicNumber" ]
 
@@ -254,6 +259,14 @@ class JavaBigRational
       return this.num.toString()
     else
       return this.num.toString() + "/" + this.denom.toString()
+  }
+
+  getMathML()
+  {
+    if ( this.denom === 1n )
+      return `<mn>${this.num.toString()}</mn>`
+    else
+      return `<mfrac><mn>${this.num.toString()}</mn><mn>${this.denom.toString()}</mn></mfrac>`
   }
 
   evaluate()


### PR DESCRIPTION
Every Field.Element (like AN or BR) now supports `getMathML`.  The result is ready to
be placed inside `<math>...</math>` or any other bit of MathML.  A `<mrow>` is
automatically added when necessary.

Along the way, I corrected the use of `getIrrational` in the JS field implementations.

Finally, the MathML output is now used in Online classic, to display the final strut length.
