### PR TITLE
Fixed new defect in classic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,5 @@ online/public/modules/
 online/public/resources/
 
 online/public/classic/resources/
+
+developer-docs/notes/vZome/.obsidian/

--- a/online/src/viewer/solid/geometry.jsx
+++ b/online/src/viewer/solid/geometry.jsx
@@ -147,7 +147,7 @@ export const ShapedGeometry = ( props ) =>
   )
 };
 
-const GltfExportContext = createContext( {} );
+const GltfExportContext = createContext( { setExporter: ()=>{}, exporter: ()=>{} } );
 
 export const GltfExportProvider = (props) =>
 {


### PR DESCRIPTION
The GltfExportContext needed a complete default, for use in Classic.

TODO: add the glTF export to the file menu