### PR TITLE
Restore left-side grid layout to fix aspect ratio bug

### DIFF
--- a/online/src/app/59icosahedra/index.jsx
+++ b/online/src/app/59icosahedra/index.jsx
@@ -111,7 +111,7 @@ const App = () => (
       </> } />
     <div id='selectors-and-model' style={{ position: 'relative', display: 'grid', 'grid-template-columns': '2fr 3fr', height: '100%' }}>
       <CellOrbitProvider>
-        <div id='text-and-selectors' style={{ display: 'grid', 'grid-template-rows': '15% 85%', height: '100%',
+        <div id='text-and-selectors' style={{ display: 'grid', 'grid-template-rows': '20% 80%', height: '100%',
             'border-right': '2px solid darkgrey' }}>
           <div>
             <Typography gutterBottom sx={{ margin: '1em' }}>


### PR DESCRIPTION
I don't really know what's happening, but this change gives a much wider range of aspect ratios
that lay out correctly.  It still goes bad for portrait mode on a phone.
