### PR TITLE
Removing circular module dependency

### DIFF
--- a/online/src/worker/legacy/controllers/index.js
+++ b/online/src/worker/legacy/controllers/index.js
@@ -3,7 +3,6 @@ import { com } from '../core-java.js';
 import { documentFactory, parse } from '../core.js'
 import { EditCursor, interpret, RenderHistory, Step } from '../interpreter.js';
 import { ControllerWrapper } from './wrapper.js';
-import { getSceneIndex } from '../../vzome-worker-static.js';
 import { renderedModelTransducer, resolveBuildPlanes } from '../scenes.js';
 import { EditorController } from './editor.js';
 
@@ -58,6 +57,29 @@ const createControllers = ( design, renderingChanges, clientEvents ) =>
 
   return wrapper;
 };
+
+// Duplicated here to avoid a weird dependency back to the static module.
+const getSceneIndex = ( title, list ) =>
+{
+  if ( !title )
+    return 0;
+  let index;
+  if ( title.startsWith( '#' ) ) {
+    const indexStr = title.substring( 1 );
+    index = parseInt( indexStr );
+    if ( isNaN( index ) || index < 0 || index > list.length ) {
+      console.log( `WARNING: ${index} is not a scene index` );
+      index = 0;
+    }
+  } else {
+    index = list .map( s => s.title ) .indexOf( title );
+    if ( index < 0 ) {
+      console.log( `WARNING: no scene titled "${title}"` );
+      index = 0;
+    }
+  }
+  return index;
+}
 
 export const loadDesign = ( xml, debug, clientEvents, sceneTitle ) =>
 {

--- a/online/src/worker/vzome-worker-static.js
+++ b/online/src/worker/vzome-worker-static.js
@@ -1,6 +1,8 @@
 
 import { resourceIndex, importLegacy } from '../revision.js';
 
+const uniqueId = Math.random();
+
 // support trampolining to work around worker CORS issue
 //   see https://github.com/evanw/esbuild/issues/312#issuecomment-1025066671
 export const WORKER_ENTRY_FILE_URL = import.meta.url;
@@ -22,7 +24,7 @@ const captureScenes = report => event =>
 }
 
 
-export const getSceneIndex = ( title, list ) =>
+const getSceneIndex = ( title, list ) =>
 {
   if ( !title )
     return 0;
@@ -216,6 +218,7 @@ const fetchTrackballScene = ( url, report ) =>
 
 const connectTrackballScene = ( report ) =>
 {
+  console.log( "call", uniqueId );
   const trackballUpdater = () => fetchTrackballScene( designWrapper .getTrackballUrl(), report );
   trackballUpdater();
   designWrapper.controller .addPropertyListener( { propertyChange: pce =>
@@ -249,6 +252,7 @@ const openDesign = async ( xmlLoading, name, report, debug, sceneTitle ) =>
       }
       report( { type: 'CONTROLLER_CREATED' } ); // do we really need this for previewing?
       designWrapper = module .loadDesign( xml, debug, clientEvents( captureScenes( report ) ), sceneTitle );
+      console.log( "open", uniqueId );
       report( { type: 'TEXT_FETCHED', payload: { text: xml, name } } ); // NOW it is safe to send the name
     } )
 
@@ -414,6 +418,7 @@ onmessage = ({ data }) =>
         return;
       }
       try {
+        console.log( "action", uniqueId );
         designWrapper .doAction( controllerPath, action, parameters );
         const { shapes, embedding } = designWrapper .getScene( '--END--', true ); // never send camera or lighting!
         postMessage( { type: 'SCENE_RENDERED', payload: { scene: { shapes, embedding } } } );


### PR DESCRIPTION
The `vzome-legacy` module was importing `getSceneIndex` from the static worker
module, which is also the module that imports `vzome-legacy` dynamically.  This
is harmless in normal situations, but disastrous in the "quick" workflow, which loads
the dynamic module from `vzome.com`.  It results in very odd behavior, since two
copies of the same module are present at runtime.

This change is the most obvious, simple way to fix the dependency, but needing the
`getSceneIndex` function in both places does point at a leaking abstraction boundary.
