### PR TITLE
Implemented `load-camera` attribute on web component

### DIFF
--- a/online/public/test/regression.html
+++ b/online/public/test/regression.html
@@ -70,7 +70,7 @@
 
   </head>
   <body>
-    <vzome-viewer id="controlled" show-scenes="true" >
+    <vzome-viewer id="controlled" show-scenes="true" load-camera="once" >
     </vzome-viewer>
     <p>Failures:</p>
     <ul id="failures">

--- a/online/src/viewer/solid/index.jsx
+++ b/online/src/viewer/solid/index.jsx
@@ -41,7 +41,7 @@ const fullScreenStyle = {
 
 const DesignViewer = ( props ) =>
 {
-  const config = mergeProps( { showScenes: false, useSpinner: false, allowFullViewport: false, undoRedo: false }, props.config );
+  const config = mergeProps( { showScenes: false, useSpinner: false, allowFullViewport: false, undoRedo: false, loadCamera: 'always' }, props.config );
   const { state, subscribeFor } = useWorkerClient();
   const { state: cameraState, setCamera, setLighting } = useCamera();
   const [ fullScreen, setFullScreen ] = createSignal( false );
@@ -74,9 +74,14 @@ const DesignViewer = ( props ) =>
     }
   });
 
+  let cameraLoaded = false;
   subscribeFor( 'SCENE_RENDERED', ( { scene } ) => {
     if ( scene.camera ) {
-      setCamera( scene.camera );
+      const { loadCamera } = props.config;
+      if ( loadCamera === 'always' || ( loadCamera === 'once' && !cameraLoaded ) ) {
+        setCamera( scene.camera );
+        cameraLoaded = true;
+      }
     }
     if ( scene.lighting ) {
       const { backgroundColor } = scene.lighting;

--- a/online/src/viewer/solid/ltcanvas.jsx
+++ b/online/src/viewer/solid/ltcanvas.jsx
@@ -31,7 +31,6 @@ const Lighting = () =>
 const LightedCameraControls = (props) =>
 {
   const { perspectiveProps, trackballProps, name } = useCamera();
-  console.log( 'LightedCameraControls sees', name );
   const [ tool ] = useInteractionTool();
   const enableTrackball = () => ( tool === undefined ) || tool().allowTrackball;
   props = mergeProps( { rotateSpeed: 4.5, zoomSpeed: 3, panSpeed: 1 }, props );

--- a/online/src/viewer/solid/perspectivecamera.jsx
+++ b/online/src/viewer/solid/perspectivecamera.jsx
@@ -9,34 +9,34 @@ export const PerspectiveCamera = (props) =>
   const set = useThree(({ set }) => set);
   const camera = useThree(({ camera }) => camera);
   const size = useThree(({ size }) => size);
-  console.log( 'PerspectiveCamera sees', props.name );
+  // console.log( 'PerspectiveCamera sees', props.name );
 
   let cam;
 
   createEffect( () => {
-    console.log( props.name, 'PerspectiveCamera lookAt' );
+    // console.log( props.name, 'PerspectiveCamera lookAt' );
     const [ x, y, z ] = props.target;
     cam .lookAt( x, y, z );
 
-    {
-      console.log( props.name, 'look at', JSON.stringify( props.target ) );
-      console.log( props.name, 'position', JSON.stringify( cam.position ) );
-    }
+    // {
+    //   console.log( props.name, 'look at', JSON.stringify( props.target ) );
+    //   console.log( props.name, 'position', JSON.stringify( cam.position ) );
+    // }
   });
 
   createEffect(() => {
-    console.log( props.name, 'PerspectiveCamera updateProjectionMatrix' );
+    // console.log( props.name, 'PerspectiveCamera updateProjectionMatrix' );
     cam.near = props.near;
     cam.far = props.far;
     cam.fov = props.fov;
     cam.aspect = size().width / size().height;
     cam.updateProjectionMatrix();
 
-    {
-      const { near, far, fov, aspect } = cam;
-      console.log( props.name, 'zoom', JSON.stringify( { near, far, fov, aspect }, null, 2 ) );
-      console.log( props.name, 'position', JSON.stringify( cam.position ) );
-    }
+    // {
+    //   const { near, far, fov, aspect } = cam;
+    //   console.log( props.name, 'zoom', JSON.stringify( { near, far, fov, aspect }, null, 2 ) );
+    //   console.log( props.name, 'position', JSON.stringify( cam.position ) );
+    // }
   });
 
   createEffect(() => {

--- a/online/src/wc/vzome-viewer.js
+++ b/online/src/wc/vzome-viewer.js
@@ -47,7 +47,7 @@ export class VZomeViewer extends HTMLElement
     } );
     this.#store = createWorkerStore( worker );
 
-    this.#config = { preview: true, showScenes: false };
+    this.#config = { preview: true, showScenes: false, loadCamera: 'always', };
 
     if ( this.hasAttribute( 'show-scenes' ) ) {
       const showScenes = this.getAttribute( 'show-scenes' ) === 'true';
@@ -57,6 +57,11 @@ export class VZomeViewer extends HTMLElement
     if ( this.hasAttribute( 'scene' ) ) {
       const sceneTitle = this.getAttribute( 'scene' );
       this.#config = { ...this.#config, sceneTitle };
+    }
+
+    if ( this.hasAttribute( 'load-camera' ) ) {
+      let loadCamera = this.getAttribute( 'load-camera' );
+      this.#config = { ...this.#config, loadCamera };
     }
 
     if ( this.hasAttribute( 'src' ) ) {
@@ -84,7 +89,7 @@ export class VZomeViewer extends HTMLElement
 
   static get observedAttributes()
   {
-    return [ "src", "show-scenes", "scene" ];
+    return [ "src", "show-scenes", "scene", "load-camera" ];
   }
 
   attributeChangedCallback( attributeName, _oldValue, _newValue )
@@ -99,6 +104,14 @@ export class VZomeViewer extends HTMLElement
       }
       break;
 
+    case "load-camera":
+      if ( _newValue !== this.#config.loadCamera ) {
+        this.#config = { ...this.#config, loadCamera: _newValue };
+        // re-fetch because that's the only time loadCamera applies
+        this.#store.postMessage( fetchDesign( this.#url, this.#config ) );
+      }
+      break;
+  
     case "scene":
       if ( _newValue !== this.#config.sceneTitle ) {
         this.#config = { ...this.#config, sceneTitle: _newValue };
@@ -157,6 +170,20 @@ export class VZomeViewer extends HTMLElement
   get showScenes()
   {
     return this.getAttribute( "show-scenes" );
+  }
+
+  set loadCamera( newValue )
+  {
+    if ( newValue === null ) {
+      this.removeAttribute( "load-camera" );
+    } else {
+      this.setAttribute( "load-camera", newValue );
+    }
+  }
+
+  get loadCamera()
+  {
+    return this.getAttribute( "load-camera" );
   }
 }
 

--- a/online/src/worker/vzome-worker-static.js
+++ b/online/src/worker/vzome-worker-static.js
@@ -252,7 +252,6 @@ const openDesign = async ( xmlLoading, name, report, debug, sceneTitle ) =>
       }
       report( { type: 'CONTROLLER_CREATED' } ); // do we really need this for previewing?
       designWrapper = module .loadDesign( xml, debug, clientEvents( captureScenes( report ) ), sceneTitle );
-      console.log( "open", uniqueId );
       report( { type: 'TEXT_FETCHED', payload: { text: xml, name } } ); // NOW it is safe to send the name
     } )
 

--- a/online/src/workerClient/camera.jsx
+++ b/online/src/workerClient/camera.jsx
@@ -108,7 +108,6 @@ const CameraProvider = ( props ) =>
       const { up, lookDir } = props.context.state.camera;
       setState( 'camera', { up, lookDir } );
       injectCameraState( state.camera, trackballCamera );
-      console.log( props.name, 'synced rotation from context' );
     });
   }
 
@@ -122,7 +121,6 @@ const CameraProvider = ( props ) =>
     // I had a nasty bug for days because I used lookAt by reference, causing the CameraControls canvas
     //  to respond very oddly to shared rotations.
     setPerspectiveProps( { position, up, target: [ ...lookAt ], near, far } );
-    console.log( props.name, 'setPerspectiveProps' );
   })
 
   const trackballCamera = new PerspectiveCamera(); // for the TrackballControls only, never used to render
@@ -135,7 +133,6 @@ const CameraProvider = ( props ) =>
     const { up, lookDir } = extractedCamera;
     if ( !! props.context ) {
       props.context.setCamera( { up, lookDir } );
-      console.log( props.name, 'synced rotation up to context' );
     } else {
       setState( 'camera', extractedCamera );
     }


### PR DESCRIPTION
The default value is `always`, which produces the existing behavior, where the
camera loaded from a design overwrites the current camera state.  A value of `once`
means that that happens on the first design load, but not thereafter... the camera
state will remain undisturbed by loading a design.  Any other value equates to `never`.

I also removed some logging left over from the camera state work.
