### PR TITLE
Improved vzome-viewer API

### DIFF
--- a/online/public/test/index.html
+++ b/online/public/test/index.html
@@ -7,18 +7,56 @@
     <script type="module">
       import "/modules/vzome-viewer.js"; // registers the custom element
 
-      const viewer = document.querySelector( "#vZomeLogo" );
-      viewer .addEventListener( "vzome-scenes-discovered", (e) => {
+      const logoViewer = document.querySelector( "#vZomeLogo" );
+      logoViewer .addEventListener( "vzome-scenes-discovered", (e) => {
         setTimeout( () => {
           console.log( 'Scenes:', JSON.stringify( e.detail ) );
-          viewer.scene = e.detail[ 3 ];
+          logoViewer.scene = e.detail[ 3 ];
         }, 3000 )
       });
+
+      let scenes;
+      let index = 1; // Yes, skipping the default scene 0 intentionally
+      let camera = false;
+
+      const prevButton = document.querySelector( "#prev" );
+      const nextButton = document.querySelector( "#next" );
+      const title = document.querySelector( "#title" );
+      const welcomeViewer = document.querySelector( "#welcome" );
+      welcomeViewer.reactive = false;
+
+      const changeScene = delta =>
+      {
+        index = Math.min( Math.max( index + delta, 1 ), scenes.length-1 );
+        title .innerHTML = scenes[index];
+        welcomeViewer .scene = scenes[index];
+        welcomeViewer .update( { camera } );
+      }
+
+      welcomeViewer .addEventListener( "vzome-scenes-discovered", (e) => {
+        scenes = e.detail;
+        console.log( JSON.stringify( scenes, null, 2 ) );
+        console.log( 'NOTE: we are intentionally bypassing the default scene for this page.' );
+        title .innerHTML = scenes[index];
+        prevButton .addEventListener( "click", e => changeScene( -1 ) );
+        nextButton .addEventListener( "click", e => changeScene( +1 ) );
+      } );
 
     </script>
   </head>
   <body>
     <article>
+      <section>
+        <div>
+          <button id="prev">prev</button>
+          <button id="next">next</button>
+          <h2 id="title"></h2>
+        </div>
+        <vzome-viewer id="welcome" scene="will be replaced"
+               src="https://vorth.github.io/vzome-sharing/2022/06/19/06-37-55-welcomeDodec/welcomeDodec.vZome" >
+          <img src="https://vorth.github.io/vzome-sharing/2022/06/19/06-37-55-welcomeDodec/watermarked.png" >
+        </vzome-viewer>
+      </section>
       <section>
         <vzome-viewer src="./models/orangePurpleChiral.vZome" id="orangePurpleChiral" >
           <img src="./models/orangePurpleChiral.png" >

--- a/online/public/test/vzome-viewer.css
+++ b/online/public/test/vzome-viewer.css
@@ -17,7 +17,7 @@ section {
   resize: both;
   gap: 1em;
   display: grid;
-  background: rgba(0, 0, 0, 0.8);
+  background: rgba(0, 0, 0, 0.4);
   padding: 1em;
   /* grid-template-rows: 1fr 1.5em; */
 }

--- a/online/src/viewer/solid/index.jsx
+++ b/online/src/viewer/solid/index.jsx
@@ -41,7 +41,7 @@ const fullScreenStyle = {
 
 const DesignViewer = ( props ) =>
 {
-  const config = mergeProps( { showScenes: false, useSpinner: false, allowFullViewport: false, undoRedo: false, loadCamera: 'always' }, props.config );
+  const config = mergeProps( { showScenes: false, useSpinner: false, allowFullViewport: false, undoRedo: false }, props.config );
   const { state, subscribeFor } = useWorkerClient();
   const { state: cameraState, setCamera, setLighting } = useCamera();
   const [ fullScreen, setFullScreen ] = createSignal( false );
@@ -74,14 +74,9 @@ const DesignViewer = ( props ) =>
     }
   });
 
-  let cameraLoaded = false;
   subscribeFor( 'SCENE_RENDERED', ( { scene } ) => {
     if ( scene.camera ) {
-      const { loadCamera } = props.config;
-      if ( loadCamera === 'always' || ( loadCamera === 'once' && !cameraLoaded ) ) {
-        setCamera( scene.camera );
-        cameraLoaded = true;
-      }
+      setCamera( scene.camera );
     }
     if ( scene.lighting ) {
       const { backgroundColor } = scene.lighting;

--- a/online/src/workerClient/actions.js
+++ b/online/src/workerClient/actions.js
@@ -16,18 +16,32 @@ export const encodeEntities = (title) =>
   return p.innerHTML;
 }
 
+const defaultLoad = {
+  camera: true,
+  lighting: true,
+  design: true,
+};
+
+const defaultConfig = {
+  preview: false,
+  debug: false,
+  showScenes: false,
+  load: defaultLoad,
+};
+
 const workerAction = ( type, payload ) => ({ type, payload, meta: 'WORKER' } );
 
-export const selectScene = title => 
+export const selectScene = ( title, load=defaultLoad ) => 
 {
-  return workerAction( 'SCENE_SELECTED', encodeEntities( title ) );
+  title = encodeEntities( title );
+  return workerAction( 'SCENE_SELECTED', { title, load } );
 }
 
 export const selectEditBefore = nodeId => workerAction( 'EDIT_SELECTED', { before: nodeId } );
 
 export const selectEditAfter = nodeId => workerAction( 'EDIT_SELECTED', { after: nodeId } );
 
-export const fetchDesign = ( url, config={ preview: false, debug: false, showScenes: false } ) => workerAction( 'URL_PROVIDED', { url, config } );
+export const fetchDesign = ( url, config=defaultConfig ) => workerAction( 'URL_PROVIDED', { url, config } );
 
 export const openDesignFile = ( file, debug=false ) => workerAction( 'FILE_PROVIDED', { file, debug } );
 


### PR DESCRIPTION
Now you can set `reactive` (attr or prop) to `false`, and then do `update( load )`
when you're done changing things.  The parameter to `update()` takes the form
`{ camera: true, lighting: true, design: true }`, with those being the default.
Load control is implemented in the worker, using `filterScene()`.
Also, the component tracks whether the `src` URL or the `scene` title has been
changed since the last `fetchDesign` or `selectScene` message was sent.
The `selectScene` message now accepts an optional load configuration.

I've updated the web component test page to replicate my CodePen sandbox
for dynamic viewer control, except with `reactive` turned off, and an explicit
`update()` call.
