### PR TITLE
Added support for labels in the scene

### DIFF
--- a/online/public/test/index.html
+++ b/online/public/test/index.html
@@ -63,7 +63,7 @@
         </vzome-viewer>
       </section>
       <section>
-        <vzome-viewer src="./models/test-show-scenes.vZome" id="testShowScenes" show-scenes="named" >
+        <vzome-viewer src="./models/test-show-scenes.vZome" id="testShowScenes" show-scenes="named" labels="true" >
         </vzome-viewer>
       </section>
       <section>

--- a/online/public/test/models/test-show-scenes.shapes.json
+++ b/online/public/test/models/test-show-scenes.shapes.json
@@ -6806,6 +6806,7 @@
   }, {
     "shape" : "128d4215-0a03-454b-b718-166b77c027d5",
     "color" : "#F7CF7F",
+    "label" : "TRIANGLE",
     "position" : {
       "x" : 0.0,
       "y" : 0.0,
@@ -7068,7 +7069,8 @@
     },
     "snapshot" : 5
   } ],
-  "snapshots" : [ [ {
+  "snapshots" : [
+    [ {
     "shape" : "cb7e5bd1-e3b3-4bc3-a324-19137331bf75",
     "color" : "#D77F7F",
     "position" : {

--- a/online/src/app/59icosahedra/selectors.jsx
+++ b/online/src/app/59icosahedra/selectors.jsx
@@ -104,7 +104,7 @@ const Selector = props =>
     <div class='selector safe-grid-item' >
       <div class="centered-scroller">
         <div class='scroller-content'>
-          <ModelWorker model={props.model} >
+          <ModelWorker model={props.model} labels={false} >
             <InteractionToolProvider>
               <CellSelectorTool model={props.model} orbits={props.orbits} />
               <SelectorCanvas/>

--- a/online/src/app/59icosahedra/state.jsx
+++ b/online/src/app/59icosahedra/state.jsx
@@ -81,7 +81,7 @@ export const useCellOrbits = () => { return useContext( CellOrbitContext ); };
 
 export const ModelWorker = props =>
 {
-  const config = { url: getModelURL( props.model ), preview: true, debug: false, sceneTitle: props.sceneTitle };
+  const config = { url: getModelURL( props.model ), preview: true, debug: false, sceneTitle: props.sceneTitle, labels: props.labels };
 
   return (
     <WorkerStateProvider>

--- a/online/src/viewer/context/viewer.jsx
+++ b/online/src/viewer/context/viewer.jsx
@@ -10,11 +10,13 @@ const ViewerContext = createContext( { scene: ()=> { console.log( 'NO ViewerProv
 
 const ViewerProvider = ( props ) =>
 {
+  const { url, labels: showLabels } = props.config || {};
   const [ scene, setScene ] = createStore( {} );
   const [ scenes, setScenes ] = createStore( [] );
   const [ source, setSource ] = createStore( {} );
   const [ problem, setProblem ] = createSignal( '' ); // cooperatively managed by both worker and client
   const [ waiting, setWaiting ] = createSignal( false );
+  const [ labels, setLabels ] = createSignal( showLabels );
   const { postMessage, subscribeFor } = useWorkerClient();
   const { state, setCamera, setLighting } = useCamera();
 
@@ -24,7 +26,6 @@ const ViewerProvider = ( props ) =>
     postMessage( fetchDesign( url, config ) );
   }
 
-  const { url } = props.config || {};
   url && postMessage( fetchDesign( url, props.config ) );
 
   const addShape = ( shape ) =>
@@ -121,7 +122,7 @@ const ViewerProvider = ( props ) =>
   } );
   
   const providerValue = {
-    scene, setScene, requestDesign, scenes, source, problem, waiting,
+    scene, setScene, requestDesign, scenes, source, problem, waiting, labels,
     clearProblem: () => setProblem( '' ),
     requestScene: ( name, config ) => postMessage( selectScene( name, config ) ),
     fetchPreview: ( url, config )  => postMessage( fetchDesign( url, config ) ),

--- a/online/src/viewer/geometry.jsx
+++ b/online/src/viewer/geometry.jsx
@@ -1,10 +1,11 @@
 
-import { createContext, createEffect, createMemo, createSignal, useContext } from "solid-js";
+import { createContext, createEffect, createMemo, createSignal, onMount, useContext } from "solid-js";
 import { Vector3, Matrix4, BufferGeometry, Float32BufferAttribute } from "three";
 import { useThree } from "solid-three";
 
 import { useInteractionTool } from "./context/interaction.jsx";
 import { GLTFExporter } from "three-stdlib";
+import { Label } from "./labels.jsx";
 
 
 const Instance = ( props ) =>
@@ -69,8 +70,19 @@ const Instance = ( props ) =>
           onPointerDown={handlePointerDown} onPointerUp={handlePointerUp} onContextMenu={handleContextMenu}>
         <meshLambertMaterial attach="material" color={props.color} emissive={emissive()} />
       </mesh>
+      {!!props.label && <Label parent={meshRef} position={props.geometry.shapeCentroid} text={props.label} />}
     </group>
   )
+}
+
+const centroid = vertices =>
+{
+  let [ sx, sy, sz ] = [ 0,0,0 ];
+  vertices .forEach( ({ x, y, z }) => {
+    sx += x; sy += y; sz += z;
+  });
+  const num = vertices .length;
+  return { x: sx/num, y: sy/num, z: sz/num };
 }
 
 const InstancedShape = ( props ) =>
@@ -96,6 +108,7 @@ const InstancedShape = ( props ) =>
     geometry.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
     geometry.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
     geometry.computeBoundingSphere();
+    geometry.shapeCentroid = centroid( vertices );
     return geometry;
   } );
 

--- a/online/src/viewer/index.jsx
+++ b/online/src/viewer/index.jsx
@@ -130,7 +130,7 @@ const UrlViewer = (props) =>
   return (
     <CameraProvider>
       <WorkerStateProvider workerClient={props.workerClient}>
-        <ViewerProvider config={{ url: props.url, preview: true, debug: false, showScenes: props.showScenes }}>
+        <ViewerProvider config={{ url: props.url, preview: true, debug: false, showScenes: props.showScenes, labels: props.config.labels }}>
           <DesignViewer config={ { ...props.config, allowFullViewport: true } }
               componentRoot={props.componentRoot}
               height="100%" width="100%" >

--- a/online/src/viewer/labels.jsx
+++ b/online/src/viewer/labels.jsx
@@ -1,0 +1,56 @@
+
+import { createEffect, onMount, useFrame, useThree } from "solid-three";
+import { CSS2DObject, CSS2DRenderer } from "three-stdlib";
+
+export const Labels = (props) =>
+{
+  const scene = useThree(({ scene }) => scene);
+  const camera = useThree(({ camera }) => camera);
+  const webGL = useThree(({gl}) => gl);
+
+  let labelRenderer;
+  onMount( () => {
+    labelRenderer = new CSS2DRenderer();
+    const labelsElem = labelRenderer.domElement;
+    labelsElem.style.position = 'absolute';
+    labelsElem.style.pointerEvents = 'none';
+    labelsElem.style.inset = '0px';
+    labelsElem.style.width = '100%';
+    labelsElem.style.height = '100%';
+    labelsElem.classList .add( 'labels' );
+
+    webGL() .domElement .insertAdjacentElement( "beforebegin", labelsElem );
+  });
+
+  createEffect( () => {
+    props.size && labelRenderer .setSize( props.size .width, props.size .height );
+  } );
+
+  useFrame( () => {
+    labelRenderer .render( scene(), camera() );
+  })
+
+  return null;
+}
+
+export const Label = (props) =>
+{
+  const scene = useThree(({ scene }) => scene);
+
+  let label;  
+  onMount( () => {
+    const elem = document .createElement( 'div' );
+    elem.className = 'vzome-label';
+    elem.textContent = props.text;
+    elem.style.backgroundColor = 'transparent';
+    label = new CSS2DObject( elem );
+    props.parent .add( label );
+  });
+
+  createEffect( () => {
+    const { x, y, z } = props.position;
+    label.position.set( x, y, z );
+  })
+
+  return label;
+}

--- a/online/src/viewer/ltcanvas.jsx
+++ b/online/src/viewer/ltcanvas.jsx
@@ -8,6 +8,8 @@ import { PerspectiveCamera } from "./perspectivecamera.jsx";
 import { TrackballControls } from "./trackballcontrols.jsx";
 import { useInteractionTool } from "../viewer/context/interaction.jsx";
 import { useCamera } from "../viewer/context/camera.jsx";
+import { Labels } from "./labels.jsx";
+import { useViewer } from "./context/viewer.jsx";
 
 const Lighting = () =>
 {
@@ -63,6 +65,8 @@ export const LightedTrackballCanvas = ( props ) =>
 {
   let size;
   const aspect = () => ( size && size.height )? size.width / size.height : 1;
+  const canvasSize = () => size;
+  const { labels } = useViewer();
 
   const [ tool ] = useInteractionTool();
 
@@ -100,6 +104,7 @@ export const LightedTrackballCanvas = ( props ) =>
 
       {props.children}
 
+      {labels && labels() && <Labels size={canvasSize()} />}
     </Canvas>;
   
   canvas.style.display = 'flex';

--- a/online/src/wc/vzome-viewer.js
+++ b/online/src/wc/vzome-viewer.js
@@ -36,7 +36,7 @@ export class VZomeViewer extends HTMLElement
       this .dispatchEvent( new CustomEvent( 'vzome-scenes-discovered', { detail: titles } ) );
     } );
 
-    this.#config = { preview: true, showScenes: 'none', camera: true, lighting: true, design: true, };
+    this.#config = { preview: true, showScenes: 'none', camera: true, lighting: true, design: true, labels: false };
 
     this.#urlChanged = true;
     this.#sceneChanged = true;
@@ -101,7 +101,7 @@ export class VZomeViewer extends HTMLElement
 
   static get observedAttributes()
   {
-    return [ "src", "show-scenes", "scene", "load-camera", "reactive" ];
+    return [ "src", "show-scenes", "scene", "load-camera", "reactive", "labels" ];
   }
 
   // This callback can happen *before* connectedCallback()!
@@ -133,6 +133,11 @@ export class VZomeViewer extends HTMLElement
     case "show-scenes":
       const showScenes = _newValue;
       this.#config = { ...this.#config, showScenes };
+      break;
+  
+    case "labels":
+      const labels = _newValue === 'true';
+      this.#config = { ...this.#config, labels };
       break;
   
     case "reactive":
@@ -181,6 +186,20 @@ export class VZomeViewer extends HTMLElement
   get showScenes()
   {
     return this.getAttribute( "show-scenes" );
+  }
+
+  set labels( newValue )
+  {
+    if ( newValue === null ) {
+      this.removeAttribute( "labels" );
+    } else {
+      this.setAttribute( "labels", newValue );
+    }
+  }
+
+  get labels()
+  {
+    return this.getAttribute( "labels" );
   }
 
   set reactive( value )


### PR DESCRIPTION
Everything is working correctly, and the labels show up in the selector panels for
`59icosahedra`.  Both the developer and the `vzome-viewer` author have
control over whether labels are shown.

No authoring support in desktop yet... it is necessary to hand-edit `.shapes.json`.