### PR TITLE
Adjust Shapes dialog height to display all styles

### DIFF
--- a/desktop/src/main/java/org/vorthmann/zome/ui/ShapesDialog.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/ShapesDialog.java
@@ -34,7 +34,8 @@ public class ShapesDialog extends EscapeDialog
             radioButton .addActionListener( new ControllerActionListener(controller) );
         }
 
-        setSize( new Dimension( 250, 250 ) );
+        // adjust height to fit all styles plus the title bar plus a bit extra at the bottom for good measure
+        setSize( new Dimension( 250, 66 + (styles.length * 24)) );
         setLocationRelativeTo( frame );
     }
 


### PR DESCRIPTION
"Vienne 121 zone" and the new "dimtool" styles were not visible because the dialog was a fixed height that was too short for them.