### PR TITLE
Support external style overrides for vzome-viewer

### DIFF
--- a/online/public/test/vzome-viewer-styles.css
+++ b/online/public/test/vzome-viewer-styles.css
@@ -1,0 +1,5 @@
+
+/* .select__listbox {
+  margin-block: 0;
+  padding: 4px;
+} */

--- a/online/src/viewer/index.jsx
+++ b/online/src/viewer/index.jsx
@@ -177,6 +177,12 @@ const renderViewer = ( workerClient, container, config ) =>
   }
 
   container .appendChild( document.createElement("style") ).textContent = urlViewerCSS;
+  // Apply external override styles to the shadow dom
+  const linkElem = document.createElement("link");
+  linkElem .setAttribute("rel", "stylesheet");
+  linkElem .setAttribute("href", "./vzome-viewer-styles.css");
+  container .appendChild( linkElem );
+
   render( bindComponent, container );
 }
 

--- a/online/src/viewer/urlviewer.css.js
+++ b/online/src/viewer/urlviewer.css.js
@@ -74,7 +74,8 @@ export const urlViewerCSS = `
 .select__listbox {
   overflow-y: auto;
   max-height: 360px;
-  padding: 8px;
+  margin-block: 0;
+  padding: 4px;
 }
 .select__item {
   font-size: 16px;


### PR DESCRIPTION
Page authors can provide `vzome-viewer-styles.css`, optionally.
