### PR TITLE
Viewer index buttons now support load-camera

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ developer-docs/notes/vZome/.obsidian/
 online/.yalc/
 
 online/yalc.lock
+
+.vscode/settings.json

--- a/online/public/test/index.html
+++ b/online/public/test/index.html
@@ -64,7 +64,7 @@
       <section>
         <div>
           <vzome-viewer-previous viewer="welcome" label="back" id="prevBtn"></vzome-viewer-previous>
-          <vzome-viewer-next viewer="welcome" label="forward"></vzome-viewer-next>
+          <vzome-viewer-next viewer="welcome" label="forward" load-camera="true"></vzome-viewer-next>
           <h3 id="title"></h3>
         </div>
         <vzome-viewer id="welcome" indexed="true" show-scenes="all" scene="#5"

--- a/online/src/wc/index-buttons.js
+++ b/online/src/wc/index-buttons.js
@@ -6,11 +6,13 @@ class VZomeViewerIndexButton extends HTMLElement
   #next;
   #viewerId;
   #viewer;
+  #loadCamera;
 
   constructor( next=true )
   {
     super();
     this.#next = next;
+    this.#loadCamera = false;
   }
 
   connectedCallback()
@@ -37,13 +39,13 @@ class VZomeViewerIndexButton extends HTMLElement
     this .appendChild( button );
     button.classList .add( 'vzome-viewer-index-button' );
 
-    const loadParams = { camera: false };
+    const loadParams = { camera: this.#loadCamera };
     button .addEventListener( "click", () => this.#next? this.#viewer .nextScene( loadParams ) : this.#viewer .previousScene( loadParams ) );
   }
 
   static get observedAttributes()
   {
-    return [ "viewer" ];
+    return [ "viewer", "load-camera" ];
   }
 
   attributeChangedCallback( attributeName, _oldValue, _newValue )
@@ -53,6 +55,10 @@ class VZomeViewerIndexButton extends HTMLElement
 
     case "viewer":
       this.#viewerId = _newValue;
+      break;
+
+    case "load-camera":
+      this.#loadCamera = _newValue === 'true';
       break;
     }
   }


### PR DESCRIPTION
The default for `load-camera` is false, for backward compatibility.