### PR TITLE
Eliminated redundant menu keyboard listeners

### DIFF
--- a/online/src/app/classic/components/appbar.jsx
+++ b/online/src/app/classic/components/appbar.jsx
@@ -16,7 +16,6 @@ export const VZomeAppBar = ( props ) =>
 {
   const spacer = <Spacer/>;
   const merged = mergeProps( {
-    spacer,
     showOpen: false,
     pathToRoot: './models',
     forDebugger: false,
@@ -35,7 +34,7 @@ export const VZomeAppBar = ( props ) =>
               vZome Online <Box component="span" fontStyle="oblique">{props.title}</Box>
             </Typography>
           </Show>
-          {merged.spacer}
+          {props.spacer}
           <Show when={merged.showOpen} >
             <OpenMenu pathToRoot={merged.pathToRoot} forDebugger={merged.forDebugger} />
           </Show>

--- a/online/src/app/classic/components/editor.jsx
+++ b/online/src/app/classic/components/editor.jsx
@@ -10,13 +10,13 @@ import { LabelDialog } from '../dialogs/label.jsx';
 import { useCamera } from '../../../viewer/context/camera.jsx';
 import { useViewer } from '../../../viewer/context/viewer.jsx';
 import { InteractionToolProvider } from '../../../viewer/context/interaction.jsx';
-import { useEditor } from '../../../viewer/context/editor.jsx';
+import { useEditor, resumeMenuKeyEvents, suspendMenuKeyEvents } from '../../../viewer/context/editor.jsx';
 import { SceneCanvas } from '../../../viewer/index.jsx';
 
 import { SnapCameraTool } from '../tools/snapcamera.jsx';
 import { SelectionTool } from '../tools/selection.jsx';
 import { StrutDragTool } from '../tools/strutdrag.jsx';
-import { ContextualMenuArea, resumeMenuKeyEvents, suspendMenuKeyEvents } from '../../framework/menus.jsx';
+import { ContextualMenuArea } from '../../framework/menus.jsx';
 import { ContextualMenu } from '../menus/contextmenu.jsx';
 
 export const SceneEditor = ( props ) =>

--- a/online/src/app/classic/components/toolbars.jsx
+++ b/online/src/app/classic/components/toolbars.jsx
@@ -1,10 +1,9 @@
 
 import { createSignal, createEffect } from "solid-js";
 
-import { controllerProperty, subController, useEditor } from '../../../viewer/context/editor.jsx';
+import { controllerProperty, subController, useEditor, resumeMenuKeyEvents, suspendMenuKeyEvents } from '../../../viewer/context/editor.jsx';
 import { useSymmetry } from "../context/symmetry.jsx";
 import { ToolConfig } from "../dialogs/toolconfig.jsx";
-import { resumeMenuKeyEvents, suspendMenuKeyEvents } from "../../framework/menus.jsx";
 
 const ToolbarSpacer = () => ( <div style={{ 'min-width': '10px', 'min-height': '10px' }}></div> )
 

--- a/online/src/app/classic/dialogs/sharing.jsx
+++ b/online/src/app/classic/dialogs/sharing.jsx
@@ -22,9 +22,8 @@ import Link from '@suid/material/Link';
 import { Tooltip } from '../../framework/tooltip.jsx'
 
 import { useViewer } from "../../../viewer/context/viewer.jsx";
-import { useEditor } from "../../../viewer/context/editor.jsx";
+import { useEditor, resumeMenuKeyEvents, suspendMenuKeyEvents } from "../../../viewer/context/editor.jsx";
 import { getUserRepos } from "../../../worker/legacy/gitcommit.js";
-import { resumeMenuKeyEvents, suspendMenuKeyEvents } from '../../framework/menus.jsx';
 
 const AUTHENTICATING = 0;
 const CHOOSING_REPO = 1;

--- a/online/src/app/classic/dialogs/webloader.jsx
+++ b/online/src/app/classic/dialogs/webloader.jsx
@@ -8,7 +8,7 @@ import DialogTitle from '@suid/material/DialogTitle';
 import Button from '@suid/material/Button';
 
 import { createSignal } from "solid-js";
-import { resumeMenuKeyEvents } from '../../framework/menus';
+import { resumeMenuKeyEvents } from '../../../viewer/context/editor.jsx';
 
 export const UrlDialog = ( props ) =>
 {

--- a/online/src/app/classic/index.jsx
+++ b/online/src/app/classic/index.jsx
@@ -4,6 +4,7 @@ import { ErrorBoundary } from "solid-js";
 import Typography from '@suid/material/Typography'
 import Link from '@suid/material/Link'
 import { DiskIcon, WorldIcon } from '../framework/icons.jsx';
+import { MenuBar } from '../framework/menus.jsx';
 import { FileMenu } from './menus/filemenu.jsx';
 import { EditMenu } from './menus/editmenu.jsx';
 import { ConstructMenu } from './menus/constructmenu.jsx';
@@ -55,12 +56,14 @@ const Classic = () =>
         <SymmetryProvider>
           <VZomeAppBar title='BETA'
             spacer={ <>
-              <FileMenu/>
-              <EditMenu/>
-              <ConstructMenu/>
-              <ToolsMenu/>
-              <SystemMenu/>
-              <HelpMenu/>
+              <MenuBar>
+                <FileMenu/>
+                <EditMenu/>
+                <ConstructMenu/>
+                <ToolsMenu/>
+                <SystemMenu/>
+                <HelpMenu/>
+              </MenuBar>
               <Persistence/>
             </>}
             about={ <>

--- a/online/src/app/classic/menus/editmenu.jsx
+++ b/online/src/app/classic/menus/editmenu.jsx
@@ -73,7 +73,7 @@ export const EditMenu = () =>
         <EditAction label="Cut"    onClick={doCut}   mods="⌘" key="X" />
         <EditAction label="Copy"   onClick={doCopy}  mods="⌘" key="C" />
         <MenuAction label="Paste"  onClick={doPaste} mods="⌘" key="V" />
-        <EditAction label="Delete" action="Delete" code="Delete|Backspace" />
+        <EditAction label="Delete" action="Delete" deleteKey={true} />
 
         <Divider />
 

--- a/online/src/app/classic/menus/filemenu.jsx
+++ b/online/src/app/classic/menus/filemenu.jsx
@@ -2,10 +2,10 @@
 import { createEffect, createSignal, mergeProps, onMount } from "solid-js";
 import { unwrap } from "solid-js/store";
 
-import { controllerExportAction, controllerProperty, useEditor } from "../../../viewer/context/editor.jsx";
+import { controllerExportAction, controllerProperty, useEditor, suspendMenuKeyEvents } from "../../../viewer/context/editor.jsx";
 import { saveFileAs, openFile, saveTextFileAs, saveTextFile } from "../../../viewer/util/files.js";
 
-import { Divider, Menu, MenuAction, MenuItem, SubMenu, suspendMenuKeyEvents } from "../../framework/menus.jsx";
+import { Divider, Menu, MenuAction, MenuItem, SubMenu } from "../../framework/menus.jsx";
 import { UrlDialog } from '../dialogs/webloader.jsx'
 import { SvgPreviewDialog } from "../dialogs/svgpreview.jsx";
 import { useCamera } from "../../../viewer/context/camera.jsx";
@@ -148,6 +148,7 @@ export const FileMenu = () =>
   {
     props = mergeProps( { format: props.ext }, props );
     const params = { drawOutlines: cameraState.outlines }; // for SVG
+    console.log( `ExportItem ${props.label}`);
     return <MenuItem onClick={ exportAs( props.ext, props.mime, props.format, params ) } disabled={props.disabled}>{props.label}</MenuItem>
   }
 

--- a/online/src/viewer/context/editor.jsx
+++ b/online/src/viewer/context/editor.jsx
@@ -21,6 +21,11 @@ const EditorContext = createContext( {} );
 
 const useEditor = () => { return useContext( EditorContext ); };
 
+let menuKeyEventsSuspended = false;
+
+export const suspendMenuKeyEvents = () => menuKeyEventsSuspended = true;
+export const resumeMenuKeyEvents = () => menuKeyEventsSuspended = false;
+
 const EditorProvider = props =>
 {
   const workerClient = useWorkerClient();
@@ -204,9 +209,41 @@ const EditorProvider = props =>
     } );
   }
 
+  const listeners = new Set();
+  const registerKeyListener = ( modifiers, deleteKey, key, handler ) =>
+  {
+    const listenerName = deleteKey? "⌫" : modifiers + key;
+    if ( ! listeners .has( listenerName ) ) {
+      console.log( `addEventListener ${listenerName}` );
+      const targetCodes = deleteKey? [ 'Delete', 'Backspace' ] : [ "Key" + key.toUpperCase() ];
+      const hasMeta = !! modifiers ?.includes( '⌘' );
+      const hasControl = !! modifiers ?.includes( '⌃' );
+      const hasShift = !! modifiers ?.includes( '⇧' );
+      const hasOption = !! modifiers ?.includes( '⌥' );
+      document.body .addEventListener( "keydown", evt => {
+        if ( menuKeyEventsSuspended )
+          return;
+        if ( targetCodes .indexOf( evt.code ) < 0 )
+          return;
+        if ( hasMeta !== evt.metaKey )
+          return;
+        if ( hasControl !== evt.ctrlKey )
+          return;
+        if ( hasShift !== evt.shiftKey )
+          return;
+        if ( hasOption !== evt.altKey )
+          return;
+        evt .preventDefault(); // Why doesn't this work for ⌘N?
+        handler();
+      } );
+      listeners .add( listenerName );
+    }
+  }
+
   const providerValue = {
     ...store,
     guard, edited,
+    registerKeyListener,
     rootController,
     indexResources,
     controllerAction,


### PR DESCRIPTION
The Kobalte dropdown menus get created and destroyed on each use, so it is
inappropriate to register key event listeners each time!
