### PR TITLE
Implemented instructions web component for Zometool

### DIFF
--- a/online/public/test/cases/indexed-viewer/index.html
+++ b/online/public/test/cases/indexed-viewer/index.html
@@ -15,26 +15,57 @@
         border-color: black;
         background-color: aliceblue;
       }
+      .hidden {
+        display: none;
+      }
     </style>
     <script type="module">
       import "/modules/vzome-viewer.js"; // registers the custom element
 
       console.log( '%%%%%%%%%%%%%%%%%% starting my script!');
 
-      const title = document.querySelector( "#title" );
+      const title    = document.querySelector( "#title" );
       const welcomeViewer = document.querySelector( "#welcome" );
+      const stepsBtn = document.querySelector( "#steps" );
+      const endBtn   = document.querySelector( "#completed" );
+      const nextBtn  = document.querySelector( "vzome-viewer-next" );
+      const prevBtn  = document.querySelector( "vzome-viewer-previous" );
+
+      let showingSteps = false;
 
       welcomeViewer .addEventListener( "vzome-design-rendered", (e) => {
+        if ( !showingSteps )
+          return;
         const { index, title: sceneTitle } = e.detail;
         title .innerHTML = `Step ${index}: ${sceneTitle}`;
       } );
 
       welcomeViewer .addEventListener( "vzome-scenes-discovered", (e) => {
         console.log( 'welcome scenes:', JSON.stringify( e.detail, null, 2 ) );
+        showDesign();
       } );
 
-      const prevBtn = document.querySelector( "#prevBtn" );
-      prevBtn .addEventListener( 'click', () => console.log( 'prev button hit!' ) );
+      const showDesign = () =>
+      {
+        title .innerHTML = 'Dodecahedron';
+        showingSteps = false;
+        welcomeViewer .selectScene( -1 );
+        stepsBtn .classList .remove( 'hidden' );
+        nextBtn  .classList .add( 'hidden' );
+        prevBtn  .classList .add( 'hidden' );
+        endBtn   .classList .add( 'hidden' );
+      }
+      const showSteps = () =>
+      {
+        showingSteps = true;
+        welcomeViewer .selectScene( 0 );
+        stepsBtn .classList .add( 'hidden' );
+        nextBtn  .classList .remove( 'hidden' );
+        prevBtn  .classList .remove( 'hidden' );
+        endBtn   .classList .remove( 'hidden' );
+      }
+      stepsBtn .addEventListener( 'click', showSteps );
+      endBtn   .addEventListener( 'click', showDesign );
 
       console.log( '%%%%%%%%%%%%%%%%%% ending my script!');
 
@@ -44,13 +75,25 @@
     <article>
       <section>
         <div>
-          <vzome-viewer-previous viewer="welcome" label="back" id="prevBtn"></vzome-viewer-previous>
-          <vzome-viewer-next viewer="welcome" label="forward" load-camera="true"></vzome-viewer-next>
-          <h3 id="title"></h3>
+          <h3 id="title">Dodecahedron</h3>
+
+          <button class="vzome-viewer-index-button" id="steps">
+            Show Steps
+          </button>
+          <button class="vzome-viewer-index-button" id="completed" class="hidden">
+            Show Completed
+          </button>
+        </div>
+        <div>
+          <vzome-viewer-previous label="back"    load-camera="true" viewer="welcome" class="hidden">
+          </vzome-viewer-previous>
+
+          <vzome-viewer-next     label="forward" load-camera="true" viewer="welcome" class="hidden">
+          </vzome-viewer-next>
         </div>
         <vzome-viewer id="welcome" indexed="true" show-scenes="all" scene="#5"
-               src="https://vorth.github.io/vzome-sharing/2022/06/19/06-37-55-welcomeDodec/welcomeDodec.vZome" >
-          <img src="https://vorth.github.io/vzome-sharing/2022/06/19/06-37-55-welcomeDodec/watermarked.png" >
+               src="https://vorth.github.io/vzome-sharing/2024/06/17/20-17-17-835Z-H4-1100-instructions/H4-1100-instructions.vZome" >
+          <img src="https://vorth.github.io/vzome-sharing/2024/06/17/20-17-17-835Z-H4-1100-instructions/H4-1100-instructions.png" >
         </vzome-viewer>
       </section>
     </article>

--- a/online/public/test/cases/zometool-instructions/index.html
+++ b/online/public/test/cases/zometool-instructions/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Test Zometool components</title>
+
+  <link rel="stylesheet" href="./styles.css">
+
+  <script type="module" src="/modules/zometool.js" >
+  </script>
+
+</head>
+<body>
+
+    <div class="title">
+      <h1>Cantellated 120-Cell</h1>
+    </div>
+
+    <!-- vvvvvvv ----- This is the portion you will enter as content HTML for the page -->
+    <div class="zometool-model">
+
+      <div class="zometool-model-description">
+        Remind you of anything?  This Archimedean solid is topologically the same as the Zome ball!
+        It just has squares instead of golden rectangles, and so all edges are the same length. 
+      </div>
+
+      <div class="zometool-model-difficulty" data-difficulty="medium">
+      </div>
+
+      <zometool-instructions src="https://vorth.github.io/vzome-sharing/2024/06/17/20-17-17-835Z-H4-1100-instructions/H4-1100-instructions.vZome">
+      </zometool-instructions>      
+
+      <zometool-parts-required>Parts table here</zometool-parts-required>
+      <zometool-covering-products>Products list here</zometool-covering-products>
+
+    </div>
+    <!-- ^^^^^^^ ----- This is the portion you will enter as content HTML for the page -->
+
+</body>
+</html>

--- a/online/public/test/cases/zometool-instructions/styles.css
+++ b/online/public/test/cases/zometool-instructions/styles.css
@@ -1,0 +1,64 @@
+
+
+html,
+body {
+  margin: 0; /* This is essential to avoid a small white border around the whole main div. */
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+*, *:before, *:after {
+  box-sizing: border-box;
+}
+
+.title {
+  display: flex;
+}
+
+h1 {
+  margin: auto;
+}
+
+/* // =============================================================================
+// Styling for model instructions
+// ============================================================================= */
+
+.zometool-model {
+  max-width: 1000px;
+  min-height: 75dvh;
+  margin: auto;
+
+  font-size: large;
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: 2fr 1fr;
+  grid-template-rows: 3fr 1fr 2fr 4fr;
+  grid-template-areas:
+    "viewer description"
+    "viewer difficulty"
+    "viewer products"
+    "viewer parts";
+}
+
+.zometool-model-description {
+  grid-area: description;
+}
+
+.zometool-model-difficulty {
+  grid-area: difficulty;
+}
+
+zometool-instructions {
+  grid-area: viewer;
+}
+
+zometool-parts-required {
+  grid-area: parts;
+}
+
+zometool-covering-products {
+  grid-area: products;
+}

--- a/online/public/test/index.html
+++ b/online/public/test/index.html
@@ -18,7 +18,11 @@
     <div>
       <a target="_blank" href="/59icosahedra">59 Icosahedra</a>
     </div>
-    <hr>
+    <hr/>
+    <div>
+      <a target="_blank" href="./cases/zometool-instructions/">Zometool instructions</a>
+    </div>
+    <hr/>
     <div>
       <a target="_blank" href="./cases/online-preview/">Preview in online format</a>
     </div>

--- a/online/scripts/esbuild-config.mjs
+++ b/online/scripts/esbuild-config.mjs
@@ -50,6 +50,7 @@ export const esbuildConfig = {
     'vzome-viewer'        : 'src/wc/vzome-viewer.js',
     'gltf-viewer'         : 'src/wc/gltf/index.jsx',
     'vrml-viewer'         : 'src/wc/vrml/index.jsx',
+    'zometool'            : 'src/wc/zometool.jsx',
   // client rendering code, dynamically imported for fast time-to-first-render
     'vzome-viewer-dynamic': 'src/viewer/index.jsx',
   // Worker entry point, only used as a module worker

--- a/online/src/app/classic/menus/contextmenu.jsx
+++ b/online/src/app/classic/menus/contextmenu.jsx
@@ -2,7 +2,7 @@
 import { ContextMenu } from "@kobalte/core/context-menu";
 
 import { subController, useEditor } from '../../framework/context/editor.jsx';
-import { useCamera } from "../../../viewer/context/camera.jsx";
+import { useCamera, copyOfCamera } from "../../../viewer/context/camera.jsx";
 
 import { ContextMenuItem, ContextMenuSeparator } from "../../framework/menus";
 
@@ -37,11 +37,6 @@ export const ContextualMenu = props =>
   const lookAtThis   = () => lookAt( state.picked.position );
   const lookAtOrigin = () => lookAt( [0,0,0] );
 
-  const copyOfCamera = camera =>
-  {
-    const { up, lookAt, lookDir, ...rest } = camera; // don't want copy-by-reference for the arrays
-    return { ...rest, up: [...up], lookAt: [...lookAt], lookDir: [...lookDir] };
-  }
   const copyCamera = () => setState( 'copiedCamera', copyOfCamera( cameraState.camera ) );
   
   const useCopiedCamera = () =>

--- a/online/src/viewer/context/camera.jsx
+++ b/online/src/viewer/context/camera.jsx
@@ -194,4 +194,10 @@ const CameraProvider = ( props ) =>
 
 const useCamera = () => { return useContext( CameraContext ); };
 
-export { defaultCamera, useCamera, CameraProvider };
+const copyOfCamera = camera =>
+  {
+    const { up, lookAt, lookDir, ...rest } = camera; // don't want copy-by-reference for the arrays
+    return { ...rest, up: [...up], lookAt: [...lookAt], lookDir: [...lookDir] };
+  }
+
+export { defaultCamera, useCamera, CameraProvider, copyOfCamera };

--- a/online/src/viewer/index.jsx
+++ b/online/src/viewer/index.jsx
@@ -34,7 +34,7 @@ const normalStyle = {
 
 const DesignViewer = ( props ) =>
 {
-  const config = mergeProps( { showScenes: 'none', useSpinner: false, allowFullViewport: false, download: true }, props.config );
+  const config = mergeProps( { showScenes: 'none', useSpinner: false, allowFullViewport: false, download: true, showPerspective: true }, props.config );
   const { scene, waiting } = useViewer();
   let rootRef;
   

--- a/online/src/wc/index-buttons.js
+++ b/online/src/wc/index-buttons.js
@@ -4,16 +4,18 @@ const debug = false;
 class VZomeViewerIndexButton extends HTMLElement
 {
   #next;
+  #end;
   #viewerId;
   #viewer;
   #loadCamera;
   #button;
   #maxSceneIndex;
 
-  constructor( next=true )
+  constructor( next=true, end=false )
   {
     super();
     this.#next = next;
+    this.#end = end;
     this.#loadCamera = false;
   }
 
@@ -62,7 +64,22 @@ class VZomeViewerIndexButton extends HTMLElement
     } );
 
     const loadParams = { camera: this.#loadCamera };
-    this.#button .addEventListener( "click", () => this.#next? this.#viewer .nextScene( loadParams ) : this.#viewer .previousScene( loadParams ) );
+    const handler = () =>
+    {
+      if ( this.#end ) {
+        if ( this.#next ) {
+          this.#viewer .selectScene( -1 )
+        } else {
+          this.#viewer .selectScene( 0 )
+        }  
+      } else
+        if ( this.#next ) {
+          this.#viewer .nextScene( loadParams )
+        } else {
+          this.#viewer .previousScene( loadParams )
+        }
+    }
+    this.#button .addEventListener( "click", handler );
   }
 
   static get observedAttributes()
@@ -99,5 +116,21 @@ export class VZomeViewerPrevButton extends VZomeViewerIndexButton
   constructor()
   {
     super( false );
+  }
+}
+
+export class VZomeViewerFirstButton extends VZomeViewerIndexButton
+{
+  constructor()
+  {
+    super( false, true );
+  }
+}
+
+export class VZomeViewerLastButton extends VZomeViewerIndexButton
+{
+  constructor()
+  {
+    super( true, true );
   }
 }

--- a/online/src/wc/vzome-viewer.js
+++ b/online/src/wc/vzome-viewer.js
@@ -3,10 +3,10 @@ import { vZomeViewerCSS } from "./vzome-viewer.css";
 
 import { createWorker } from '../viewer/context/worker.jsx';
 import { fetchDesign, selectScene, decodeEntities } from "../viewer/util/actions.js";
-import { VZomeViewerNextButton, VZomeViewerPrevButton } from "./index-buttons.js";
+import { VZomeViewerFirstButton, VZomeViewerLastButton, VZomeViewerNextButton, VZomeViewerPrevButton } from "./index-buttons.js";
 
 const debug = false;
-export class VZomeViewer extends HTMLElement
+class VZomeViewer extends HTMLElement
 {
   #root;
   #container;
@@ -69,6 +69,24 @@ export class VZomeViewer extends HTMLElement
     this.#updateCalled = false;
     this.#loadFlags = {};
     debug && console.log( 'custom element constructed' );
+  }
+
+  selectScene( index, loadFlags={} )
+  {
+    debug && console.log( 'User called selectScene()' );
+    this.#loadFlags = loadFlags;
+    if ( ! this.#indexed ) {
+      console.log( 'This selectScene call ignored; the viewer is not indexed.  Set indexed to true if you want to use selectScene.' );
+      return;
+    }
+    if ( ! this.#sceneIndices ) {
+      console.log( 'This selectScene call ignored; no scenes were discovered.' );
+      return;
+    }
+    this.#sceneIndex = ( index < 0 )? this.#sceneIndices.length-1 : 0;
+    this.#config = { ...this.#config, sceneTitle: this.#sceneIndices[ this.#sceneIndex ] };
+    this.#sceneChanged = true;
+    this.#triggerWorker();
   }
 
   previousScene( loadFlags={} )
@@ -341,5 +359,7 @@ export class VZomeViewer extends HTMLElement
 
 customElements.define( "vzome-viewer", VZomeViewer );
 
+customElements .define( "vzome-viewer-end",      VZomeViewerLastButton );
 customElements .define( "vzome-viewer-next",     VZomeViewerNextButton );
 customElements .define( "vzome-viewer-previous", VZomeViewerPrevButton );
+customElements .define( "vzome-viewer-start",    VZomeViewerFirstButton );

--- a/online/src/wc/zometool.css.js
+++ b/online/src/wc/zometool.css.js
@@ -1,0 +1,83 @@
+export const instructionsCSS = `
+:host {
+  display: inline-grid;
+  overflow: hidden;
+  position: relative;
+  font-family: sans-serif;
+  --vzome-label-background: white;
+}
+
+:host > div:empty {
+  background: radial-gradient(#EEE, #AAA);
+}
+
+:host > div,
+:host > div > div {
+  position: absolute;
+  inset: 0;
+}
+
+.switch {
+  height: 30px;
+}
+
+.step-buttons {
+  margin: auto;
+  min-height: 4rem;
+  gap: 13px;
+  display: flex;
+  align-items: center;
+}
+
+.step-button {
+  appearance: none;
+  height: 60px;
+  outline: none;
+  border: 1px solid black;
+  border-radius: 8px;
+  padding: 0 30px;
+  background-color: hsl(200 98% 39%);
+  color: white;
+  font-size: 3.5rem;
+  line-height: 0;
+}
+
+.limit-step {
+  height: 48px;
+  padding: 0 18px;
+  font-size: 2rem;
+}
+
+.step-button-svg {
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  fill: currentColor;
+  flex-shrink: 0;
+}
+.step-button:hover {
+  background-color: hsl(201 98% 44%);
+}
+.step-button:active {
+  background-color: hsl(201 98% 48%);
+}
+.step-button:disabled {
+  background-color: hsl(200 98% 30%);
+  color: rgba(255, 255, 255, 0.2);
+  border-color: light-dark(rgba(118, 118, 118, 0.3), rgba(195, 195, 195, 0.3));
+}
+
+.step-button:focus-visible {
+  outline: 2px solid hsl(200 98% 39%);
+  outline-offset: 2px;
+}
+
+.zometool-instructions {
+  height: 100%;
+  display: grid;
+  grid-template-rows: min-content 1fr min-content;
+  gap: 0.5em;
+}
+
+`;

--- a/online/src/wc/zometool.jsx
+++ b/online/src/wc/zometool.jsx
@@ -1,0 +1,172 @@
+
+import { createEffect, createSignal } from 'solid-js';
+import { render } from 'solid-js/web';
+
+import { Button } from "@kobalte/core/button";
+import { Switch } from "@kobalte/core/switch";
+
+import { CameraProvider, DesignViewer } from '../viewer/index.jsx';
+import { ViewerProvider, useViewer } from '../viewer/context/viewer.jsx';
+import { WorkerStateProvider } from '../viewer/context/worker.jsx';
+
+import { instructionsCSS } from "./zometool.css";
+import { urlViewerCSS } from "../viewer/urlviewer.css.js";
+
+const debug = true;
+
+const StepControls = props =>
+{
+  const { scenes, requestScene } = useViewer();
+  const [ index, setIndex ] = createSignal( 1 );
+  const [ maxIndex, setMaxIndex ] = createSignal( 0 );
+  const atStart = () => index() === 1;  // NOTE: scene 0 is the default scene, which we ignore
+  const atEnd = () => index() === maxIndex();
+
+  createEffect( () => setMaxIndex( scenes?.length ) );
+
+  createEffect( () => {
+    if ( props.show ) {
+      requestScene( '#' + index(), { camera: false } );
+    } else {
+      requestScene( '#' + maxIndex(), { camera: true } );
+    }
+  } );
+
+  const change = ( delta ) => evt =>
+  {
+    let newIndex;
+    if ( delta === 0 ) {
+      newIndex = 1;
+    } else if ( delta === -2 ) {
+      newIndex = maxIndex();
+    } else {
+      newIndex = index() + delta;
+    }
+    setIndex( newIndex );
+  }
+
+  return (
+    <div class="step-buttons">
+      <Show when={props.show}>
+        <Button disabled={atStart()} class='step-button limit-step' tooltip='First step'    onClick={ change( 0 ) } >
+          <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false" class="step-button-svg">
+            <path d="M24 0v24H0V0h24z" fill="none" opacity=".87"></path>
+            <path d="M17.7 15.89L13.82 12l3.89-3.89c.39-.39.39-1.02 0-1.41-.39-.39-1.02-.39-1.41 0l-4.59 4.59c-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0 .38-.38.38-1.02-.01-1.4zM7 6c.55 0 1 .45 1 1v10c0 .55-.45 1-1 1s-1-.45-1-1V7c0-.55.45-1 1-1z"></path>
+          </svg>
+        </Button>
+        <Button disabled={atStart()} class='step-button' tooltip='Previous step' onClick={ change( -1 ) } >
+          <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false" class="step-button-svg">
+            <path d="M14.91 6.71c-.39-.39-1.02-.39-1.41 0L8.91 11.3c-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L11.03 12l3.88-3.88c.38-.39.38-1.03 0-1.41z"></path>
+          </svg>
+        </Button>
+        <Button disabled={atEnd()}   class='step-button' tooltip='Next step'     onClick={ change( +1 ) } >
+          <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false" class="step-button-svg">
+            <path d="M9.31 6.71c-.39.39-.39 1.02 0 1.41L13.19 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.72 6.7c-.38-.38-1.02-.38-1.41.01z"></path>
+          </svg>
+        </Button>
+        <Button disabled={atEnd()}   class='step-button limit-step' tooltip='Last step'     onClick={ change( -2 ) } >
+          <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false" class="step-button-svg">
+            <path d="M0 0h24v24H0V0z" fill="none" opacity=".87"></path>
+            <path d="M6.29 8.11L10.18 12l-3.89 3.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L7.7 6.7c-.39-.39-1.02-.39-1.41 0-.38.39-.38 1.03 0 1.41zM17 6c.55 0 1 .45 1 1v10c0 .55-.45 1-1 1s-1-.45-1-1V7c0-.55.45-1 1-1z"></path>
+          </svg>
+        </Button>
+      </Show>
+    </div>
+  );
+}
+
+const ZometoolInstructions = props =>
+{
+  const [ steps, setSteps ] = createSignal( false );
+  const toggleSteps = () => setSteps( v => !v );
+
+  return (
+    <CameraProvider>
+      <WorkerStateProvider>
+        <ViewerProvider config={{ url: props.url, preview: true, debug: false, showScenes: false, labels: true, source: true }}>
+          <div class='zometool-instructions'>
+
+            <Switch class="switch" checked={steps()} onChange={toggleSteps}>
+              <Switch.Label class="switch__label">Show Build Steps</Switch.Label>
+              <Switch.Input class="switch__input" />
+              <Switch.Control class="switch__control">
+                <Switch.Thumb class="switch__thumb" />
+              </Switch.Control>
+            </Switch>
+
+            <DesignViewer config={ { ...props.config, download: !steps(), allowFullViewport: true } }
+                componentRoot={props.componentRoot}
+                height="100%" width="100%" >
+            </DesignViewer>
+
+            <StepControls show={steps()} />
+          </div>
+        </ViewerProvider>
+      </WorkerStateProvider>
+    </CameraProvider>
+  );
+}
+
+const renderComponent = ( url, container ) =>
+  {
+    const bindComponent = () =>
+    {
+      return (
+        <ZometoolInstructions url={url} >
+        </ZometoolInstructions>
+      );
+    }
+  
+    container .appendChild( document.createElement("style") ).textContent = urlViewerCSS;
+    // Apply external override styles to the shadow dom
+    // const linkElem = document.createElement("link");
+    // linkElem .setAttribute("rel", "stylesheet");
+    // linkElem .setAttribute("href", "./zometool-styles.css");
+    // container .appendChild( linkElem );
+  
+    render( bindComponent, container );
+  }
+  
+class ZometoolInstructionsElement extends HTMLElement
+{
+  #container;
+  #url;
+
+  constructor()
+  {
+    super();
+    const root = this.attachShadow({ mode: "open" });
+
+    root.appendChild( document.createElement("style") ).textContent = instructionsCSS;
+    this.#container = document.createElement("div");
+    root.appendChild( this.#container );
+
+    debug && console.log( 'custom element constructed' );
+  }
+
+  connectedCallback()
+  {
+    debug && console.log( 'custom element connected' );
+
+    renderComponent( this.#url, this.#container );
+  }
+
+  static get observedAttributes()
+  {
+    return [ "src", ];
+  }
+
+  // This callback can happen *before* connectedCallback()!
+  attributeChangedCallback( attributeName, _oldValue, _newValue )
+  {
+    debug && console.log( 'custom element attribute changed' );
+    switch (attributeName) {
+
+    case "src":
+      this.#url = new URL( _newValue, window.location ) .toString();
+    }
+  }
+}
+
+customElements.define( "zometool-instructions", ZometoolInstructionsElement );
+


### PR DESCRIPTION
I have added "start" and "end" button components, though I don't expect to use them
for the Zometool pages.  The "end" button, in particular, is not good for leaving an
"instructions" mode, since it is disabled on the last scene.  I was using them in the
`indexed-viewer` test page, but decided to have explicit, custom mode buttons instead;
they use the new `selectScene()` viewer method.

I have a SolidJS component, `ZometoolInstructions`, and a web component.
Everything works.