### PR TITLE
Normalized shape identities for complete BOM support

### DIFF
--- a/core/src/main/java/com/vzome/core/render/JsonMapper.java
+++ b/core/src/main/java/com/vzome/core/render/JsonMapper.java
@@ -87,7 +87,9 @@ public class JsonMapper
                     // a strut
                     Direction orbit = shape .getOrbit();
                     node .put( "orbit", orbit .getName() );
+                    node .put( "orbitC", orbit .getCanonicalName() );
                     AlgebraicNumber length = shape .getLength();
+                    node .put( "length", this .objectMapper .valueToTree( length.toTrailingDivisor() ) .toString() );
                     name = orbit .getLengthName( length );
                     if ( name == "" ) {
                         StringBuffer buf = new StringBuffer();

--- a/online/public/test/cases/zometool-instructions/all-parts.vZome
+++ b/online/public/test/cases/zometool-instructions/all-parts.vZome
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<vzome:vZome xmlns:vzome="http://xml.vzome.com/vZome/4.0.0/" buildNumber="64" field="golden" version="7.1">
-  <EditHistory editNumber="26" lastStickyEdit="26">
+<vzome:vZome xmlns:vzome="http://xml.vzome.com/vZome/4.0.0/" buildNumber="DEV" field="golden" version="7.1">
+  <EditHistory editNumber="28" lastStickyEdit="26">
     <StrutCreation anchor="0 0 0 0 0 0" index="0" len="2 2"/>
     <StrutCreation anchor="2 2 0 0 0 0" index="0" len="2 4"/>
     <StrutCreation anchor="4 6 0 0 0 0" index="16" len="4 6"/>
@@ -27,6 +27,8 @@
     <Snapshot id="5"/>
     <StrutCreation anchor="5 8 3 5 0 0" dir="green" index="2" len="2 3"/>
     <Snapshot id="6"/>
+    <StrutCreation anchor="0 1 1 2 0 0" dir="navy" index="10" len="1 1"/>
+    <StrutCreation anchor="0 1 1 2 0 0" dir="navy" index="48" len="0 1"/>
   </EditHistory>
   <notes>
     <page snapshot="3" title="">
@@ -76,7 +78,7 @@
     <directionalLight color="30,30,30" x="0.0" y="0.0" z="-1.0"/>
   </sceneModel>
   <Viewing>
-    <ViewModel distance="108.0" far="216.0" near="0.10000000149011612" parallel="false" stereoAngle="0.0" width="54.0">
+    <ViewModel distance="108.73126983642578" far="217.4625244140625" near="0.10067709535360336" parallel="false" stereoAngle="0.0" width="54.365631103515625">
       <LookAtPoint x="0.0" y="0.0" z="0.0"/>
       <UpDirection x="-0.05732567980885506" y="0.8251294493675232" z="-0.5620279908180237"/>
       <LookDirection x="0.500179648399353" y="-0.4634685516357422" z="-0.7314486503601074"/>

--- a/online/public/test/cases/zometool-model/index.html
+++ b/online/public/test/cases/zometool-model/index.html
@@ -27,7 +27,7 @@
       <div class="zometool-model-difficulty" data-difficulty="medium">
       </div>
 
-      <zometool-instructions src="../zometool-instructions/all-parts.vZome">
+      <zometool-instructions src="https://raw.githubusercontent.com/vorth/vzome-sharing/main/2024/07/12/21-44-12-332Z-all-parts/all-parts.vZome">
       </zometool-instructions>      
 
       <zometool-parts-required></zometool-parts-required>

--- a/online/src/viewer/context/viewer.jsx
+++ b/online/src/viewer/context/viewer.jsx
@@ -55,14 +55,6 @@ const ViewerProvider = ( props ) =>
     }
   }
 
-  const logShapes = () =>
-  {
-    console.log( 'SHAPES:' );
-    Object.values( scene.shapes ) .forEach( shape => {
-      console.log( `  ${shape.id} ${shape.zone} [${shape.instances.length}]` );
-    })
-  }
-
   subscribeFor( 'SYMMETRY_CHANGED', ( { orientations } ) => {
     setScene( 'orientations', reconcile( orientations ) );
   });

--- a/online/src/wc/zometool/bom.js
+++ b/online/src/wc/zometool/bom.js
@@ -1,4 +1,29 @@
 
+const svgMapping = {
+  ball: 'ball',
+
+  b0:   '[[0,0,1],[0,0,1]]:[-1,1,1]',
+  b1:   '[[0,0,1],[0,0,1]]:[1,0,1]',
+  b2:   '[[0,0,1],[0,0,1]]:[0,1,1]',
+
+  y0:   '[[0,0,1],[2,-1,1]]:[-1,1,1]',
+  y1:   '[[0,0,1],[2,-1,1]]:[1,0,1]',
+  y2:   '[[0,0,1],[2,-1,1]]:[0,1,1]',
+
+  r00:  '[[-1,1,1],[0,0,1]]:[2,-1,1]',
+  r0:   '[[-1,1,1],[0,0,1]]:[-1,1,1]',
+  r1:   '[[-1,1,1],[0,0,1]]:[1,0,1]',
+  r2:   '[[-1,1,1],[0,0,1]]:[0,1,1]',
+
+  g0:   '[[2,-1,1],[5,-3,1]]:[-1,1,1]',
+  g1:   '[[2,-1,1],[5,-3,1]]:[1,0,1]',
+  g2:   '[[2,-1,1],[5,-3,1]]:[0,1,1]',
+
+  hg0:  '[[2,-1,1],[5,-3,1]]:[-1,1,2]',
+  hg1:  '[[2,-1,1],[5,-3,1]]:[1,0,2]',
+  hg2:  '[[2,-1,1],[5,-3,1]]:[0,1,2]',
+}
+
 const partcodeMapping = {
   ball: 'PZB-BAL-W',
   b0:   'PST-B0-BLU',
@@ -19,28 +44,16 @@ const partcodeMapping = {
   hg2:  'PST-HG2-GRN',
 }
 
-const lengthMapping = {
-  ' :2 -phi'        : 'r00',
-  " :1/2"           : 'hg1',
-  " :1/2*phi"       : 'hg2',
-  " :-1/2 +1/2*phi" : 'hg0',
-}
 
 export const normalizeBOM = rawBoM =>
 {
-  for (const key in lengthMapping) {
-    if ( Object.hasOwnProperty.call( rawBoM, key )) {
-      const count = rawBoM[ key ];
-      rawBoM[ lengthMapping[ key ] ] = count;
-    }
-  }
-
   const bom = [];
   // the order in partcodeMapping will be the order in bom
   for (const key in partcodeMapping) {
-    if ( Object.hasOwnProperty.call( rawBoM, key ) ) {
+    const rawKey = svgMapping[ key ];
+    if ( Object.hasOwnProperty.call( rawBoM, rawKey ) ) {
       const partNum = partcodeMapping[ key ];
-      const count = rawBoM[ key ];
+      const count = rawBoM[ rawKey ];
       bom .push( { key, partNum, count } )
     }
   }

--- a/online/src/worker/fields/common.js
+++ b/online/src/worker/fields/common.js
@@ -1,6 +1,6 @@
 
 
-BigInt.prototype.toJSON = function() { return this.toString()  }
+BigInt.prototype.toJSON = function() { return Number(this)  }  // What will this do when the BigInt is too big?
 
 // Most of this code is from Jacob Rus: https://observablehq.com/@jrus/zome-arithmetic
 

--- a/online/src/worker/legacy/interpreter.js
+++ b/online/src/worker/legacy/interpreter.js
@@ -121,8 +121,6 @@ export class RenderHistory
     let shape = this.shapes[ shapeId ];
     if ( ! shape ) {
       shape = realizeShape( rm .getShape() );
-      const orbit = rm .getStrutOrbit();
-      shape.zone = orbit? `${orbit.toString()} ${rm.getStrutZone()}` : 'Ball';
       this.shapes[ shapeId ] = shape;
     }
     let instance = normalizeRenderedManifestation( rm );

--- a/online/src/worker/legacy/partslist.js
+++ b/online/src/worker/legacy/partslist.js
@@ -2,10 +2,10 @@
 export const assemblePartsList = shapes =>
 {
   const bom = {};
-  for (const key in shapes) {
-    const { orbit, name, instances } = shapes[ key ];
-    if ( !name ) continue;
-    const row = name;
+  for (const id in shapes) {
+    const { orbit, length, name, instances } = shapes[ id ];
+    if ( !name && !orbit ) continue;
+    const row = name || `${orbit}:${length}`
     for (const { color } of instances) {
       if ( ! bom[ row ] )
         bom[ row ] = 1;

--- a/online/src/worker/legacy/preview.js
+++ b/online/src/worker/legacy/preview.js
@@ -46,10 +46,82 @@ export const normalizePreview = ( preview ) =>
   snapshots .push( normalizeInstances( instances, "main_" ) );
   const defaultSnapshot = snapshots.length-1;
 
+  const normalizeShape = shape =>
+  {
+    const { name, orbit, orbitC, length, id, vertices, faces } = shape;
+    if ( orbitC ) // latest format 2024-07
+      return { id, orbit: orbitC, length, vertices, faces };
+    if ( name === 'ball' )
+      return { id, name, vertices, faces };
+
+    // earlier 2024 strut format, with orbit and name
+    if ( name && orbit ) {
+      const orbits = {
+        'red'   : '[[-1,1,1],[0,0,1]]',
+        'yellow': '[[0,0,1],[2,-1,1]]',
+        'blue'  : '[[0,0,1],[0,0,1]]',
+        'green' : '[[2,-1,1],[5,-3,1]]',
+      }
+      // TODO: handle more orbits, and odd lengths
+      if ( orbits[ orbit ] ) {
+        let length;
+        switch ( name ) {
+
+          case ' :1/2':
+            length = '[1,0,2]';
+            break;
+
+          case ' :1/2*phi':
+            length = '[0,1,2]';
+            break;
+  
+          case ' :-1/2 +1/2*phi':
+            length = '[-1,1,2]';
+            break;
+          
+          case ' :2 -phi':
+            length = '[2,-1,1]';
+            break;
+
+          case 'b0':
+          case 'y0':
+          case 'r0':
+          case 'g0':
+            length = '[-1,1,1]';
+            break;
+        
+          case 'b1':
+          case 'y1':
+          case 'r1':
+          case 'g1':
+            length = '[1,0,1]';
+            break;
+            
+          case 'b2':
+          case 'y2':
+          case 'r2':
+          case 'g2':
+            length = '[0,1,1]';
+            break;
+        
+          default:
+            break;
+        }
+
+        if ( length )
+          return { id, orbit: orbits[ orbit ], length, vertices, faces };
+      }
+    }
+
+    // These three fields are the minumum required for rendering.
+    //  Any other fields (above) support bill-of-materials features.
+    return { id, vertices, faces };
+  }
+
   // Convert the preview.shapes array to the final shapes object
   const shapes = {}
   preview.shapes.map( shape => {
-    shapes[ shape.id ] = shape;
+    shapes[ shape.id ] = normalizeShape( shape );
   } );
 
   const normalizePreviewScene = ( { title, snapshot, view } ) =>

--- a/online/src/worker/legacy/scenes.js
+++ b/online/src/worker/legacy/scenes.js
@@ -8,6 +8,15 @@ export const realizeShape = ( shape ) =>
   })
   const faces = shape.getFaceSet().toArray().map( (value) => ({ vertices: [...value.array] }) ); // not a no-op, converts to POJS
   const id = 's' + shape.getGuid().toString();
+  const name = shape .getName();
+  if ( name === 'ball' ) {
+    return { id, name, vertices, faces };
+  }
+  else if ( !!name ) {
+    const orbit = shape .getOrbit() .getCanonicalName();
+    const length = JSON.stringify( shape .getLength() .toTrailingDivisor() );
+    return { id, orbit, length, vertices, faces };
+  }
   return { id, vertices, faces };
 }
 
@@ -50,8 +59,6 @@ export const renderedModelTransducer = ( shapeCache, clientEvents ) =>
     let shape = shapeCache[ shapeId ];
     if ( ! shape ) {
       shape = realizeShape( rm .getShape() );
-      const orbit = rm .getStrutOrbit();
-      shape.zone = orbit? `${orbit.toString()} ${rm.getStrutZone()}` : 'Ball';
       shapeCache[ shapeId ] = shape;
       clientEvents .shapeDefined( shape );
     }


### PR DESCRIPTION
Desktop vZome will now add `orbitC` and `length` fields to `.shapes.json`
previews, containing the canonical orbit name and the canonical length, respectively.
When normalizing the preview in vZome Online, `orbitC` is renamed as `orbit`.
Panel shapes have no metadata, and ball shapes have just `name==='ball'`.

I'm not removing the old `name` and `orbit` fields from the legacy desktop
preview format, in case the folks in China use that information to derive their BOMs.

Zometool parts-list (BOM) computation is now expecting a parts table whose keys
are 'ball' or `${orbit}:${length}`, from a normalized shape.

The normalized shape format is created directly when interpreting XML.
