### PR TITLE
Only macs will use lightweight GLJPanel for the main view

### DIFF
--- a/desktop/src/main/java/org/vorthmann/j3d/Platform.java
+++ b/desktop/src/main/java/org/vorthmann/j3d/Platform.java
@@ -16,7 +16,7 @@ import java.util.logging.Logger;
  */
 public class Platform
 {	
-	static boolean isMac = false;
+	public static boolean isMac = false;
 	
 	static boolean isWindows = false;
     

--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
@@ -571,7 +571,7 @@ public class DocumentFrame extends JFrame implements PropertyChangeListener, Con
                 //  in certain circumstances, causing vZome to hang.
                 // BUT... the performance is atrocious, so I want to let folks (and me!) force
                 //  use of the heavyweight canvas, since crashes/spins seem to vary from system to system.
-                boolean lightweight = ! mController .propertyIsTrue( "vzome.jogl.heavyweight.canvas" );
+                boolean lightweight = Platform.isMac && ! mController .propertyIsTrue( "vzome.jogl.heavyweight.canvas" );
                 logger.log( Level.INFO, "vzome.jogl.heavyweight.canvas: " + !lightweight );
                 RenderingViewer viewer = factory3d .createRenderingViewer( scene, lightweight );
 


### PR DESCRIPTION
I don't want Windows and Linux users to pay the performance penalty, when the
defect we are avoiding is only on Macs.
