### PR TITLE
Fixed WIDTH_FACTOR bug

### DIFF
--- a/online/src/viewer/context/camera.jsx
+++ b/online/src/viewer/context/camera.jsx
@@ -7,7 +7,7 @@ import { createStore } from 'solid-js/store';
 export const INITIAL_DISTANCE = 108;
 const NEAR_FACTOR = 0.1 / INITIAL_DISTANCE;
 const FAR_FACTOR = 2.0;
-const WIDTH_FACTOR = 0.5;
+const WIDTH_FACTOR = 0.45;
 
 const defaultCamera = () => ({
   // zoom


### PR DESCRIPTION
The width factor did not match desktop, which caused a subtle defect when
switching scenes whose camera positions were different.  The trackball update
caused the camera width to be recomputed with the wrong factor.  This made
a subtle "zoom" effect.
