### PR TITLE
Fixed username case defect in GitHub browser app

### DIFF
--- a/online/src/app/browser/browser.jsx
+++ b/online/src/app/browser/browser.jsx
@@ -100,7 +100,7 @@ const filterUniqueUsers = users =>
 }
 
 const queryParams = new URLSearchParams( window.location.search );
-const defaultGithubUser = queryParams.get( 'user' ) || localStorage.getItem( 'vzome-github-user' ) || "vorth";
+const defaultGithubUser = queryParams.get( 'user' ) ?.toLowerCase() || localStorage.getItem( 'vzome-github-user' ) || "vorth";
 console.log( "defaultGithubUser ", defaultGithubUser );
 const storedUsers = JSON.parse( localStorage.getItem( 'vzome-github-users' ) || '[ "david-hall", "john-kostick", "thynstyx", "vorth" ]' );
 let knownUsers = filterUniqueUsers( [ defaultGithubUser, ...storedUsers ] );

--- a/online/src/app/browser/users.jsx
+++ b/online/src/app/browser/users.jsx
@@ -3,11 +3,16 @@ import { Select } from "@kobalte/core/select";
 
 export const UsersMenu = (props) =>
 {
+  const changeUser = user => {
+    // user should never be null, now that we lowercase the query parameter first, but still...
+    if ( !! user )
+      props.setUser( user );    
+  }
   return (
     <div style={ { background: 'lightgray' } }>
       <Select
         value={props.currentUser}
-        onChange={props.setUser}
+        onChange={changeUser}
         options={props.users}
         placeholder="Select a GitHub user…"
         itemComponent={props => (


### PR DESCRIPTION
A mixed-case username as a query parameter would cause a null entry from
the select component.  Now we lowercase the query parameter right away.
