### PR TITLE
Fixed a bug in the POV-Ray exporter

### DIFF
--- a/core/src/main/java/com/vzome/core/exporters/POVRayExporter.java
+++ b/core/src/main/java/com/vzome/core/exporters/POVRayExporter.java
@@ -100,9 +100,10 @@ public class POVRayExporter extends DocumentExporter
 		output .println( new String( out .toByteArray() ) );
 		output .println();
 
-		Vector3f dir = new Vector3f();
 		for ( int i = 0; i<3; i++ ) {
 			Color color = mLights .getDirectionalLightColor( i );
+	        RealVector rv = mLights .getDirectionalLightVector( i );
+	        Vector3f dir = new Vector3f( rv.x, rv.y, rv.z );
 			mapViewToWorld( mScene, dir );
 			output .print( "light_source { -light_distance * " + printTuple3d( new Vector3f( dir ) ) );
 			output .print( " " );


### PR DESCRIPTION
Almost a year ago, for `online-r161`, I introduced an API change for the
Lights class, but I didn't adapt the POV-Ray exporter code correctly.  This
corrects that oversight.
