### PR TITLE
Porting POV-Ray and other exporters

### DIFF
--- a/cicd/jsweet-legacy-code.bash
+++ b/cicd/jsweet-legacy-code.bash
@@ -24,7 +24,7 @@ banner 'Transpiling core Java sources with JSweet' #############################
 ./gradlew --continue -p online coreClean core &> core-errors.txt    # ignore the exit code, it always fails
 cat core-errors.txt
 
-grep -q 'transpilation failed with 33 error(s) and 0 warning(s)' core-errors.txt \
+grep -q 'transpilation failed with 35 error(s) and 0 warning(s)' core-errors.txt \
   && banner 'JSweet core transpile found the expected errors' \
   || { banner 'UNEXPECTED CHANGE IN JSWEET CORE ERRORS'; exit 1; }
 

--- a/cicd/online.bash
+++ b/cicd/online.bash
@@ -94,27 +94,16 @@ buildForProduction() {
 }
 
 prepareJSweet(){
-  banner 'We are no longer using JSweet. See online/build.gradle for more details.'
+  banner 'JSweet no longer builds successfully. See online/build.gradle for more details.'
   # source cicd/prepare-jsweet.bash || exit $?
 }
 
 jsweet(){
-  banner 'We are no longer using JSweet. See online/build.gradle for more details.'
-  # source cicd/jsweet-legacy-code.bash || exit $?
+  source cicd/jsweet-legacy-code.bash || exit $?
 }
 
 devJava(){
-  jsweet || exit $?
-
-  cd online
-
-  marshallResources || exit $?
-
-  generateRevisionJs || exit $?
-
-  installJsDependencies || exit $?
-
-  yarn run dev
+  banner 'We are no longer using JSweet automatically. You can still use the "jsweet" command here manually.'
 }
 
 devJs(){

--- a/core/src/main/java/com/vzome/core/editor/DocumentModel.java
+++ b/core/src/main/java/com/vzome/core/editor/DocumentModel.java
@@ -47,6 +47,7 @@ import com.vzome.core.editor.api.Context;
 import com.vzome.core.editor.api.EditorModel;
 import com.vzome.core.editor.api.OrbitSource;
 import com.vzome.core.editor.api.UndoableEdit;
+import com.vzome.core.exporters.DocumentIntf;
 import com.vzome.core.exporters.ShapesJsonExporter;
 import com.vzome.core.math.Projection;
 import com.vzome.core.math.RealVector;
@@ -65,10 +66,11 @@ import com.vzome.core.model.VefModelExporter;
 import com.vzome.core.render.RenderedModel;
 import com.vzome.core.tools.BookmarkToolFactory;
 import com.vzome.core.viewing.Camera;
+import com.vzome.core.viewing.CameraIntf;
 import com.vzome.core.viewing.Lights;
 import com.vzome.xml.DomSerializer;
 
-public class DocumentModel implements Snapshot .Recorder, Context
+public class DocumentModel implements Snapshot .Recorder, Context, DocumentIntf
 {
     private final RealizedModelImpl mRealizedModel;
 
@@ -871,6 +873,12 @@ public class DocumentModel implements Snapshot .Recorder, Context
     }
 
     public Camera getCamera()
+    {
+        return this .defaultCamera;
+    }
+
+    @Override
+    public CameraIntf getCameraModel()
     {
         return this .defaultCamera;
     }

--- a/core/src/main/java/com/vzome/core/exporters/DocumentExporter.java
+++ b/core/src/main/java/com/vzome/core/exporters/DocumentExporter.java
@@ -3,21 +3,20 @@ package com.vzome.core.exporters;
 import java.io.File;
 import java.io.Writer;
 
-import com.vzome.core.editor.DocumentModel;
-import com.vzome.core.viewing.Camera;
+import com.vzome.core.viewing.CameraIntf;
 import com.vzome.core.viewing.Lights;
 
 public abstract class DocumentExporter extends GeometryExporter
 {
     protected transient Lights mLights;
-    protected transient Camera mScene;
+    protected transient CameraIntf mScene;
 
     /**
      * Subclasses can override this if they need to export history, the lesson model, or the selection.
      */
-    public void exportDocument( DocumentModel doc, File file, Writer writer, int height, int width ) throws Exception
+    public void exportDocument( DocumentIntf doc, File file, Writer writer, int height, int width ) throws Exception
     {
-        mScene = doc .getCamera();
+        mScene = doc .getCameraModel();
         mLights = doc .getSceneLighting();
         this .exportGeometry( doc .getRenderedModel(), file, writer, height, width );
         mScene = null;

--- a/core/src/main/java/com/vzome/core/exporters/DocumentIntf.java
+++ b/core/src/main/java/com/vzome/core/exporters/DocumentIntf.java
@@ -1,0 +1,25 @@
+package com.vzome.core.exporters;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import com.vzome.core.editor.ToolsModel;
+import com.vzome.core.editor.api.EditorModel;
+import com.vzome.core.render.RenderedModel;
+import com.vzome.core.viewing.CameraIntf;
+import com.vzome.core.viewing.Lights;
+
+public interface DocumentIntf
+{
+    CameraIntf getCameraModel();
+
+    Lights getSceneLighting();
+
+    RenderedModel getRenderedModel();
+
+    ToolsModel getToolsModel();
+
+    Element getDetailsXml( Document dom, boolean b );
+
+    EditorModel getEditorModel();
+}

--- a/core/src/main/java/com/vzome/core/exporters/GeoGebraExporter.java
+++ b/core/src/main/java/com/vzome/core/exporters/GeoGebraExporter.java
@@ -38,7 +38,7 @@ import com.vzome.core.model.Manifestation;
 import com.vzome.core.model.Panel;
 import com.vzome.core.model.Strut;
 import com.vzome.core.render.RenderedManifestation;
-import com.vzome.core.viewing.Camera;
+import com.vzome.core.viewing.CameraIntf;
 
 // Combines features from DaeExporter and OffExporter
 public class GeoGebraExporter extends DocumentExporter
@@ -205,7 +205,7 @@ public class GeoGebraExporter extends DocumentExporter
             return template;
         }
         
-        private void setScene(Camera scene, Color color) throws XPathExpressionException {
+        private void setScene(CameraIntf scene, Color color) throws XPathExpressionException {
             Element euclidianView3DNode = (Element) xpath.evaluate("//geogebra//euclidianView3D",
                     doc.getDocumentElement(), XPathConstants.NODE);
             { // coordSystem

--- a/core/src/main/java/com/vzome/core/exporters/GeometryExporter.java
+++ b/core/src/main/java/com/vzome/core/exporters/GeometryExporter.java
@@ -47,9 +47,6 @@ public abstract class GeometryExporter implements RealZomeScaling
         return ResourceLoader .loadStringResource( resourcePath );
     }
 
-    /**
-     * Subclasses can override this if they need to export history, the lesson model, or the selection.
-     */
     public void exportGeometry( RenderedModel model, File file, Writer writer, int height, int width ) throws Exception
     {
         mModel = model;

--- a/core/src/main/java/com/vzome/core/exporters/HistoryExporter.java
+++ b/core/src/main/java/com/vzome/core/exporters/HistoryExporter.java
@@ -10,13 +10,12 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import com.vzome.core.editor.DocumentModel;
 import com.vzome.xml.DomSerializer;
 
 public class HistoryExporter extends DocumentExporter
 {
     @Override
-    public void exportDocument( DocumentModel document, File file, Writer writer, int height, int width ) throws Exception
+    public void exportDocument( com.vzome.core.exporters.DocumentIntf document, File file, Writer writer, int height, int width ) throws Exception
     {
         DocumentBuilderFactory factory = DocumentBuilderFactory .newInstance();
         factory .setNamespaceAware( true );

--- a/core/src/main/java/com/vzome/core/exporters/OpenScadExporter.java
+++ b/core/src/main/java/com/vzome/core/exporters/OpenScadExporter.java
@@ -17,7 +17,6 @@ import com.vzome.core.commands.Command;
 import com.vzome.core.construction.Construction;
 import com.vzome.core.construction.Point;
 import com.vzome.core.construction.Polygon;
-import com.vzome.core.editor.DocumentModel;
 import com.vzome.core.editor.Tool;
 import com.vzome.core.editor.ToolsModel;
 import com.vzome.core.math.RealVector;
@@ -37,7 +36,7 @@ import com.vzome.core.render.RenderedManifestation;
 public class OpenScadExporter extends DocumentExporter
 {
     @Override
-    public void exportDocument( DocumentModel doc, File file, Writer writer, int height, int width ) throws Exception
+    public void exportDocument( DocumentIntf doc, File file, Writer writer, int height, int width ) throws Exception
     {
         ToolsModel toolsModel = doc .getToolsModel();
         super .mModel = doc .getRenderedModel();

--- a/core/src/main/java/com/vzome/core/exporters/POVRayExporter.java
+++ b/core/src/main/java/com/vzome/core/exporters/POVRayExporter.java
@@ -14,10 +14,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import javax.vecmath.Matrix4f;
-import javax.vecmath.Tuple3f;
-import javax.vecmath.Vector3f;
-
 import com.vzome.core.algebra.AlgebraicField;
 import com.vzome.core.algebra.AlgebraicMatrix;
 import com.vzome.core.algebra.AlgebraicVector;
@@ -26,7 +22,7 @@ import com.vzome.core.math.Polyhedron;
 import com.vzome.core.math.RealVector;
 import com.vzome.core.math.symmetry.Embedding;
 import com.vzome.core.render.RenderedManifestation;
-import com.vzome.core.viewing.Camera;
+import com.vzome.core.viewing.CameraIntf;
 
 /**
  * Renders out to POV-Ray using #declare statements to reuse geometry.
@@ -38,12 +34,8 @@ public class POVRayExporter extends DocumentExporter
 	
 	private static final String PREAMBLE_FILE = "com/vzome/core/exporters/povray/preamble.pov";
 
-    public void mapViewToWorld( Camera view, Vector3f vector )
+    public void mapViewToWorld( CameraIntf view, RealVector vector )
     {
-        Matrix4f viewTrans = new Matrix4f();
-        view .getViewTransform( viewTrans );
-        viewTrans .invert();
-        viewTrans .transform( vector );
     }
 
     @Override
@@ -56,9 +48,8 @@ public class POVRayExporter extends DocumentExporter
 	{
 	    output = new PrintWriter( writer );
 	    
-		Vector3f lookDir = new Vector3f(), upDir = new Vector3f(), rightDir = new Vector3f();
-		mScene .getViewOrientation( lookDir, upDir );
-		rightDir .cross( lookDir, upDir );
+		RealVector lookDir = mScene .getLookDirectionRV();
+		RealVector upDir = mScene .getUpDirectionRV();
 		FORMAT .setMaximumFractionDigits( 8 );
 
         output .println();
@@ -67,23 +58,13 @@ public class POVRayExporter extends DocumentExporter
         output .println();
         output .println( "#declare             up_dir = " + printTuple3d( upDir ) + ";" );
         output .println();
-        output .println( "#declare          right_dir = " + printTuple3d( rightDir ) + ";" );
-        output .println();
         output .println( "#declare viewpoint_distance = " + mScene .getViewDistance() + ";" );
         output .println();
-        output .println( "#declare near_clip_distance = " + mScene .getNearClipDistance() + ";" );
-        output .println();
-        output .println( "#declare far_clip_distance = " + mScene .getFarClipDistance() + ";" );
-        output .println();
-		output .println( "#declare      look_at_point = " + printTuple3d( mScene .getLookAtPoint() ) + ";" );
+		output .println( "#declare      look_at_point = " + printTuple3d( mScene .getLookAtPointRV() ) + ";" );
         output .println();
 		output .println( "#declare      field_of_view = " + mScene .getFieldOfView() + ";" );
         output .println();
-		output .println( "#declare       canvas_width = " + width + ";" );
-        output .println();
-		output .println( "#declare      canvas_height = " + height + ";" );
-        output .println();
-        output .println( "#declare      parallel_proj = " + (mScene.isPerspective()?0:1) + ";" );
+        output .println( "#declare      parallel_proj = " + (mScene .isPerspective()?0:1) + ";" );
         output .println();
 
 		InputStream input = getClass() .getClassLoader()
@@ -103,9 +84,8 @@ public class POVRayExporter extends DocumentExporter
 		for ( int i = 0; i<3; i++ ) {
 			Color color = mLights .getDirectionalLightColor( i );
 	        RealVector rv = mLights .getDirectionalLightVector( i );
-	        Vector3f dir = new Vector3f( rv.x, rv.y, rv.z );
-			mapViewToWorld( mScene, dir );
-			output .print( "light_source { -light_distance * " + printTuple3d( new Vector3f( dir ) ) );
+	        rv = mScene .mapViewToWorld( rv );
+			output .print( "light_source { -light_distance * " + printTuple3d( rv ) );
 			output .print( " " );
 			printColor( color );
 			output .println( " * multiplier_light_" + (i+1) + " }" );
@@ -216,7 +196,7 @@ public class POVRayExporter extends DocumentExporter
         return "color_" + color .toString() .replace( ',', '_' );
     }
    
-    private String printTuple3d( Tuple3f t )
+    private String printTuple3d( RealVector t )
     {
     	StringBuilder buf = new StringBuilder( "<" );
     	buf .append( FORMAT.format(t.x) );

--- a/core/src/main/java/com/vzome/core/exporters/PartGeometryExporter.java
+++ b/core/src/main/java/com/vzome/core/exporters/PartGeometryExporter.java
@@ -12,7 +12,6 @@ import java.util.TreeSet;
 
 import com.vzome.core.algebra.AlgebraicField;
 import com.vzome.core.algebra.AlgebraicVector;
-import com.vzome.core.editor.DocumentModel;
 import com.vzome.core.editor.api.Selection;
 import com.vzome.core.generic.ArrayComparator;
 import com.vzome.core.model.Connector;
@@ -25,7 +24,7 @@ public class PartGeometryExporter extends VefExporter
 {
     private transient Selection selection;
 
-    public void exportDocument( DocumentModel doc, File file, Writer writer, int height, int width ) throws Exception
+    public void exportDocument( DocumentIntf doc, File file, Writer writer, int height, int width ) throws Exception
     {
         mModel = doc .getRenderedModel();
         this .selection = doc .getEditorModel() .getSelection();

--- a/core/src/main/java/com/vzome/core/exporters/SideEffectsExporter.java
+++ b/core/src/main/java/com/vzome/core/exporters/SideEffectsExporter.java
@@ -10,7 +10,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import com.vzome.core.editor.DocumentModel;
 import com.vzome.xml.DomSerializer;
 
 /**
@@ -22,7 +21,7 @@ import com.vzome.xml.DomSerializer;
 public class SideEffectsExporter extends DocumentExporter
 {
     @Override
-    public void exportDocument( DocumentModel document, File file, Writer writer, int height, int width ) throws Exception
+    public void exportDocument( com.vzome.core.exporters.DocumentIntf document, File file, Writer writer, int height, int width ) throws Exception
     {
         DocumentBuilderFactory factory = DocumentBuilderFactory .newInstance();
         factory .setNamespaceAware( true );

--- a/core/src/main/java/com/vzome/core/viewing/Camera.java
+++ b/core/src/main/java/com/vzome/core/viewing/Camera.java
@@ -16,7 +16,7 @@ import com.vzome.core.math.RealMatrix4;
 import com.vzome.core.math.RealVector;
 import com.vzome.xml.DomUtils;
 
-public class Camera
+public class Camera implements CameraIntf
 {
     /**
      * The original frustum.
@@ -383,5 +383,37 @@ public class Camera
             float z = Float .parseFloat( str );
             mLookDirection = new Vector3f( x, y, z );
         }
+    }
+
+    @Override
+    public RealVector mapViewToWorld( RealVector rv )
+    {
+        Vector3f vector = new Vector3f( rv.x, rv.y, rv.z );
+        Matrix4f viewTrans = new Matrix4f();
+        this .getViewTransform( viewTrans );
+        viewTrans .invert();
+        viewTrans .transform( vector );
+        return new RealVector( vector.x, vector.y, vector.z );
+    }
+
+    @Override
+    public RealVector getLookAtPointRV()
+    {
+        Point3f vector = getLookAtPoint();
+        return new RealVector( vector.x, vector.y, vector.z );
+    }
+
+    @Override
+    public RealVector getLookDirectionRV()
+    {
+        Vector3f vector = getLookDirection();
+        return new RealVector( vector.x, vector.y, vector.z );
+    }
+
+    @Override
+    public RealVector getUpDirectionRV()
+    {
+        Vector3f vector = getUpDirection();
+        return new RealVector( vector.x, vector.y, vector.z );
     }
 }

--- a/core/src/main/java/com/vzome/core/viewing/CameraIntf.java
+++ b/core/src/main/java/com/vzome/core/viewing/CameraIntf.java
@@ -1,0 +1,22 @@
+package com.vzome.core.viewing;
+
+import com.vzome.core.math.RealVector;
+
+public interface CameraIntf
+{
+    boolean isPerspective();
+
+    float getFieldOfView();
+
+    float getViewDistance();
+
+    float getMagnification();
+
+    RealVector getLookAtPointRV();
+
+    RealVector getLookDirectionRV();
+
+    RealVector getUpDirectionRV();
+
+    RealVector mapViewToWorld( RealVector rv );
+}

--- a/online/README.md
+++ b/online/README.md
@@ -32,6 +32,9 @@ cicd/online.bash quickstart
 
 ## Legacy Code Dev Workflow
 
+  This workflow is no longer viable unless you *already* have all of the JSweet components built and installed locally.
+  The JSweet Artifactory server is offline for good, and so the build is not working.
+
 You'll need [Maven](https://maven.apache.org/) installed for these steps.
 You will also require an installation of [JDK 11](https://www.oracle.com/java/technologies/javase/jdk11-archive-downloads.html).
 

--- a/online/build.gradle
+++ b/online/build.gradle
@@ -17,10 +17,10 @@ buildscript {
 	repositories {
     mavenLocal()
 		mavenCentral()
-		maven { url "https://repository.jsweet.org/artifactory/libs-release-local" }
-		maven { url "https://repository.jsweet.org/artifactory/libs-snapshot-local" }
-		maven { url "https://repository.jsweet.org/artifactory/plugins-release-local" }
-		maven { url "https://repository.jsweet.org/artifactory/plugins-snapshot-local" }
+		// maven { url "https://repository.jsweet.org/artifactory/libs-release-local" }
+		// maven { url "https://repository.jsweet.org/artifactory/libs-snapshot-local" }
+		// maven { url "https://repository.jsweet.org/artifactory/plugins-release-local" }
+		// maven { url "https://repository.jsweet.org/artifactory/plugins-snapshot-local" }
 	}
 	dependencies {
 		classpath('org.jsweet:jsweet-gradle-plugin:3.1.0') {
@@ -36,10 +36,10 @@ plugins {
 repositories {
   mavenLocal()
   mavenCentral()
-  maven { url "https://repository.jsweet.org/artifactory/libs-release-local" }
-  maven { url "https://repository.jsweet.org/artifactory/libs-snapshot-local" }
-  maven { url "https://repository.jsweet.org/artifactory/plugins-release-local" }
-  maven { url "https://repository.jsweet.org/artifactory/plugins-snapshot-local" }
+  // maven { url "https://repository.jsweet.org/artifactory/libs-release-local" }
+  // maven { url "https://repository.jsweet.org/artifactory/libs-snapshot-local" }
+  // maven { url "https://repository.jsweet.org/artifactory/plugins-release-local" }
+  // maven { url "https://repository.jsweet.org/artifactory/plugins-snapshot-local" }
   ivy { // not really an Ivy repo, but this pattern lets us automate the bare JAR download for vecmath
     url "https://jogamp.org/deployment"
     metadataSources {
@@ -192,6 +192,7 @@ core.config {
     'com/vzome/core/editor/Snapshot.java',
     
     'com/vzome/core/render/Colors.java',
+    'com/vzome/core/viewing/CameraIntf.java',
     'com/vzome/core/viewing/Lights.java',
     'com/vzome/core/viewing/AbstractShapes.java',
     'com/vzome/core/viewing/AntiprismShapes.java',
@@ -229,10 +230,12 @@ core.config {
 
     'com/vzome/core/generic/SubClassIterator.java',
             
+    // These have already been reimplemented
     'com/vzome/core/algebra/RootThreeField.java',
     'com/vzome/core/algebra/RootTwoField.java',
     'com/vzome/core/algebra/PentagonField.java',
     'com/vzome/core/algebra/HeptagonField.java',
+
     'com/vzome/core/algebra/*Impl.java',
     'com/vzome/core/algebra/AlgebraicFields.java',
 
@@ -248,20 +251,20 @@ core.config {
     'com/vzome/core/edits/RealizeMetaParts.java',
     // 'com/vzome/core/edits/ReplaceWithShape.java',
 
+    // These have already been reimplemented
     'com/vzome/core/exporters/ColoredMeshJsonExporter.java',
     'com/vzome/core/exporters/SimpleMeshJsonExporter.java',
-    'com/vzome/core/exporters/HistoryExporter.java',
     'com/vzome/core/exporters/ShapesJsonExporter.java',
-    'com/vzome/core/exporters/GeoGebraExporter.java',
-    'com/vzome/core/exporters/DocumentExporter.java',
-    'com/vzome/core/exporters/OpenScadExporter.java',
-    'com/vzome/core/exporters/POVRayExporter.java',
-    'com/vzome/core/exporters/PartGeometryExporter.java',
+
+    // These probably don't make sense online, and aren't public anyway
+    'com/vzome/core/exporters/HistoryExporter.java',
     'com/vzome/core/exporters/SideEffectsExporter.java',
-    'com/vzome/core/exporters/DaeExporter.java',
-    'com/vzome/core/exporters/STEPExporter.java',
     'com/vzome/core/exporters/PartsListExporter.java',
-    'com/vzome/core/exporters/MathTableExporter.java',
+
+    // I think I want to include all of these, but...
+    'com/vzome/core/exporters/GeoGebraExporter.java',  // uses DOM and xpath
+    'com/vzome/core/exporters/DaeExporter.java',       // uses DOM and xpath
+    'com/vzome/core/exporters/STEPExporter.java',      // emits multiple files
 
     'com/vzome/desktop/controller/CameraController.java',
     'com/vzome/desktop/controller/JsonClientRendering.java',

--- a/online/src/worker/java/java/io/File.java
+++ b/online/src/worker/java/java/io/File.java
@@ -13,4 +13,14 @@ public class File
     {
         return null;
     }
+
+    public String getName()
+    {
+      return null;
+    }
+
+    public File getParentFile()
+    {
+      return null;
+    }
 }

--- a/online/src/worker/legacy/candies/j4ts-2.1.0-SNAPSHOT/bundle.js
+++ b/online/src/worker/legacy/candies/j4ts-2.1.0-SNAPSHOT/bundle.js
@@ -4916,6 +4916,14 @@ export var java;
             function AbstractCollection() {
             }
             /* Default method injected from java.util.Collection */
+            AbstractCollection.prototype.stream = function () {
+                return (new javaemul.internal.stream.StreamHelper(this));
+            };
+            /* Default method injected from java.util.Collection */
+            AbstractCollection.prototype.parallelStream = function () {
+                return this.stream();
+            };
+            /* Default method injected from java.util.Collection */
             AbstractCollection.prototype.removeIf = function (filter) {
                 javaemul.internal.InternalPreconditions.checkNotNull(((function (funcInst) { if (funcInst == null || typeof funcInst == 'function') {
                     return funcInst;
@@ -4935,10 +4943,6 @@ export var java;
                 }
                 return removed;
             };
-            /* Default method injected from java.util.Collection */
-            AbstractCollection.prototype.parallelStream = function () {
-                return this.stream();
-            };
             /* Default method injected from java.lang.Iterable */
             AbstractCollection.prototype.forEach = function (action) {
                 javaemul.internal.InternalPreconditions.checkNotNull(((function (funcInst) { if (funcInst == null || typeof funcInst == 'function') {
@@ -4953,10 +4957,6 @@ export var java;
                 for (var index = this.iterator(); index.hasNext();) {
                     _loop_3(index);
                 }
-            };
-            /* Default method injected from java.util.Collection */
-            AbstractCollection.prototype.stream = function () {
-                return (new javaemul.internal.stream.StreamHelper(this));
             };
             /**
              *
@@ -11153,10 +11153,6 @@ export var java;
                     throw new Error('invalid overload');
             }
             /* Default method injected from java.util.Iterator */
-            Scanner.prototype.remove = function () {
-                throw new java.lang.UnsupportedOperationException();
-            };
-            /* Default method injected from java.util.Iterator */
             Scanner.prototype.forEachRemaining = function (consumer) {
                 var _this = this;
                 javaemul.internal.InternalPreconditions.checkNotNull(((function (funcInst) { if (funcInst == null || typeof funcInst == 'function') {
@@ -11168,6 +11164,10 @@ export var java;
                     }
                 }
                 ;
+            };
+            /* Default method injected from java.util.Iterator */
+            Scanner.prototype.remove = function () {
+                throw new java.lang.UnsupportedOperationException();
             };
             Scanner.numeral_$LI$ = function () { if (Scanner.numeral == null) {
                 Scanner.numeral = Scanner.digit + "+";
@@ -17251,14 +17251,9 @@ export var java;
                 }
             };
             /* Default method injected from java.util.Map */
-            AbstractMap.prototype.computeIfAbsent = function (key, mappingFunction) {
-                var result;
-                if ((result = this.get(key)) == null) {
-                    result = (function (target) { return (typeof target === 'function') ? target(key) : target.apply(key); })(mappingFunction);
-                    if (result != null)
-                        this.put(key, result);
-                }
-                return result;
+            AbstractMap.prototype.getOrDefault = function (key, defaultValue) {
+                var v;
+                return (((v = this.get(key)) != null) || this.containsKey(key)) ? v : defaultValue;
             };
             /* Default method injected from java.util.Map */
             AbstractMap.prototype.merge = function (key, value, map) {
@@ -17273,9 +17268,14 @@ export var java;
                 return next;
             };
             /* Default method injected from java.util.Map */
-            AbstractMap.prototype.getOrDefault = function (key, defaultValue) {
-                var v;
-                return (((v = this.get(key)) != null) || this.containsKey(key)) ? v : defaultValue;
+            AbstractMap.prototype.computeIfAbsent = function (key, mappingFunction) {
+                var result;
+                if ((result = this.get(key)) == null) {
+                    result = (function (target) { return (typeof target === 'function') ? target(key) : target.apply(key); })(mappingFunction);
+                    if (result != null)
+                        this.put(key, result);
+                }
+                return result;
             };
             /* Default method injected from java.util.Map */
             AbstractMap.prototype.putIfAbsent = function (key, value) {
@@ -24978,6 +24978,14 @@ export var java;
                     this.coll = coll;
                 }
                 /* Default method injected from java.util.Collection */
+                UnmodifiableCollection.prototype.stream = function () {
+                    return (new javaemul.internal.stream.StreamHelper(this));
+                };
+                /* Default method injected from java.util.Collection */
+                UnmodifiableCollection.prototype.parallelStream = function () {
+                    return this.stream();
+                };
+                /* Default method injected from java.util.Collection */
                 UnmodifiableCollection.prototype.removeIf = function (filter) {
                     javaemul.internal.InternalPreconditions.checkNotNull(((function (funcInst) { if (funcInst == null || typeof funcInst == 'function') {
                         return funcInst;
@@ -24997,10 +25005,6 @@ export var java;
                     }
                     return removed;
                 };
-                /* Default method injected from java.util.Collection */
-                UnmodifiableCollection.prototype.parallelStream = function () {
-                    return this.stream();
-                };
                 /* Default method injected from java.lang.Iterable */
                 UnmodifiableCollection.prototype.forEach = function (action) {
                     javaemul.internal.InternalPreconditions.checkNotNull(((function (funcInst) { if (funcInst == null || typeof funcInst == 'function') {
@@ -25015,10 +25019,6 @@ export var java;
                     for (var index = this.iterator(); index.hasNext();) {
                         _loop_7(index);
                     }
-                };
-                /* Default method injected from java.util.Collection */
-                UnmodifiableCollection.prototype.stream = function () {
-                    return (new javaemul.internal.stream.StreamHelper(this));
                 };
                 /**
                  *
@@ -25522,14 +25522,9 @@ export var java;
                     }
                 };
                 /* Default method injected from java.util.Map */
-                UnmodifiableMap.prototype.computeIfAbsent = function (key, mappingFunction) {
-                    var result;
-                    if ((result = this.get(key)) == null) {
-                        result = (function (target) { return (typeof target === 'function') ? target(key) : target.apply(key); })(mappingFunction);
-                        if (result != null)
-                            this.put(key, result);
-                    }
-                    return result;
+                UnmodifiableMap.prototype.getOrDefault = function (key, defaultValue) {
+                    var v;
+                    return (((v = this.get(key)) != null) || this.containsKey(key)) ? v : defaultValue;
                 };
                 /* Default method injected from java.util.Map */
                 UnmodifiableMap.prototype.merge = function (key, value, map) {
@@ -25544,9 +25539,14 @@ export var java;
                     return next;
                 };
                 /* Default method injected from java.util.Map */
-                UnmodifiableMap.prototype.getOrDefault = function (key, defaultValue) {
-                    var v;
-                    return (((v = this.get(key)) != null) || this.containsKey(key)) ? v : defaultValue;
+                UnmodifiableMap.prototype.computeIfAbsent = function (key, mappingFunction) {
+                    var result;
+                    if ((result = this.get(key)) == null) {
+                        result = (function (target) { return (typeof target === 'function') ? target(key) : target.apply(key); })(mappingFunction);
+                        if (result != null)
+                            this.put(key, result);
+                    }
+                    return result;
                 };
                 /* Default method injected from java.util.Map */
                 UnmodifiableMap.prototype.putIfAbsent = function (key, value) {
@@ -26262,6 +26262,14 @@ export var java;
                 return _this;
             }
             /* Default method injected from java.util.Collection */
+            LinkedList.prototype.stream = function () {
+                return (new javaemul.internal.stream.StreamHelper(this));
+            };
+            /* Default method injected from java.util.Collection */
+            LinkedList.prototype.parallelStream = function () {
+                return this.stream();
+            };
+            /* Default method injected from java.util.Collection */
             LinkedList.prototype.removeIf = function (filter) {
                 javaemul.internal.InternalPreconditions.checkNotNull(((function (funcInst) { if (funcInst == null || typeof funcInst == 'function') {
                     return funcInst;
@@ -26281,6 +26289,21 @@ export var java;
                 }
                 return removed;
             };
+            /* Default method injected from java.lang.Iterable */
+            LinkedList.prototype.forEach = function (action) {
+                javaemul.internal.InternalPreconditions.checkNotNull(((function (funcInst) { if (funcInst == null || typeof funcInst == 'function') {
+                    return funcInst;
+                } return function (arg0) { return (funcInst['accept'] ? funcInst['accept'] : funcInst).call(funcInst, arg0); }; })(action)));
+                var _loop_10 = function (index) {
+                    var t = index.next();
+                    {
+                        (function (target) { return (typeof target === 'function') ? target(t) : target.accept(t); })(action);
+                    }
+                };
+                for (var index = this.iterator(); index.hasNext();) {
+                    _loop_10(index);
+                }
+            };
             /* Default method injected from java.util.List */
             LinkedList.prototype.sort = function (c) {
                 var a = this.toArray();
@@ -26297,29 +26320,6 @@ export var java;
                         i.set(e);
                     }
                 }
-            };
-            /* Default method injected from java.util.Collection */
-            LinkedList.prototype.parallelStream = function () {
-                return this.stream();
-            };
-            /* Default method injected from java.lang.Iterable */
-            LinkedList.prototype.forEach = function (action) {
-                javaemul.internal.InternalPreconditions.checkNotNull(((function (funcInst) { if (funcInst == null || typeof funcInst == 'function') {
-                    return funcInst;
-                } return function (arg0) { return (funcInst['accept'] ? funcInst['accept'] : funcInst).call(funcInst, arg0); }; })(action)));
-                var _loop_10 = function (index) {
-                    var t = index.next();
-                    {
-                        (function (target) { return (typeof target === 'function') ? target(t) : target.accept(t); })(action);
-                    }
-                };
-                for (var index = this.iterator(); index.hasNext();) {
-                    _loop_10(index);
-                }
-            };
-            /* Default method injected from java.util.Collection */
-            LinkedList.prototype.stream = function () {
-                return (new javaemul.internal.stream.StreamHelper(this));
             };
             /**
              *
@@ -27196,14 +27196,9 @@ export var java;
                 }
             };
             /* Default method injected from java.util.Map */
-            IdentityHashMap.prototype.computeIfAbsent = function (key, mappingFunction) {
-                var result;
-                if ((result = this.get(key)) == null) {
-                    result = (function (target) { return (typeof target === 'function') ? target(key) : target.apply(key); })(mappingFunction);
-                    if (result != null)
-                        this.put(key, result);
-                }
-                return result;
+            IdentityHashMap.prototype.getOrDefault = function (key, defaultValue) {
+                var v;
+                return (((v = this.get(key)) != null) || this.containsKey(key)) ? v : defaultValue;
             };
             /* Default method injected from java.util.Map */
             IdentityHashMap.prototype.merge = function (key, value, map) {
@@ -27218,9 +27213,14 @@ export var java;
                 return next;
             };
             /* Default method injected from java.util.Map */
-            IdentityHashMap.prototype.getOrDefault = function (key, defaultValue) {
-                var v;
-                return (((v = this.get(key)) != null) || this.containsKey(key)) ? v : defaultValue;
+            IdentityHashMap.prototype.computeIfAbsent = function (key, mappingFunction) {
+                var result;
+                if ((result = this.get(key)) == null) {
+                    result = (function (target) { return (typeof target === 'function') ? target(key) : target.apply(key); })(mappingFunction);
+                    if (result != null)
+                        this.put(key, result);
+                }
+                return result;
             };
             /* Default method injected from java.util.Map */
             IdentityHashMap.prototype.putIfAbsent = function (key, value) {
@@ -29398,14 +29398,9 @@ export var java;
                 }
             };
             /* Default method injected from java.util.Map */
-            LinkedHashMap.prototype.computeIfAbsent = function (key, mappingFunction) {
-                var result;
-                if ((result = this.get(key)) == null) {
-                    result = (function (target) { return (typeof target === 'function') ? target(key) : target.apply(key); })(mappingFunction);
-                    if (result != null)
-                        this.put(key, result);
-                }
-                return result;
+            LinkedHashMap.prototype.getOrDefault = function (key, defaultValue) {
+                var v;
+                return (((v = this.get(key)) != null) || this.containsKey(key)) ? v : defaultValue;
             };
             /* Default method injected from java.util.Map */
             LinkedHashMap.prototype.merge = function (key, value, map) {
@@ -29420,9 +29415,14 @@ export var java;
                 return next;
             };
             /* Default method injected from java.util.Map */
-            LinkedHashMap.prototype.getOrDefault = function (key, defaultValue) {
-                var v;
-                return (((v = this.get(key)) != null) || this.containsKey(key)) ? v : defaultValue;
+            LinkedHashMap.prototype.computeIfAbsent = function (key, mappingFunction) {
+                var result;
+                if ((result = this.get(key)) == null) {
+                    result = (function (target) { return (typeof target === 'function') ? target(key) : target.apply(key); })(mappingFunction);
+                    if (result != null)
+                        this.put(key, result);
+                }
+                return result;
             };
             /* Default method injected from java.util.Map */
             LinkedHashMap.prototype.putIfAbsent = function (key, value) {

--- a/online/src/worker/legacy/controllers/editor.js
+++ b/online/src/worker/legacy/controllers/editor.js
@@ -5,8 +5,7 @@ import { JsProperties } from '../jsweet2js.js';
 import { PickingController } from './picking.js';
 import { BuildPlaneController } from './buildplane.js';
 import { modelToJS } from "../json.js";
-import { export2d, export3d } from "../exporters.js";
-import { serializeVZomeXml } from '../serializer.js';
+import { export2d, export3d, export3dDocument } from "../exporters.js";
 
 
 export class EditorController extends com.vzome.desktop.controller.DefaultController
@@ -210,6 +209,11 @@ export class EditorController extends com.vzome.desktop.controller.DefaultContro
             const { renderedModel } = this.legacyDesign;
             const config = { format, height, width, useShapes, drawOutlines, monochrome, showBackground, useLighting };
             exported = export2d( { renderedModel, camera, lighting }, config );
+            break;
+          }
+
+          case 'pov': {
+            exported = export3dDocument( this.legacyDesign, camera, lighting, { format, height, width } );
             break;
           }
 

--- a/online/src/worker/legacy/core-java.js
+++ b/online/src/worker/legacy/core-java.js
@@ -53,6 +53,12 @@ import { java, javaemul } from "./candies/j4ts-2.1.0-SNAPSHOT/bundle.js"
             getAbsolutePath() {
                 return null;
             }
+            getName() {
+                return null;
+            }
+            getParentFile() {
+                return null;
+            }
         }
         io.File = File;
         File["__class"] = "java.io.File";
@@ -2897,14 +2903,6 @@ export var com;
                     getBoilerplate(resourcePath) {
                         return com.vzome.xml.ResourceLoader.loadStringResource(resourcePath);
                     }
-                    /**
-                     * Subclasses can override this if they need to export history, the lesson model, or the selection.
-                     * @param {com.vzome.core.render.RenderedModel} model
-                     * @param {java.io.File} file
-                     * @param {java.io.Writer} writer
-                     * @param {number} height
-                     * @param {number} width
-                     */
                     exportGeometry(model, file, writer, height, width) {
                         this.mModel = model;
                         this.doExport(file, writer, height, width);
@@ -3954,6 +3952,29 @@ export var com;
                             this.orbits = new com.vzome.core.math.symmetry.OrbitSet(symmetry);
                         }
                         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                        getEmbedding() {
+                            const symmetry = this.getSymmetry();
+                            const field = symmetry.getField();
+                            const embedding = (s => { let a = []; while (s-- > 0)
+                                a.push(0); return a; })(16);
+                            for (let i = 0; i < 3; i++) {
+                                {
+                                    const columnSelect = field.basisVector(3, i);
+                                    const colRV = symmetry.embedInR3(columnSelect);
+                                    embedding[i * 4 + 0] = colRV.x;
+                                    embedding[i * 4 + 1] = colRV.y;
+                                    embedding[i * 4 + 2] = colRV.z;
+                                    embedding[i * 4 + 3] = 0.0;
+                                }
+                                ;
+                            }
+                            embedding[12] = 0.0;
+                            embedding[13] = 0.0;
+                            embedding[14] = 0.0;
+                            embedding[15] = 1.0;
+                            return embedding;
+                        }
+                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                         getOrientations$() {
                             return this.getOrientations(false);
                         }
@@ -4014,29 +4035,6 @@ export var com;
                             }
                             else
                                 throw new Error('invalid overload');
-                        }
-                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                        getEmbedding() {
-                            const symmetry = this.getSymmetry();
-                            const field = symmetry.getField();
-                            const embedding = (s => { let a = []; while (s-- > 0)
-                                a.push(0); return a; })(16);
-                            for (let i = 0; i < 3; i++) {
-                                {
-                                    const columnSelect = field.basisVector(3, i);
-                                    const colRV = symmetry.embedInR3(columnSelect);
-                                    embedding[i * 4 + 0] = colRV.x;
-                                    embedding[i * 4 + 1] = colRV.y;
-                                    embedding[i * 4 + 2] = colRV.z;
-                                    embedding[i * 4 + 3] = 0.0;
-                                }
-                                ;
-                            }
-                            embedding[12] = 0.0;
-                            embedding[13] = 0.0;
-                            embedding[14] = 0.0;
-                            embedding[15] = 1.0;
-                            return embedding;
                         }
                         /**
                          *
@@ -16763,6 +16761,29 @@ export var com;
                         this.setStyle(styleName);
                     }
                     /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                    getEmbedding() {
+                        const symmetry = this.getSymmetry();
+                        const field = symmetry.getField();
+                        const embedding = (s => { let a = []; while (s-- > 0)
+                            a.push(0); return a; })(16);
+                        for (let i = 0; i < 3; i++) {
+                            {
+                                const columnSelect = field.basisVector(3, i);
+                                const colRV = symmetry.embedInR3(columnSelect);
+                                embedding[i * 4 + 0] = colRV.x;
+                                embedding[i * 4 + 1] = colRV.y;
+                                embedding[i * 4 + 2] = colRV.z;
+                                embedding[i * 4 + 3] = 0.0;
+                            }
+                            ;
+                        }
+                        embedding[12] = 0.0;
+                        embedding[13] = 0.0;
+                        embedding[14] = 0.0;
+                        embedding[15] = 1.0;
+                        return embedding;
+                    }
+                    /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                     getOrientations$() {
                         return this.getOrientations(false);
                     }
@@ -16844,29 +16865,6 @@ export var com;
                         }
                         else
                             throw new Error('invalid overload');
-                    }
-                    /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                    getEmbedding() {
-                        const symmetry = this.getSymmetry();
-                        const field = symmetry.getField();
-                        const embedding = (s => { let a = []; while (s-- > 0)
-                            a.push(0); return a; })(16);
-                        for (let i = 0; i < 3; i++) {
-                            {
-                                const columnSelect = field.basisVector(3, i);
-                                const colRV = symmetry.embedInR3(columnSelect);
-                                embedding[i * 4 + 0] = colRV.x;
-                                embedding[i * 4 + 1] = colRV.y;
-                                embedding[i * 4 + 2] = colRV.z;
-                                embedding[i * 4 + 3] = 0.0;
-                            }
-                            ;
-                        }
-                        embedding[12] = 0.0;
-                        embedding[13] = 0.0;
-                        embedding[14] = 0.0;
-                        embedding[15] = 1.0;
-                        return embedding;
                     }
                     static logger_$LI$() { if (SymmetrySystem.logger == null) {
                         SymmetrySystem.logger = java.util.logging.Logger.getLogger("com.vzome.core.editor");
@@ -23452,6 +23450,46 @@ export var com;
                 exporters.PythonBuild123dExporter = PythonBuild123dExporter;
                 PythonBuild123dExporter["__class"] = "com.vzome.core.exporters.PythonBuild123dExporter";
                 PythonBuild123dExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
+            })(exporters = core.exporters || (core.exporters = {}));
+        })(core = vzome.core || (vzome.core = {}));
+    })(vzome = com.vzome || (com.vzome = {}));
+})(com || (com = {}));
+(function (com) {
+    var vzome;
+    (function (vzome) {
+        var core;
+        (function (core) {
+            var exporters;
+            (function (exporters) {
+                class DocumentExporter extends com.vzome.core.exporters.GeometryExporter {
+                    constructor() {
+                        super();
+                        if (this.mLights === undefined) {
+                            this.mLights = null;
+                        }
+                        if (this.mScene === undefined) {
+                            this.mScene = null;
+                        }
+                    }
+                    /**
+                     * Subclasses can override this if they need to export history, the lesson model, or the selection.
+                     * @param {*} doc
+                     * @param {java.io.File} file
+                     * @param {java.io.Writer} writer
+                     * @param {number} height
+                     * @param {number} width
+                     */
+                    exportDocument(doc, file, writer, height, width) {
+                        this.mScene = doc.getCameraModel();
+                        this.mLights = doc.getSceneLighting();
+                        this.exportGeometry(doc.getRenderedModel(), file, writer, height, width);
+                        this.mScene = null;
+                        this.mLights = null;
+                    }
+                }
+                exporters.DocumentExporter = DocumentExporter;
+                DocumentExporter["__class"] = "com.vzome.core.exporters.DocumentExporter";
+                DocumentExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
             })(exporters = core.exporters || (core.exporters = {}));
         })(core = vzome.core || (vzome.core = {}));
     })(vzome = com.vzome || (com.vzome = {}));
@@ -32183,6 +32221,331 @@ export var com;
     (function (vzome) {
         var core;
         (function (core) {
+            var exporters;
+            (function (exporters) {
+                class MathTableExporter extends com.vzome.core.exporters.GeometryExporter {
+                    constructor() {
+                        super();
+                    }
+                    static X_$LI$() { if (MathTableExporter.X == null) {
+                        MathTableExporter.X = com.vzome.core.algebra.AlgebraicVector.X;
+                    } return MathTableExporter.X; }
+                    static Y_$LI$() { if (MathTableExporter.Y == null) {
+                        MathTableExporter.Y = com.vzome.core.algebra.AlgebraicVector.Y;
+                    } return MathTableExporter.Y; }
+                    /**
+                     *
+                     * @param {java.io.File} file
+                     * @param {java.io.Writer} writer
+                     * @param {number} height
+                     * @param {number} width
+                     */
+                    doExport(file, writer, height, width) {
+                        const field = this.mModel.getField();
+                        const buf = new java.lang.StringBuilder();
+                        buf.append("{\n");
+                        MathTableExporter.writeFieldData(field, buf);
+                        MathTableExporter.writeUnitTermsOrDiagonals(field, buf);
+                        MathTableExporter.writeMultiplicationTable(field, buf);
+                        MathTableExporter.writeDivisionTable(field, buf);
+                        MathTableExporter.writeExponentsTable(field, buf);
+                        if (field != null && field instanceof com.vzome.core.algebra.PolygonField) {
+                            MathTableExporter.writeNamedNumbers(field, buf);
+                            MathTableExporter.writeEmbedding(field, buf);
+                            MathTableExporter.writeTrigTable(field, buf);
+                        }
+                        buf.setLength(buf.length() - 2);
+                        buf.append("\n}\n");
+                        this.output = new java.io.PrintWriter(writer);
+                        this.output.println$java_lang_Object(/* replace */ buf.toString().split("\'").join("\""));
+                        this.output.flush();
+                    }
+                    /*private*/ static getUnitTermOrDiagonal(field, i) {
+                        return (field != null && field instanceof com.vzome.core.algebra.PolygonField) ? field.getUnitDiagonal(i) : field.getUnitTerm(i);
+                    }
+                    /*private*/ static getFieldOrderOrDiagonalCount(field) {
+                        return (field != null && field instanceof com.vzome.core.algebra.PolygonField) ? field.diagonalCount() : field.getOrder();
+                    }
+                    /*private*/ static writeFieldData(field, buf) {
+                        buf.append(" \'field\': { ").append("\'name\': \'").append(field.getName()).append("\', ").append("\'order\': ").append(field.getOrder());
+                        if (field != null && field instanceof com.vzome.core.algebra.PolygonField) {
+                            const pfield = field;
+                            buf.append(", \'parity\': \'").append(pfield.isOdd() ? "odd" : "even").append("\', ").append("\'diagonalCount\': ").append(pfield.diagonalCount()).append(", ").append("\'polygonSides\': ").append(pfield.polygonSides());
+                        }
+                        buf.append(" },\n");
+                    }
+                    /*private*/ static writeEmbedding(field, buf) {
+                        const symm = new com.vzome.core.math.symmetry.AntiprismSymmetry(field);
+                        const embeddingRows = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+                        for (let i = 0; i < 3; i++) {
+                            {
+                                const column = symm.embedInR3(field.basisVector(3, i));
+                                embeddingRows[0 + i] = column.x;
+                                embeddingRows[4 + i] = column.y;
+                                embeddingRows[8 + i] = column.z;
+                            }
+                            ;
+                        }
+                        buf.append(" \'embedding\': [ ");
+                        let delim = "";
+                        for (let index = 0; index < embeddingRows.length; index++) {
+                            let f = embeddingRows[index];
+                            {
+                                buf.append(delim).append(f);
+                                delim = ", ";
+                            }
+                        }
+                        buf.append(" ],\n");
+                    }
+                    /*private*/ static writeUnitTermsOrDiagonals(field, buf) {
+                        const limit = MathTableExporter.getFieldOrderOrDiagonalCount(field);
+                        buf.append(" \'unitTerms\': [ ");
+                        let delim = "\n";
+                        for (let i = 0; i < limit; i++) {
+                            {
+                                const number = MathTableExporter.getUnitTermOrDiagonal(field, i);
+                                const name = (i === 0) ? "1" : field['getIrrational$int'](i);
+                                buf.append(delim);
+                                delim = ",\n";
+                                buf.append("  { \'name\': \'").append(name).append("\'");
+                                buf.append(", \'value\': ").append(MathTableExporter.formatAN(number));
+                                buf.append(" }");
+                            }
+                            ;
+                        }
+                        buf.append("\n ],\n");
+                    }
+                    static OPTIONAL_NAMED_VALUES_$LI$() { if (MathTableExporter.OPTIONAL_NAMED_VALUES == null) {
+                        MathTableExporter.OPTIONAL_NAMED_VALUES = ["phi", "rho", "sigma", "alpha", "beta", "gamma", "delta", "epsilon", "theta", "kappa", "lambda", "mu", "\u221a2", "\u221a3", "\u221a5", "\u221a6", "\u221a7", "\u221a8", "\u221a10"];
+                    } return MathTableExporter.OPTIONAL_NAMED_VALUES; }
+                    /*private*/ static writeNamedNumbers(field, buf) {
+                        buf.append(" \'namedNumbers\': [");
+                        let delim = "\n";
+                        for (let index = 0; index < MathTableExporter.OPTIONAL_NAMED_VALUES_$LI$().length; index++) {
+                            let name = MathTableExporter.OPTIONAL_NAMED_VALUES_$LI$()[index];
+                            {
+                                const number = field.getNumberByName(name);
+                                if (number != null) {
+                                    buf.append(delim);
+                                    delim = ",\n";
+                                    buf.append("  { \'name\': \'").append(name).append("\', ");
+                                    buf.append("\'value\': ").append(MathTableExporter.formatAN(number)).append(", ");
+                                    switch ((name)) {
+                                        case "phi":
+                                            MathTableExporter.writeDiagonalRatio(field, 5, buf);
+                                            break;
+                                        case "rho":
+                                            MathTableExporter.writeDiagonalRatio(field, 7, buf);
+                                            break;
+                                        case "sigma":
+                                            MathTableExporter.writeDiagonalRatio(field, 7, buf, 3);
+                                            break;
+                                        case "\u221a2":
+                                            MathTableExporter.writeDiagonalRatio(field, 4, buf);
+                                            break;
+                                        case "\u221a3":
+                                            MathTableExporter.writeDiagonalRatio(field, 6, buf);
+                                            break;
+                                        default:
+                                            break;
+                                    }
+                                    buf.append("\'reciprocal\': ").append(MathTableExporter.formatAN(number.reciprocal()));
+                                    buf.append(" }");
+                                }
+                            }
+                        }
+                        buf.append("\n ],\n");
+                    }
+                    /*private*/ static writeTrigTable(field, buf) {
+                        const rotationMatrix = (new com.vzome.core.math.symmetry.AntiprismSymmetry(field)).getRotationMatrix();
+                        const vX = field.basisVector(3, MathTableExporter.X_$LI$());
+                        const v1 = rotationMatrix.timesColumn(vX);
+                        let bisector = vX.plus(v1).scale(field.getUnitTerm(1).reciprocal());
+                        let v = vX;
+                        const nSides = field.polygonSides();
+                        buf.append(" \'trig\': [\n");
+                        for (let i = 0; i < nSides; i++) {
+                            {
+                                MathTableExporter.writeTrigEntry(i, nSides, v, bisector, buf);
+                                buf.append(i === nSides - 1 ? "\n" : ",\n");
+                                v = rotationMatrix.timesColumn(v);
+                                bisector = rotationMatrix.timesColumn(bisector);
+                            }
+                            ;
+                        }
+                        buf.append(" ],\n");
+                    }
+                    /*private*/ static writeMultiplicationTable(field, buf) {
+                        MathTableExporter.writeTable(field, buf, "multiplication", (n1, n2) => n1['times$com_vzome_core_algebra_AlgebraicNumber'](n2));
+                    }
+                    /*private*/ static writeDivisionTable(field, buf) {
+                        MathTableExporter.writeTable(field, buf, "division", (n1, n2) => n1.dividedBy(n2));
+                    }
+                    /*private*/ static writeTable(field, buf, tableName, op) {
+                        const operandFactory = (field != null && field instanceof com.vzome.core.algebra.PolygonField) ? (instance$PolygonField, n) => { return instance$PolygonField.getUnitDiagonal(n); } : (n) => { return field.getUnitTerm(n); };
+                        const limit = (field != null && field instanceof com.vzome.core.algebra.PolygonField) ? field.diagonalCount() : field.getOrder();
+                        buf.append(" \'").append(tableName).append("\': [\n");
+                        let delim1 = "";
+                        for (let i = 0; i < limit; i++) {
+                            {
+                                const n1 = (target => (typeof target === 'function') ? target(i) : target.apply(i))(operandFactory);
+                                buf.append(delim1).append("  [ ");
+                                delim1 = ",\n";
+                                let delim2 = "";
+                                for (let j = 0; j < limit; j++) {
+                                    {
+                                        const n2 = (target => (typeof target === 'function') ? target(j) : target.apply(j))(operandFactory);
+                                        const result = (target => (typeof target === 'function') ? target(n1, n2) : target.apply(n1, n2))(op);
+                                        buf.append(delim2);
+                                        delim2 = ", ";
+                                        buf.append(MathTableExporter.formatAN(result));
+                                    }
+                                    ;
+                                }
+                                buf.append(" ]");
+                            }
+                            ;
+                        }
+                        buf.append("\n ],\n");
+                    }
+                    /*private*/ static writeExponentsTable(field, buf) {
+                        const limit = MathTableExporter.getFieldOrderOrDiagonalCount(field);
+                        const range = 6;
+                        buf.append(" \'exponents\': [\n");
+                        let delim1 = "";
+                        for (let i = 1; i < limit; i++) {
+                            {
+                                buf.append(delim1).append("  {");
+                                delim1 = ",\n";
+                                const name = field['getIrrational$int'](i);
+                                buf.append(" \'base\': \'").append(name).append("\'");
+                                {
+                                    buf.append(",\n    \'positivePowers\': [ ");
+                                    let delim2 = "";
+                                    const base = MathTableExporter.getUnitTermOrDiagonal(field, i);
+                                    let result = base;
+                                    for (let power = 1; power <= range; power++) {
+                                        {
+                                            buf.append(delim2);
+                                            delim2 = ", ";
+                                            buf.append(MathTableExporter.formatAN(result));
+                                            result = result['times$com_vzome_core_algebra_AlgebraicNumber'](base);
+                                        }
+                                        ;
+                                    }
+                                    buf.append(" ]");
+                                }
+                                ;
+                                {
+                                    buf.append(",\n    \'negativePowers\': [ ");
+                                    let delim2 = "";
+                                    const base = MathTableExporter.getUnitTermOrDiagonal(field, i).reciprocal();
+                                    let result = base;
+                                    for (let power = 1; power <= range; power++) {
+                                        {
+                                            buf.append(delim2);
+                                            delim2 = ", ";
+                                            buf.append(MathTableExporter.formatAN(result));
+                                            result = result['times$com_vzome_core_algebra_AlgebraicNumber'](base);
+                                        }
+                                        ;
+                                    }
+                                    buf.append(" ]");
+                                }
+                                ;
+                                buf.append("\n  }");
+                            }
+                            ;
+                        }
+                        buf.append("\n ],\n");
+                    }
+                    static writeDiagonalRatio(field, divisor, buf, step = 2) {
+                        if (field.polygonSides() % divisor === 0) {
+                            const n = (field.polygonSides() / divisor | 0);
+                            const denominator = field.getUnitDiagonal(n - 1);
+                            const numerator = field.getUnitDiagonal((step * n) - 1);
+                            buf.append("\'numerator\': ").append(MathTableExporter.formatAN(numerator)).append(", ");
+                            buf.append("\'denominator\': ").append(MathTableExporter.formatAN(denominator)).append(", ");
+                        }
+                        else {
+                            throw new java.lang.IllegalStateException("shouldn\'t ever get here");
+                        }
+                    }
+                    /*private*/ static writeTrigEntry(i, nSides, vStep, bisector, buf) {
+                        const delim1 = "\', ";
+                        const delim2 = ", ";
+                        const infinite = "{ \'alg\': \'\u221e\', \'dec\': \'\u221e\', \'tdf\': \'\u221e\' }";
+                        let v = vStep;
+                        for (let n = 0; n < 2; n++) {
+                            {
+                                const k = (i * 2) + n;
+                                const degrees = k * 180.0 / nSides;
+                                const sin = v.getComponent(MathTableExporter.Y_$LI$());
+                                const cos = v.getComponent(MathTableExporter.X_$LI$());
+                                buf.append("  { ");
+                                buf.append("\'rot\': \'").append(k).append("/").append(nSides * 2).append(delim1);
+                                buf.append("\'rad\': \'").append(k).append("\u03c0/").append(nSides).append(delim1);
+                                buf.append("\'deg\': ").append(degrees).append(delim2);
+                                buf.append("\'sin\': ").append(MathTableExporter.formatAN(sin)).append(delim2);
+                                buf.append("\'cos\': ").append(MathTableExporter.formatAN(cos)).append(delim2);
+                                buf.append("\'tan\': ").append(cos.isZero() ? infinite : MathTableExporter.formatAN(sin.dividedBy(cos))).append(delim2);
+                                buf.append("\'csc\': ").append(sin.isZero() ? infinite : MathTableExporter.formatAN(sin.reciprocal())).append(delim2);
+                                buf.append("\'sec\': ").append(cos.isZero() ? infinite : MathTableExporter.formatAN(cos.reciprocal())).append(delim2);
+                                buf.append("\'cot\': ").append(sin.isZero() ? infinite : MathTableExporter.formatAN(cos.dividedBy(sin)));
+                                buf.append(" }");
+                                if (n === 0) {
+                                    buf.append(",\n");
+                                }
+                                v = bisector;
+                            }
+                            ;
+                        }
+                    }
+                    /*private*/ static formatAN(n) {
+                        const buf = new java.lang.StringBuilder();
+                        buf.append("{ \'alg\': \'").append(n).append("\', \'dec\': ").append(n.evaluate()).append(", \'tdf\': [");
+                        let delim = "";
+                        {
+                            let array = n.toTrailingDivisor();
+                            for (let index = 0; index < array.length; index++) {
+                                let term = array[index];
+                                {
+                                    buf.append(delim);
+                                    delim = ", ";
+                                    buf.append(term);
+                                }
+                            }
+                        }
+                        buf.append("] }");
+                        return buf.toString();
+                    }
+                    /**
+                     *
+                     * @return {string}
+                     */
+                    getFileExtension() {
+                        return "math.json";
+                    }
+                    /**
+                     *
+                     * @return {string}
+                     */
+                    getContentType() {
+                        return "application/json";
+                    }
+                }
+                exporters.MathTableExporter = MathTableExporter;
+                MathTableExporter["__class"] = "com.vzome.core.exporters.MathTableExporter";
+                MathTableExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
+            })(exporters = core.exporters || (core.exporters = {}));
+        })(core = vzome.core || (vzome.core = {}));
+    })(vzome = com.vzome || (com.vzome = {}));
+})(com || (com = {}));
+(function (com) {
+    var vzome;
+    (function (vzome) {
+        var core;
+        (function (core) {
             var algebra;
             (function (algebra) {
                 class SnubDodecField extends com.vzome.core.algebra.AbstractAlgebraicField {
@@ -36343,6 +36706,576 @@ export var com;
                 })(SqrtPhiFieldApplication = sqrtphi.SqrtPhiFieldApplication || (sqrtphi.SqrtPhiFieldApplication = {}));
             })(sqrtphi = fields.sqrtphi || (fields.sqrtphi = {}));
         })(fields = vzome.fields || (vzome.fields = {}));
+    })(vzome = com.vzome || (com.vzome = {}));
+})(com || (com = {}));
+(function (com) {
+    var vzome;
+    (function (vzome) {
+        var core;
+        (function (core) {
+            var exporters;
+            (function (exporters) {
+                /**
+                 * An exporter that produces a parametric OpenSCAD file,
+                 * to support generation of STL files for struts of arbitrary length.
+                 * This is based on Aaron Siegel's "zome-strut.scad" library.
+                 *
+                 * @author vorth
+                 * @class
+                 * @extends com.vzome.core.exporters.DocumentExporter
+                 */
+                class OpenScadExporter extends com.vzome.core.exporters.DocumentExporter {
+                    /**
+                     *
+                     * @param {*} doc
+                     * @param {java.io.File} file
+                     * @param {java.io.Writer} writer
+                     * @param {number} height
+                     * @param {number} width
+                     */
+                    exportDocument(doc, file, writer, height, width) {
+                        const toolsModel = doc.getToolsModel();
+                        this.mModel = doc.getRenderedModel();
+                        const field = this.mModel.getField();
+                        const tipBookmark = toolsModel.values().stream().filter((tool) => "tip vertex" === tool.getLabel()).findAny();
+                        if (!tipBookmark.isPresent())
+                            throw new com.vzome.core.commands.Command.Failure("You must have a bookmark named \"tip vertex\" for the strut endpoint.");
+                        const tipItems = tipBookmark.get().getParameters();
+                        const tipPoint = tipItems.get(0);
+                        if (tipItems.size() > 1 || !(tipPoint != null && tipPoint instanceof com.vzome.core.construction.Point))
+                            throw new com.vzome.core.commands.Command.Failure("The \"tip vertex\" bookmark must select a single ball.");
+                        const tipVertex = tipPoint.getLocation();
+                        const floatingBookmark = toolsModel.values().stream().filter((tool) => "floating panels" === tool.getLabel()).findAny();
+                        let floatingVerticesSet = (new java.util.TreeSet());
+                        if (!floatingBookmark.isPresent())
+                            throw new com.vzome.core.commands.Command.Failure("You must have a bookmark named \"floating panels\".");
+                        for (let index = floatingBookmark.get().getParameters().iterator(); index.hasNext();) {
+                            let polygon = index.next();
+                            {
+                                if (!(polygon != null && polygon instanceof com.vzome.core.construction.Polygon))
+                                    throw new com.vzome.core.commands.Command.Failure("The \"floating panels\" bookmark must select only panels.");
+                                {
+                                    let array = polygon.getVertices();
+                                    for (let index = 0; index < array.length; index++) {
+                                        let vertex = array[index];
+                                        {
+                                            floatingVerticesSet.add(vertex);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        let bottomFaceNormal = null;
+                        const bottomFaceBookmark = toolsModel.values().stream().filter((tool) => "bottom face" === tool.getLabel()).findAny();
+                        if (bottomFaceBookmark.isPresent()) {
+                            const bottomFaceItems = bottomFaceBookmark.get().getParameters();
+                            const bottomFacePanel = bottomFaceItems.get(0);
+                            if (bottomFaceItems.size() > 1 || !(bottomFacePanel != null && bottomFacePanel instanceof com.vzome.core.construction.Polygon))
+                                throw new com.vzome.core.commands.Command.Failure("The \"bottom face\" bookmark must select a single panel.");
+                            bottomFaceNormal = bottomFacePanel.getNormal();
+                        }
+                        let fixedVerticesSet = (new java.util.TreeSet());
+                        let orbitName = null;
+                        for (let index = this.mModel.iterator(); index.hasNext();) {
+                            let rm = index.next();
+                            {
+                                const man = rm.getManifestation();
+                                if (man != null && (man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Panel") >= 0)) {
+                                    const panel = man;
+                                    for (let index = panel.iterator(); index.hasNext();) {
+                                        let vertex = index.next();
+                                        {
+                                            if (!floatingVerticesSet.contains(vertex))
+                                                fixedVerticesSet.add(vertex);
+                                        }
+                                    }
+                                }
+                                else if (man != null && (man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0)) {
+                                    if (orbitName != null)
+                                        throw new com.vzome.core.commands.Command.Failure("The model must contain a single prototype strut.");
+                                    orbitName = rm.getStrutOrbit().getName();
+                                }
+                            }
+                        }
+                        if (orbitName == null)
+                            throw new com.vzome.core.commands.Command.Failure("The model must contain a single prototype strut.");
+                        const sortedFixedVertexList = (new java.util.ArrayList(fixedVerticesSet));
+                        const sortedFloatingVertexList = (new java.util.ArrayList(floatingVerticesSet));
+                        fixedVerticesSet = null;
+                        floatingVerticesSet = null;
+                        this.output = new java.io.PrintWriter(writer);
+                        let prelude = super.getBoilerplate("com/vzome/core/exporters/zome-strut-prelude.scad");
+                        prelude = /* replaceAll */ prelude.replace(new RegExp("%%ORBIT%%", 'g'), orbitName);
+                        this.output.println$java_lang_Object(prelude);
+                        this.output.println$java_lang_Object("  irrational = " + field.getCoefficients()[1] + ";");
+                        this.output.println$();
+                        this.output.println$java_lang_Object("module " + orbitName + "_strut( size, scalar=1.0, offsets=0 ) {");
+                        this.output.println$();
+                        if (bottomFaceNormal == null) {
+                            this.output.println$java_lang_Object("  // WARNING: The vZome design contained no \"bottom face\" bookmark.");
+                            this.output.println$java_lang_Object("  bottom_face_normal = [ 0, 0, -1 ];");
+                        }
+                        else {
+                            const bottomFaceDirection = this.mModel.renderVector(bottomFaceNormal).normalize();
+                            this.output.println$java_lang_Object("  bottom_face_normal = [ " + bottomFaceDirection.toString$() + " ];");
+                        }
+                        this.output.println$();
+                        const tipVertexString = this.mModel.renderVector(tipVertex).scale(com.vzome.core.render.RealZomeScaling.RZOME_MM_SCALING).toString$();
+                        this.output.println$java_lang_Object("  tip_vertex = [ " + tipVertexString + " ];");
+                        this.output.println$();
+                        this.output.println$java_lang_Object("  fixed_vertices = [ ");
+                        for (let index = sortedFixedVertexList.iterator(); index.hasNext();) {
+                            let vertex = index.next();
+                            {
+                                this.output.print("[ ");
+                                this.output.print(this.mModel.renderVector(vertex).scale(com.vzome.core.render.RealZomeScaling.RZOME_MM_SCALING).toString$());
+                                this.output.print(" ], ");
+                            }
+                        }
+                        this.output.println$java_lang_Object(" ];");
+                        this.output.println$java_lang_Object("  floating_vertices = [ ");
+                        for (let index = sortedFloatingVertexList.iterator(); index.hasNext();) {
+                            let vertex = index.next();
+                            {
+                                this.output.print("[ ");
+                                this.output.print(this.mModel.renderVector(vertex).scale(com.vzome.core.render.RealZomeScaling.RZOME_MM_SCALING).toString$());
+                                this.output.print(" ], ");
+                            }
+                        }
+                        this.output.println$java_lang_Object(" ];");
+                        this.output.println$java_lang_Object("  faces = [ ");
+                        for (let index = this.mModel.iterator(); index.hasNext();) {
+                            let rm = index.next();
+                            {
+                                const man = rm.getManifestation();
+                                if (man != null && (man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Panel") >= 0)) {
+                                    this.output.print("[ ");
+                                    const panel = man;
+                                    const stack = (new java.util.Stack());
+                                    for (let index = panel.iterator(); index.hasNext();) {
+                                        let vertex = index.next();
+                                        {
+                                            stack.push(vertex);
+                                        }
+                                    }
+                                    while ((!stack.isEmpty())) {
+                                        {
+                                            const vertex = stack.pop();
+                                            let index = sortedFixedVertexList.indexOf(vertex);
+                                            if (index < 0) {
+                                                index = sortedFixedVertexList.size() + sortedFloatingVertexList.indexOf(vertex);
+                                            }
+                                            this.output.print(index + ", ");
+                                        }
+                                    }
+                                    ;
+                                    this.output.print("], ");
+                                }
+                            }
+                        }
+                        this.output.println$java_lang_Object(" ];");
+                        this.output.println$java_lang_Object("  zome_strut( tip_vertex, fixed_vertices, floating_vertices, faces, bottom_face_normal, size, scalar, offsets );");
+                        this.output.println$java_lang_Object("}");
+                        this.output.flush();
+                    }
+                    /**
+                     *
+                     * @return {string}
+                     */
+                    getFileExtension() {
+                        return "scad";
+                    }
+                    /**
+                     *
+                     * @param {java.io.File} file
+                     * @param {java.io.Writer} writer
+                     * @param {number} height
+                     * @param {number} width
+                     */
+                    doExport(file, writer, height, width) {
+                    }
+                    constructor() {
+                        super();
+                    }
+                }
+                exporters.OpenScadExporter = OpenScadExporter;
+                OpenScadExporter["__class"] = "com.vzome.core.exporters.OpenScadExporter";
+                OpenScadExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
+            })(exporters = core.exporters || (core.exporters = {}));
+        })(core = vzome.core || (vzome.core = {}));
+    })(vzome = com.vzome || (com.vzome = {}));
+})(com || (com = {}));
+(function (com) {
+    var vzome;
+    (function (vzome) {
+        var core;
+        (function (core) {
+            var exporters;
+            (function (exporters) {
+                /**
+                 * Renders out to POV-Ray using #declare statements to reuse geometry.
+                 * @author vorth
+                 * @class
+                 * @extends com.vzome.core.exporters.DocumentExporter
+                 */
+                class POVRayExporter extends com.vzome.core.exporters.DocumentExporter {
+                    constructor() {
+                        super();
+                    }
+                    static FORMAT_$LI$() { if (POVRayExporter.FORMAT == null) {
+                        POVRayExporter.FORMAT = java.text.NumberFormat.getNumberInstance(java.util.Locale.US);
+                    } return POVRayExporter.FORMAT; }
+                    mapViewToWorld(view, vector) {
+                    }
+                    /**
+                     *
+                     * @return {boolean}
+                     */
+                    needsManifestations() {
+                        return false;
+                    }
+                    /**
+                     *
+                     * @param {java.io.File} povFile
+                     * @param {java.io.Writer} writer
+                     * @param {number} height
+                     * @param {number} width
+                     */
+                    doExport(povFile, writer, height, width) {
+                        this.output = new java.io.PrintWriter(writer);
+                        const lookDir = this.mScene.getLookDirectionRV();
+                        const upDir = this.mScene.getUpDirectionRV();
+                        POVRayExporter.FORMAT_$LI$().setMaximumFractionDigits(8);
+                        this.output.println$();
+                        this.output.println$();
+                        this.output.println$java_lang_Object("#declare           look_dir = " + this.printTuple3d(lookDir) + ";");
+                        this.output.println$();
+                        this.output.println$java_lang_Object("#declare             up_dir = " + this.printTuple3d(upDir) + ";");
+                        this.output.println$();
+                        this.output.println$java_lang_Object("#declare viewpoint_distance = " + this.mScene.getViewDistance() + ";");
+                        this.output.println$();
+                        this.output.println$java_lang_Object("#declare      look_at_point = " + this.printTuple3d(this.mScene.getLookAtPointRV()) + ";");
+                        this.output.println$();
+                        this.output.println$java_lang_Object("#declare      field_of_view = " + this.mScene.getFieldOfView() + ";");
+                        this.output.println$();
+                        this.output.println$java_lang_Object("#declare      parallel_proj = " + (this.mScene.isPerspective() ? 0 : 1) + ";");
+                        this.output.println$();
+                        const input = this.constructor.getClassLoader().getResourceAsStream(POVRayExporter.PREAMBLE_FILE);
+                        const out = new java.io.ByteArrayOutputStream();
+                        const buf = (s => { let a = []; while (s-- > 0)
+                            a.push(0); return a; })(1024);
+                        let num;
+                        try {
+                            while (((num = input.read(buf, 0, 1024)) > 0)) {
+                                out.write(buf, 0, num);
+                            }
+                            ;
+                        }
+                        catch (e) {
+                            console.error(e.message, e);
+                        }
+                        this.output.println$java_lang_Object(new String(out.toByteArray()));
+                        this.output.println$();
+                        for (let i = 0; i < 3; i++) {
+                            {
+                                const color = this.mLights.getDirectionalLightColor(i);
+                                let rv = this.mLights.getDirectionalLightVector(i);
+                                rv = this.mScene.mapViewToWorld(rv);
+                                this.output.print("light_source { -light_distance * " + this.printTuple3d(rv));
+                                this.output.print(" ");
+                                this.printColor(color);
+                                this.output.println$java_lang_Object(" * multiplier_light_" + (i + 1) + " }");
+                                this.output.println$();
+                            }
+                            ;
+                        }
+                        this.output.print("#declare ambient_color = ");
+                        this.printColor(this.mLights.getAmbientColor());
+                        this.output.println$java_lang_Object(";");
+                        this.output.println$();
+                        this.output.println$java_lang_Object("#default { texture { finish { phong 0.3 ambient multiplier_ambient * ambient_color diffuse 0.6 } } }");
+                        this.output.println$();
+                        this.output.print("background { ");
+                        this.printColor(this.mLights.getBackgroundColor());
+                        this.output.println$java_lang_Object(" }");
+                        this.output.println$();
+                        const instances = new java.lang.StringBuffer();
+                        const field = this.mModel.getField();
+                        const embedding = this.mModel.getEmbedding();
+                        let embeddingTransform = " ";
+                        if (!embedding.isTrivial()) {
+                            embeddingTransform = " transform embedding ";
+                            this.output.print("#declare embedding = transform { matrix < ");
+                            for (let i = 0; i < 3; i++) {
+                                {
+                                    const columnSelect = field.basisVector(3, i);
+                                    const columnI = embedding.embedInR3(columnSelect);
+                                    this.output.print(columnI.x);
+                                    this.output.print(", ");
+                                    this.output.print(columnI.y);
+                                    this.output.print(", ");
+                                    this.output.print(columnI.z);
+                                    this.output.print(", ");
+                                }
+                                ;
+                            }
+                            this.output.println$java_lang_Object(" 0, 0, 0 > }");
+                            this.output.flush();
+                        }
+                        let numTransforms = 0;
+                        const shapes = (new java.util.HashSet());
+                        const transforms = (new java.util.HashMap());
+                        const colors = (new java.util.HashMap());
+                        for (let index = this.mModel.iterator(); index.hasNext();) {
+                            let rm = index.next();
+                            {
+                                const shapeName = "S" + /* replaceAll */ rm.getShapeId().toString().replace(new RegExp("-", 'g'), "");
+                                if (!shapes.contains(shapeName)) {
+                                    shapes.add(shapeName);
+                                    this.exportShape(shapeName, rm.getShape());
+                                }
+                                const transform = rm.getOrientation();
+                                let transformName = transforms.get(transform);
+                                if (transformName == null) {
+                                    transformName = "trans" + numTransforms++;
+                                    transforms.put(transform, transformName);
+                                    this.exportTransform(transformName, transform);
+                                }
+                                let color = rm.getColor();
+                                if (color == null)
+                                    color = com.vzome.core.construction.Color.WHITE_$LI$();
+                                let colorName = colors.get(color);
+                                if (colorName == null) {
+                                    colorName = this.nameColor(color);
+                                    colors.put(color, colorName);
+                                    this.exportColor(colorName, color);
+                                }
+                                instances.append("object { " + shapeName + " transform " + transformName + " translate ");
+                                instances.append("(<");
+                                let loc = rm.getLocationAV();
+                                if (loc == null)
+                                    loc = rm.getShape().getField().origin(3);
+                                this.appendVector(loc, instances);
+                                instances.append(">)");
+                                instances.append(embeddingTransform + "transform anim texture { " + colorName + " } }");
+                                instances.append(java.lang.System.getProperty("line.separator"));
+                            }
+                        }
+                        this.output.println$java_lang_Object(instances.toString());
+                        this.output.flush();
+                        if (povFile == null)
+                            return;
+                        let filename = povFile.getName();
+                        const index = filename.lastIndexOf(".pov");
+                        if (index > 0) {
+                            filename = filename.substring(0, index);
+                        }
+                        const file = new java.io.File(povFile.getParentFile(), filename + ".ini");
+                        this.output = new java.io.PrintWriter(new java.io.FileWriter(file));
+                        this.output.println$java_lang_Object("+W" + 600);
+                        this.output.println$java_lang_Object("+H" + 600);
+                        this.output.println$java_lang_Object("+A");
+                        this.output.println$java_lang_Object("Input_File_Name=" + filename + ".pov");
+                        this.output.println$java_lang_Object("Output_File_Name=" + filename + ".png");
+                        this.output.close();
+                    }
+                    nameColor(color) {
+                        return "color_" + /* replace */ color.toString().split(',').join('_');
+                    }
+                    /*private*/ printTuple3d(t) {
+                        const buf = new java.lang.StringBuilder("<");
+                        buf.append(POVRayExporter.FORMAT_$LI$().format(t.x));
+                        buf.append(",");
+                        buf.append(POVRayExporter.FORMAT_$LI$().format(t.y));
+                        buf.append(",");
+                        buf.append(POVRayExporter.FORMAT_$LI$().format(t.z));
+                        buf.append(">");
+                        return buf.toString();
+                    }
+                    exportColor(name, color) {
+                        this.output.print("#declare " + /* replace */ name.split('.').join('_') + " = texture { pigment { ");
+                        this.printColor(color);
+                        this.output.println$java_lang_Object(" } };");
+                    }
+                    /*private*/ printColor(color) {
+                        const doAlpha = color.getAlpha() < 255;
+                        if (doAlpha)
+                            this.output.print("color rgbf <");
+                        else
+                            this.output.print("color rgb <");
+                        const rgb = color.getRGBColorComponents([0, 0, 0, 0]);
+                        this.output.print(POVRayExporter.FORMAT_$LI$().format(rgb[0]) + ",");
+                        this.output.print(POVRayExporter.FORMAT_$LI$().format(rgb[1]) + ",");
+                        if (doAlpha) {
+                            this.output.print(POVRayExporter.FORMAT_$LI$().format(rgb[2]) + ",");
+                            this.output.print(POVRayExporter.FORMAT_$LI$().format(rgb[3]));
+                        }
+                        else {
+                            this.output.print(POVRayExporter.FORMAT_$LI$().format(rgb[2]));
+                        }
+                        this.output.print(">");
+                    }
+                    appendVector(loc, buf) {
+                        const vector = loc.toRealVector();
+                        buf.append(POVRayExporter.FORMAT_$LI$().format(vector.x));
+                        buf.append(", ");
+                        buf.append(POVRayExporter.FORMAT_$LI$().format(vector.y));
+                        buf.append(", ");
+                        buf.append(POVRayExporter.FORMAT_$LI$().format(vector.z));
+                    }
+                    /*private*/ exportShape(shapeName, poly) {
+                        this.output.print("#declare " + shapeName + " = ");
+                        const vertices = poly.getVertexList();
+                        this.output.println$java_lang_Object("mesh {");
+                        poly.getTriangleFaces();
+                        for (let index = poly.getTriangleFaces().iterator(); index.hasNext();) {
+                            let face = index.next();
+                            {
+                                this.output.print("triangle {");
+                                for (let loopIndex = 0; loopIndex < face.vertices.length; loopIndex++) {
+                                    let index = face.vertices[loopIndex];
+                                    {
+                                        const loc = vertices.get(index);
+                                        const buf = new java.lang.StringBuffer();
+                                        buf.append("<");
+                                        this.appendVector(loc, buf);
+                                        buf.append(">");
+                                        this.output.print(buf.toString());
+                                    }
+                                }
+                                this.output.println$java_lang_Object("}");
+                            }
+                        }
+                        this.output.println$java_lang_Object("}");
+                        this.output.flush();
+                    }
+                    /*private*/ exportTransform(name, transform) {
+                        const field = this.mModel.getField();
+                        this.output.print("#declare " + name + " = transform { matrix < ");
+                        const buf = new java.lang.StringBuffer();
+                        for (let i = 0; i < 3; i++) {
+                            {
+                                const columnSelect = field.basisVector(3, i);
+                                const columnI = transform.timesColumn(columnSelect);
+                                this.appendVector(columnI, buf);
+                                buf.append(", ");
+                            }
+                            ;
+                        }
+                        this.output.print(buf);
+                        this.output.println$java_lang_Object(" 0, 0, 0 > }");
+                        this.output.flush();
+                    }
+                    /**
+                     *
+                     * @return {string}
+                     */
+                    getFileExtension() {
+                        return "pov";
+                    }
+                }
+                POVRayExporter.PREAMBLE_FILE = "com/vzome/core/exporters/povray/preamble.pov";
+                exporters.POVRayExporter = POVRayExporter;
+                POVRayExporter["__class"] = "com.vzome.core.exporters.POVRayExporter";
+                POVRayExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
+            })(exporters = core.exporters || (core.exporters = {}));
+        })(core = vzome.core || (vzome.core = {}));
+    })(vzome = com.vzome || (com.vzome = {}));
+})(com || (com = {}));
+(function (com) {
+    var vzome;
+    (function (vzome) {
+        var core;
+        (function (core) {
+            var exporters;
+            (function (exporters) {
+                class PartGeometryExporter extends com.vzome.core.exporters.VefExporter {
+                    constructor() {
+                        super();
+                        if (this.selection === undefined) {
+                            this.selection = null;
+                        }
+                    }
+                    exportDocument(doc, file, writer, height, width) {
+                        this.mModel = doc.getRenderedModel();
+                        this.selection = doc.getEditorModel().getSelection();
+                        this.doExport(file, writer, height, width);
+                        this.selection = null;
+                        this.mModel = null;
+                    }
+                    /**
+                     *
+                     * @param {java.io.File} directory
+                     * @param {java.io.Writer} writer
+                     * @param {number} height
+                     * @param {number} width
+                     */
+                    doExport(directory, writer, height, width) {
+                        const field = this.mModel.getField();
+                        const exporter = new com.vzome.core.model.VefModelExporter(writer, field);
+                        for (let index = this.mModel.iterator(); index.hasNext();) {
+                            let rm = index.next();
+                            {
+                                exporter.exportManifestation(rm.getManifestation());
+                            }
+                        }
+                        exporter.finish();
+                        this.exportSelection(exporter);
+                    }
+                    /*private*/ exportSelection(exporter) {
+                        let tip = null;
+                        const arrayComparator = (new com.vzome.core.generic.ArrayComparator());
+                        const panelVertices = (new java.util.TreeSet((((funcInst) => { if (funcInst == null || typeof funcInst == 'function') {
+                            return funcInst;
+                        } return (arg0, arg1) => (funcInst['compare'] ? funcInst['compare'] : funcInst).call(funcInst, arg0, arg1); })(arrayComparator.getLengthFirstArrayComparator()))));
+                        const vertexArrayPanelMap = (new java.util.HashMap());
+                        for (let index = this.selection.iterator(); index.hasNext();) {
+                            let man = index.next();
+                            {
+                                if (man != null && (man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Connector") >= 0)) {
+                                    if (tip == null) {
+                                        tip = man;
+                                    }
+                                }
+                                else if (man != null && (man.constructor != null && man.constructor["__interfaces"] != null && man.constructor["__interfaces"].indexOf("com.vzome.core.model.Panel") >= 0)) {
+                                    const panel = man;
+                                    const corners = (new java.util.ArrayList(panel.getVertexCount()));
+                                    for (let index = panel.iterator(); index.hasNext();) {
+                                        let vertex = index.next();
+                                        {
+                                            corners.add(vertex);
+                                        }
+                                    }
+                                    const cornerArray = (s => { let a = []; while (s-- > 0)
+                                        a.push(null); return a; })(corners.size());
+                                    corners.toArray(cornerArray);
+                                    panelVertices.add(cornerArray);
+                                    vertexArrayPanelMap.put(cornerArray, panel);
+                                }
+                            }
+                        }
+                        if (tip != null) {
+                            exporter.exportSelectedManifestation(null);
+                            exporter.exportSelectedManifestation(tip);
+                            if (!panelVertices.isEmpty()) {
+                                exporter.exportSelectedManifestation(null);
+                                for (let index = panelVertices.iterator(); index.hasNext();) {
+                                    let vertexArray = index.next();
+                                    {
+                                        const panel = vertexArrayPanelMap.get(vertexArray);
+                                        exporter.exportSelectedManifestation(panel);
+                                    }
+                                }
+                            }
+                            exporter.exportSelectedManifestation(null);
+                        }
+                    }
+                }
+                exporters.PartGeometryExporter = PartGeometryExporter;
+                PartGeometryExporter["__class"] = "com.vzome.core.exporters.PartGeometryExporter";
+                PartGeometryExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
+            })(exporters = core.exporters || (core.exporters = {}));
+        })(core = vzome.core || (vzome.core = {}));
     })(vzome = com.vzome || (com.vzome = {}));
 })(com || (com = {}));
 (function (com) {
@@ -46769,6 +47702,29 @@ export var com;
                             this.__parent = __parent;
                         }
                         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                        getEmbedding() {
+                            const symmetry = this.getSymmetry();
+                            const field = symmetry.getField();
+                            const embedding = (s => { let a = []; while (s-- > 0)
+                                a.push(0); return a; })(16);
+                            for (let i = 0; i < 3; i++) {
+                                {
+                                    const columnSelect = field.basisVector(3, i);
+                                    const colRV = symmetry.embedInR3(columnSelect);
+                                    embedding[i * 4 + 0] = colRV.x;
+                                    embedding[i * 4 + 1] = colRV.y;
+                                    embedding[i * 4 + 2] = colRV.z;
+                                    embedding[i * 4 + 3] = 0.0;
+                                }
+                                ;
+                            }
+                            embedding[12] = 0.0;
+                            embedding[13] = 0.0;
+                            embedding[14] = 0.0;
+                            embedding[15] = 1.0;
+                            return embedding;
+                        }
+                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                         getOrientations$() {
                             return this.getOrientations(false);
                         }
@@ -46823,29 +47779,6 @@ export var com;
                             }
                             else
                                 throw new Error('invalid overload');
-                        }
-                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                        getEmbedding() {
-                            const symmetry = this.getSymmetry();
-                            const field = symmetry.getField();
-                            const embedding = (s => { let a = []; while (s-- > 0)
-                                a.push(0); return a; })(16);
-                            for (let i = 0; i < 3; i++) {
-                                {
-                                    const columnSelect = field.basisVector(3, i);
-                                    const colRV = symmetry.embedInR3(columnSelect);
-                                    embedding[i * 4 + 0] = colRV.x;
-                                    embedding[i * 4 + 1] = colRV.y;
-                                    embedding[i * 4 + 2] = colRV.z;
-                                    embedding[i * 4 + 3] = 0.0;
-                                }
-                                ;
-                            }
-                            embedding[12] = 0.0;
-                            embedding[13] = 0.0;
-                            embedding[14] = 0.0;
-                            embedding[15] = 1.0;
-                            return embedding;
                         }
                         /**
                          *
@@ -52266,6 +53199,7 @@ com.vzome.core.commands.CommandLinePlaneIntersect.PARAM_SIGNATURE_$LI$();
 com.vzome.core.construction.SegmentRotated4D.logger_$LI$();
 com.vzome.core.commands.CommandImportVEFData.ATTR_SIGNATURE_$LI$();
 com.vzome.core.commands.CommandImportVEFData.PARAM_SIGNATURE_$LI$();
+com.vzome.core.exporters.POVRayExporter.FORMAT_$LI$();
 com.vzome.core.exporters.PlyExporter.FORMAT_$LI$();
 com.vzome.core.exporters.PlyExporter.__static_initialize();
 com.vzome.desktop.controller.PreviewStrut.logger_$LI$();
@@ -52274,6 +53208,9 @@ com.vzome.desktop.controller.NumberController.MATH_OPS_$LI$();
 com.vzome.desktop.controller.NumberController.OPTIONAL_NAMED_VALUES_$LI$();
 com.vzome.core.algebra.SnubDodecField.IRRATIONAL_LABELS_$LI$();
 com.vzome.core.algebra.SnubDodecField.PHI_VALUE_$LI$();
+com.vzome.core.exporters.MathTableExporter.OPTIONAL_NAMED_VALUES_$LI$();
+com.vzome.core.exporters.MathTableExporter.Y_$LI$();
+com.vzome.core.exporters.MathTableExporter.X_$LI$();
 com.vzome.core.editor.api.SideEffects.BUG_ACCOMMODATION_LOGGER_$LI$();
 com.vzome.core.editor.EditHistory.breakpointLogger_$LI$();
 com.vzome.core.editor.EditHistory.logger_$LI$();

--- a/online/src/worker/legacy/exporters.js
+++ b/online/src/worker/legacy/exporters.js
@@ -10,6 +10,11 @@ const exporterClasses = {
   'off'      : 'OffExporter',
   'ply'      : 'PlyExporter',
   'vrml'     : 'VRMLExporter',
+  'pov'      : 'PovRayExporter',
+  'partgeom' : 'PartGeometryExporter',
+  'openscad' : 'OpenScadExporter',
+  'math'     : 'MathTableExporter',
+
   'pdf'      : 'PDFExporter',
   'ps'       : 'PostScriptExporter',
   'svg'      : 'SVGExporter',
@@ -31,6 +36,34 @@ export const export3d = ( scene, configuration ) =>
   const exporter = new com.vzome.core.exporters[ exporterClasses[ format ] ]();
   const out = new java.io.StringWriter();
   exporter .exportGeometry( renderedModel, null, out, height, width );
+  return out.toString();
+}
+
+const createDocument = ( legacyDesign, camera, lighting ) =>
+{
+  // TODO
+  return {
+    // CameraIntf getCameraModel();
+
+    // Lights getSceneLighting();
+
+    // RenderedModel getRenderedModel();
+
+    // ToolsModel getToolsModel();
+
+    // Element getDetailsXml( Document dom, boolean b );
+
+    // EditorModel getEditorModel();
+  }
+}
+
+export const export3dDocument = ( legacyDesign, camera, lighting, configuration ) =>
+{
+  const { format, height, width } = configuration;
+  const exporter = new com.vzome.core.exporters[ exporterClasses[ format ] ]();
+  const out = new java.io.StringWriter();
+  const document = createDocument( legacyDesign, camera, lighting );
+  exporter .exportDocument( document, null, out, height, width );
   return out.toString();
 }
 


### PR DESCRIPTION
I did the necessary Java refactoring to allow `PovRayExporter.java` and some
others to transpile with JSweet.  This involved introducing `DocumentIntf` and
`CameraIntf`.

I did some of the work on the Javascript side, but I haven't completed the
key `createDocument` function to create the DocumentIntf instance yet.

Along the way, I noticed that PartGeomExporter probably does not work on
the Java side, since its `exportDocument()` method won't be called.