### PR TITLE
Supporting quick workflow with inspector/debugger

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
+{
+	"name": "Node.js",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/javascript-node",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			"settings": {},
+			"extensions": []
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [8855],
+
+	// Use 'portsAttributes' to set default properties for specific forwarded ports. 
+	// More info: https://containers.dev/implementors/json_reference/#port-attributes
+	"portsAttributes": {
+		"8855": {
+			"label": "vZome inspector",
+			"onAutoForward": "notify"
+		}
+	},
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "cicd/online.bash dev"
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/online/scripts/test-app.mjs
+++ b/online/scripts/test-app.mjs
@@ -11,19 +11,19 @@ const commonConfig = {
   outdir: 'public/modules',
 };
 
-const port = 8532;
+const port = 8855;
 
 if ( argv .includes( 'quick' ) ) {
   // Avoid bundling any of the legacy code; the 'vzome-legacy' dynamic bundle will be missing from runtime
   delete commonConfig.entryPoints[ 'vzome-legacy' ];
   commonConfig.external = [ './legacy/*.js' ];
 
-  writeFileSync( 'src/revision.js', 'export const REVISION="QUICKSTART";' );
+  writeFileSync( 'src/revision.js', 'export const REVISION="QUICKSTART"; export const resourceIndex = []; export const importLegacy = async () => import( "https://www.vzome.com/modules/r114/vzome-legacy.js" );' );
 
   console.log( '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%' );
   console.log( '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%' );
   console.log( '' );
-  console.log( `       visit  http://localhost:${port}/browser` );
+  console.log( `       visit  http://localhost:${port}/?debug=true` );
   console.log( '' );
   console.log( '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%' );
   console.log( '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%' );

--- a/online/src/worker/vzome-worker-static.js
+++ b/online/src/worker/vzome-worker-static.js
@@ -1,4 +1,5 @@
 
+import { importLegacy } from '../revision.js';
 
 // support trampolining to work around worker CORS issue
 //   see https://github.com/evanw/esbuild/issues/312#issuecomment-1025066671
@@ -150,7 +151,7 @@ const clientEvents = report =>
 const createDesign = ( report, fieldName ) =>
 {
   report( { type: 'FETCH_STARTED', payload: { name: 'untitled.vZome', preview: false } } );
-  return import( './legacy/dynamic.js' )
+  return importLegacy()
 
     .then( module => {
       designController = module .newDesign( fieldName, clientEvents( report ) );
@@ -166,7 +167,7 @@ const createDesign = ( report, fieldName ) =>
 
 const getField = name =>
 {
-  return import( './legacy/dynamic.js' )
+  return importLegacy()
     .then( module => {
       return module .getField( name );
     } );
@@ -174,7 +175,7 @@ const getField = name =>
 
 const loadDesign = ( xmlLoading, report, debug ) =>
 {
-  return Promise.all( [ import( './legacy/dynamic.js' ), xmlLoading ] )
+  return Promise.all( [ importLegacy(), xmlLoading ] )
 
     .then( ([ module, xml ]) => {
       designController = module .loadDesign( xml, debug, clientEvents( report ) );


### PR DESCRIPTION
The legacy module (at r114) is dynamically imported from vzome.com.

This lets me run the quick workflow in a devcontainer, and debug the inspector code.  I need this because I need to match the scene protocol used in this old branch, so I can make the old inspector client code work against modern worker code.