### PR TITLE
Attempt to fix intel build

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -22,8 +22,7 @@ jobs:
       matrix:
         arch: [intel, arm64]
 
-    # macos-12 is an Intel image, apparently, whereas macos-latest is Arm64
-    runs-on: ${{ matrix.arch == 'intel' && 'macos-12' || 'macos-latest' }} 
+    runs-on: 'macos-latest'
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
Use of the macos-12 image is not viable any more.
