### PR TITLE
Fixed case sensitivity in BOM color tests

### DIFF
--- a/online/serve/app/test/cases/zometool-model/index.html
+++ b/online/serve/app/test/cases/zometool-model/index.html
@@ -27,7 +27,8 @@
       <div class="zometool-model-difficulty" data-difficulty="medium">
       </div>
 
-      <zometool-instructions src="https://raw.githubusercontent.com/vorth/vzome-sharing/main/2024/09/25/23-37-59-596Z-standard-colors-and-lengths-instructions/standard-colors-and-lengths-instructions.vZome">
+      <!-- <zometool-instructions src="https://raw.githubusercontent.com/vorth/vzome-sharing/main/2024/09/25/23-37-59-596Z-standard-colors-and-lengths-instructions/standard-colors-and-lengths-instructions.vZome"> -->
+      <zometool-instructions src="https://raw.githubusercontent.com/lucosmic/vzome-sharing/main/2025/01/12/01-29-12-PRJ-DNA-kit/PRJ-DNA-kit.vZome">
       <!-- <zometool-instructions src="https://raw.githubusercontent.com/vorth/vzome-sharing/main/2024/09/01/21-01-21-623Z-standard-colors-and-lengths/standard-colors-and-lengths.vZome"> -->
       <!-- <zometool-instructions src="https://raw.githubusercontent.com/vorth/vzome-sharing/main/2024/09/24/02-42-34-519Z-hyperdo-steps-correct-scale/hyperdo-steps-correct-scale.vZome"> -->
       </zometool-instructions>      

--- a/online/src/worker/legacy/partslist.js
+++ b/online/src/worker/legacy/partslist.js
@@ -7,7 +7,7 @@ export const assemblePartsList = ( shapes, colors ) =>
     if ( !name && !orbit ) continue;
     const row = name || `${orbit}:${length}`
     for (const { color } of instances) {
-      const match = Object.entries( colors ) .filter( ([ name, value ]) => value === color );
+      const match = Object.entries( colors ) .filter( ([ name, value ]) => value === color.toLowerCase() );
       const colorBin = match[0]? match[0][ 0 ] : 'other';
       if ( ! bom[ row ] )
         bom[ row ] = {};


### PR DESCRIPTION
Any file written by desktop vZome did not match (I think), because the hex codes
are serialized in uppercase.
