### PR TITLE
Fixes to let VSCode run online in a local Docker container in Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -33,9 +33,10 @@
 *.zomic text
 
 
-# Declare files that will always have explicit CR, LF or CRLF line endings on checkout. 
+# Declare extensions or specific file names that will always have explicit CR, LF or CRLF line endings on checkout. 
 # Future zomic regression tests will explicitly verify the ability to parse each one.
 # Listed alphabetically:
+*.bash text eol=lf
 *.bat text eol=crlf
 *.crlf.zomic text eol=crlf
 *.cr.zomic text eol=cr

--- a/cicd/online.bash
+++ b/cicd/online.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 REVISION=${BUILD_NUMBER:-'DEV'}
 

--- a/online/README.md
+++ b/online/README.md
@@ -60,7 +60,7 @@ If you do lots of development, you may have [Docker](https://www.docker.com/) in
 If you do, you can skip installing other vZome prerequisite tools by using the same "dev container" that GitHub Codespaces would use, but
 running on your own machine, in your Docker host.
 
-In this case, when you open VS Code on this project it will offer to "Reopen in Container".
+In this case, when you open the top level vzome folder in VS Code, it will offer to "Reopen in Container".
 Accept that, and wait for the workspace to be ready.
 
 Once the workspace is ready, you can [start the dev server](#start-the-development-server)


### PR DESCRIPTION
1) Fix the shebang for the .bash script that's used by VSCode. The shebang of other scripts may need to be modified similarly later, but that will be done on an as-needed basis.
2) Ensure that git applies the correct line ending (LF) for all .bash files when they are checked out rather than having them be OS dependent.
3) Clarify local VSCode instructions
