### PR TITLE
Fixed failing unit tests

### DIFF
--- a/core/src/test/java/com/vzome/core/exporters/ExporterTest.java
+++ b/core/src/test/java/com/vzome/core/exporters/ExporterTest.java
@@ -651,7 +651,7 @@ public class ExporterTest {
         String expected
                 = "OFF\n" + 
                 "# numVertices numFaces numEdges (numEdges is ignored)\n" + 
-                "25 14 6\n" + 
+                "25 14 0\n" + 
                 "\n" + 
                 "# Vertices.  Each line is the XYZ coordinates of one vertex.\n" + 
                 "0.0000000000000000 0.0000000000000000 0.0000000000000000\n" + 

--- a/core/src/test/java/com/vzome/core/kinds/FieldApplicationTest.java
+++ b/core/src/test/java/com/vzome/core/kinds/FieldApplicationTest.java
@@ -532,7 +532,7 @@ public class FieldApplicationTest
         String name = shapes.getName();
         assertNotNull(name + ".getConnectorShape()", shapes.getConnectorShape());
         AlgebraicField field = symmetry.getField();
-        AlgebraicNumber length = field.createPower(1);
+        AlgebraicNumber length = field.createPower(3);
         for(Direction dir : symmetry .getDirections() ) {
             assertNotNull(name + ".getStrutShape()", shapes.getStrutShape(dir, length));
         }


### PR DESCRIPTION
Now that very short green struts don't generate a shape, these two unit tests
need to be adjusted.
