### PR TITLE
Added copy.mesh action

### DIFF
--- a/core/src/main/java/com/vzome/core/editor/DocumentModel.java
+++ b/core/src/main/java/com/vzome/core/editor/DocumentModel.java
@@ -61,6 +61,7 @@ import com.vzome.core.model.ManifestationChanges;
 import com.vzome.core.model.ManifestationImpl;
 import com.vzome.core.model.Panel;
 import com.vzome.core.model.RealizedModelImpl;
+import com.vzome.core.model.SimpleMeshJson;
 import com.vzome.core.model.Strut;
 import com.vzome.core.model.VefModelExporter;
 import com.vzome.core.render.RenderedModel;
@@ -376,6 +377,15 @@ public class DocumentModel implements Snapshot .Recorder, Context, DocumentIntf
     {
         StringWriter out = new StringWriter();
         switch ( format ) {
+
+        case "mesh":
+            try {
+                SimpleMeshJson .generate( this .editorModel .getSelection(), this .field, out );
+            } catch (IOException e) {
+                // TODO fail better here
+                e.printStackTrace();
+            }
+            break;
 
         case "cmesh":
             try {

--- a/desktop/src/main/java/com/vzome/desktop/awt/DocumentController.java
+++ b/desktop/src/main/java/com/vzome/desktop/awt/DocumentController.java
@@ -710,6 +710,10 @@ public class DocumentController extends DefaultGraphicsController implements Sce
                 documentModel .doEdit( "Delete" );
                 break;
     
+            case "copy.mesh":
+                setProperty( "clipboard", documentModel .copyRenderedModel( "mesh" ) );
+                break;
+        
             case "copy":
             case "copy.cmesh":
                 setProperty( "clipboard", documentModel .copyRenderedModel( "cmesh" ) );


### PR DESCRIPTION
This enables me to get simple mesh JSON without the silly last-object
offset, or rather letting me control the last object as the origin.
