### PR TITLE
Simple Mesh JSON imports support scale and rotate

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,8 +2,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name":             "online TESTS",
-
+      "name":                             "online TESTS",
       "type": "chrome",
       "request": "launch",
       "url": "http://localhost:8532/app/test/",
@@ -13,16 +12,14 @@
       }
     },
     {
-      "name":             "debug desktop vZome",
-
+      "name":                             "debug desktop vZome",
       "type": "java",
       "request": "launch",
       "mainClass": "org.vorthmann.zome.ui.ApplicationUI",
       "args": "${command:SpecifyProgramArgs}"
     },
     {
-      "name":             "classic PWA",
-
+      "name":                             "classic PWA",
       "type": "chrome",
       "request": "launch",
       "url": "https://localhost:8532/app/classic?debug=true",
@@ -32,19 +29,26 @@
       }
     },
     {
-      "name":             "JK regression",
-
+      "name":                             "Generate H4 0100 Polytope JSON",
+      "type": "java",
+      "request": "launch",
+      "mainClass": "com.vzome.core.apps.Dump4dPolytopeVson",
+      "projectName": "core",
+      "args": [ "0100" ],
+      "console":"externalTerminal"
+    },
+    {
+      "name":                             "JK regression",
       "type": "chrome",
       "request": "launch",
       "url": "http://localhost:8532/app/test/regression.html",
       "pathMapping": {
         "/app/": "${workspaceFolder}/online/src/serve/app",
-        "/": "${workspaceFolder}/online/src",
+        "/": "${workspaceFolder}/online/src"
       }
     },
     {
-      "name":             "GitHub orbit scan",
-
+      "name":                             "GitHub orbit scan",
       "type": "chrome",
       "request": "launch",
       "url": "http://localhost:8532/app/test/orbitscan.html",

--- a/core/src/main/java/com/vzome/core/algebra/AbstractAlgebraicField.java
+++ b/core/src/main/java/com/vzome/core/algebra/AbstractAlgebraicField.java
@@ -635,10 +635,12 @@ public abstract class AbstractAlgebraicField implements AlgebraicField
     @Override
     public AlgebraicVector createVectorFromTDs( int[][] nums )
     {
-        AlgebraicNumber x = this .createAlgebraicNumberFromTD( nums[0] );
-        AlgebraicNumber y = this .createAlgebraicNumberFromTD( nums[1] );
-        AlgebraicNumber z = this .createAlgebraicNumberFromTD( nums[2] );
-        return new AlgebraicVector( x, y, z );
+        int dims = nums.length;
+        AlgebraicNumber[] coords = new AlgebraicNumber[ dims ];
+        for(int c = 0; c < coords.length; c++) {
+          coords[c] = this.createAlgebraicNumberFromTD( nums[c] );
+        }
+        return new AlgebraicVector( coords );
     }
 
     /**

--- a/core/src/main/java/com/vzome/core/edits/ImportSimpleMeshJson.java
+++ b/core/src/main/java/com/vzome/core/edits/ImportSimpleMeshJson.java
@@ -2,14 +2,23 @@ package com.vzome.core.edits;
 
 import java.io.IOException;
 
+import org.w3c.dom.Element;
+
 import com.vzome.core.algebra.AlgebraicField.Registry;
 import com.vzome.core.editor.api.EditorModel;
 import com.vzome.core.editor.api.ManifestConstructions;
+import com.vzome.core.math.Projection;
+import com.vzome.core.algebra.AlgebraicField;
 import com.vzome.core.algebra.AlgebraicVector;
+import com.vzome.core.commands.Command.Failure;
+import com.vzome.core.commands.XmlSaveFormat;
 import com.vzome.core.model.SimpleMeshJson;
+import com.vzome.xml.DomUtils;
 
 public class ImportSimpleMeshJson extends ImportMesh
 {
+    protected boolean scaleAndProject = true;
+
     public ImportSimpleMeshJson( EditorModel editor )
     {
         super( editor );
@@ -19,12 +28,42 @@ public class ImportSimpleMeshJson extends ImportMesh
     protected void parseMeshData( AlgebraicVector offset, ManifestConstructions events, Registry registry )
             throws IOException
     {
-        SimpleMeshJson .parse( meshData, offset, projection, events, registry );
+        // Legacy code dropped the 4th coordinate from the projection, implicitly because it never used
+        //   the 4th coordinate, always making a 3D vector.  New code drops the 1st coordinate.
+        boolean wFirst = false;
+
+        if ( ! this.scaleAndProject ) {
+            wFirst = true;
+            AlgebraicField field = this.mManifestations .getField();
+            this.scale = field.one();
+            this .projection = new Projection.Default( field );
+        }
+        SimpleMeshJson .parse( meshData, offset, projection, scale, wFirst, events, registry );
     }
 
     @Override
     protected String getXmlElementName()
     {
         return "ImportSimpleMeshJson";
+    }
+
+    @Override
+    protected void getXmlAttributes( Element element )
+    {
+        if ( scaleAndProject )
+            DomUtils .addAttribute( element, "scaleAndProject", ((Boolean) scaleAndProject) .toString() );
+
+        super.getXmlAttributes( element );
+    }
+
+    @Override
+    protected void setXmlAttributes( Element xml, XmlSaveFormat format ) throws Failure
+    {
+        String boolStr = xml .getAttribute( "scaleAndProject" );
+        // Default is true, but legacy files must behave as if false
+        if ( boolStr == null || ! boolStr .equals( "true" ) )
+            scaleAndProject = false;
+
+        super.setXmlAttributes( xml, format );
     }
 }

--- a/core/src/test/java/com/vzome/core/apps/Dump4dPolytopeVson.java
+++ b/core/src/test/java/com/vzome/core/apps/Dump4dPolytopeVson.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -21,6 +20,7 @@ import com.vzome.core.math.symmetry.WythoffConstruction.Listener;
 
 public class Dump4dPolytopeVson
 {
+    // Not using this any more; we now output simple mesh JSON
     public static class IndexPair
     {
         public Integer start;
@@ -37,12 +37,14 @@ public class Dump4dPolytopeVson
             this.p2 = p2;
         }
         
-        public IndexPair asIndexPair( List<AlgebraicVector> vertices )
+        public int[] asIndexPair( List<AlgebraicVector> vertices )
         {
-            IndexPair result = new IndexPair();
-            result .start = vertices .indexOf( p1 );
-            result.end = vertices .indexOf( p2 );
-            return result;
+            // IndexPair result = new IndexPair();
+            // result .start = vertices .indexOf( p1 );
+            // result.end = vertices .indexOf( p2 );
+
+            // we now output simple mesh JSON
+            return new int[] { vertices .indexOf( p1 ), vertices .indexOf( p2 ) };
         }
 
         @Override
@@ -77,7 +79,7 @@ public class Dump4dPolytopeVson
     public static class VsonBuilder implements Listener
 	{
         private SortedSet<AlgebraicVector> vertexPoints = new TreeSet<>();
-        private Set<Edge> edges = new HashSet<>();
+        private Set<Edge> edgeSet = new HashSet<>();
         
         public VsonBuilder( String field )
         {
@@ -101,7 +103,7 @@ public class Dump4dPolytopeVson
         public Object addEdge( Object p1, Object p2 )
         {
             Edge result = new Edge( (AlgebraicVector) p1, (AlgebraicVector) p2 );
-            edges .add( result );
+            edgeSet .add( result );
             return result;
         }
         
@@ -112,20 +114,20 @@ public class Dump4dPolytopeVson
         public void index()
         {
             vertices = new ArrayList<>(vertexPoints);
-            struts = edges .stream()
+            edges = edgeSet .stream()
                         .map( edge -> edge .asIndexPair( vertices ) )
                         .collect( Collectors.toList() );
         }
         
-        public List<Integer> getBalls()
-        {
-            return IntStream .range( 0, vertices .size() ) .boxed() .collect( Collectors.toList() ); 
-        }
+        // public List<Integer> getBalls()
+        // {
+        //     return IntStream .range( 0, vertices .size() ) .boxed() .collect( Collectors.toList() ); 
+        // }
         
         // These are public to show up in JSON
         public String field;
         public List<AlgebraicVector> vertices;
-        public List<IndexPair> struts;
+        public List<int[]> edges;
     };
 
     public static void main(String[] args)
@@ -163,5 +165,5 @@ public class Dump4dPolytopeVson
     //  Fortunately, the mechanism uses "isAssignableFrom", so you can have
     //  a view class that extends others or implements interfaces.
     
-	private static class View implements AlgebraicNumber.Views.Rational, Polyhedron.Views.Polygons {}
+	private static class View implements AlgebraicNumber.Views.TrailingDivisor, Polyhedron.Views.Polygons {}
 }

--- a/online/src/worker/java/com/vzome/jsweet/JsAlgebraicField.java
+++ b/online/src/worker/java/com/vzome/jsweet/JsAlgebraicField.java
@@ -143,10 +143,12 @@ public class JsAlgebraicField implements AlgebraicField
     @Override
     public AlgebraicVector createVectorFromTDs( int[][] nums )
     {
-        AlgebraicNumber x = this .createAlgebraicNumberFromTD( nums[0] );
-        AlgebraicNumber y = this .createAlgebraicNumberFromTD( nums[1] );
-        AlgebraicNumber z = this .createAlgebraicNumberFromTD( nums[2] );
-        return new AlgebraicVector( x, y, z );
+        int dims = nums.length;
+        AlgebraicNumber[] coords = new AlgebraicNumber[ dims ];
+        for(int c = 0; c < coords.length; c++) {
+          coords[c] = this.createAlgebraicNumberFromTD( nums[c] );
+        }
+        return new AlgebraicVector( coords );
     }
 
     @Override

--- a/online/src/worker/legacy/core-java.js
+++ b/online/src/worker/legacy/core-java.js
@@ -1211,10 +1211,16 @@ export var com;
                  * @return {com.vzome.core.algebra.AlgebraicVector}
                  */
                 createVectorFromTDs(nums) {
-                    const x = this.createAlgebraicNumberFromTD(nums[0]);
-                    const y = this.createAlgebraicNumberFromTD(nums[1]);
-                    const z = this.createAlgebraicNumberFromTD(nums[2]);
-                    return new com.vzome.core.algebra.AlgebraicVector(x, y, z);
+                    const dims = nums.length;
+                    const coords = (s => { let a = []; while (s-- > 0)
+                        a.push(null); return a; })(dims);
+                    for (let c = 0; c < coords.length; c++) {
+                        {
+                            coords[c] = this.createAlgebraicNumberFromTD(nums[c]);
+                        }
+                        ;
+                    }
+                    return new com.vzome.core.algebra.AlgebraicVector(coords);
                 }
                 /**
                  *
@@ -3954,10 +3960,6 @@ export var com;
                             this.orbits = new com.vzome.core.math.symmetry.OrbitSet(symmetry);
                         }
                         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                        getZone(orbit, orientation) {
-                            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
-                        }
-                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                         getEmbedding() {
                             const symmetry = this.getSymmetry();
                             const field = symmetry.getField();
@@ -3979,6 +3981,10 @@ export var com;
                             embedding[14] = 0.0;
                             embedding[15] = 1.0;
                             return embedding;
+                        }
+                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                        getZone(orbit, orientation) {
+                            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
                         }
                         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                         getOrientations(rowMajor) {
@@ -16781,10 +16787,6 @@ export var com;
                         this.setStyle(styleName);
                     }
                     /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                    getZone(orbit, orientation) {
-                        return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
-                    }
-                    /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                     getEmbedding() {
                         const symmetry = this.getSymmetry();
                         const field = symmetry.getField();
@@ -16806,6 +16808,10 @@ export var com;
                         embedding[14] = 0.0;
                         embedding[15] = 1.0;
                         return embedding;
+                    }
+                    /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                    getZone(orbit, orientation) {
+                        return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
                     }
                     /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                     getOrientations(rowMajor) {
@@ -19258,10 +19264,16 @@ export var com;
                      * @return {com.vzome.core.algebra.AlgebraicVector}
                      */
                     createVectorFromTDs(nums) {
-                        const x = this.createAlgebraicNumberFromTD(nums[0]);
-                        const y = this.createAlgebraicNumberFromTD(nums[1]);
-                        const z = this.createAlgebraicNumberFromTD(nums[2]);
-                        return new com.vzome.core.algebra.AlgebraicVector(x, y, z);
+                        const dims = nums.length;
+                        const coords = (s => { let a = []; while (s-- > 0)
+                            a.push(null); return a; })(dims);
+                        for (let c = 0; c < coords.length; c++) {
+                            {
+                                coords[c] = this.createAlgebraicNumberFromTD(nums[c]);
+                            }
+                            ;
+                        }
+                        return new com.vzome.core.algebra.AlgebraicVector(coords);
                     }
                     /**
                      * Generates an AlgebraicVector with all AlgebraicNumber terms being integers (having unit denominators).
@@ -48069,10 +48081,6 @@ export var com;
                             this.__parent = __parent;
                         }
                         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                        getZone(orbit, orientation) {
-                            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
-                        }
-                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                         getEmbedding() {
                             const symmetry = this.getSymmetry();
                             const field = symmetry.getField();
@@ -48094,6 +48102,10 @@ export var com;
                             embedding[14] = 0.0;
                             embedding[15] = 1.0;
                             return embedding;
+                        }
+                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                        getZone(orbit, orientation) {
+                            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
                         }
                         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                         getOrientations(rowMajor) {

--- a/online/src/worker/legacy/ts/com/vzome/core/algebra/AbstractAlgebraicField.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/algebra/AbstractAlgebraicField.ts
@@ -605,10 +605,12 @@ namespace com.vzome.core.algebra {
          * @return {com.vzome.core.algebra.AlgebraicVector}
          */
         public createVectorFromTDs(nums: number[][]): com.vzome.core.algebra.AlgebraicVector {
-            const x: com.vzome.core.algebra.AlgebraicNumber = this.createAlgebraicNumberFromTD(nums[0]);
-            const y: com.vzome.core.algebra.AlgebraicNumber = this.createAlgebraicNumberFromTD(nums[1]);
-            const z: com.vzome.core.algebra.AlgebraicNumber = this.createAlgebraicNumberFromTD(nums[2]);
-            return new com.vzome.core.algebra.AlgebraicVector(x, y, z);
+            const dims: number = nums.length;
+            const coords: com.vzome.core.algebra.AlgebraicNumber[] = (s => { let a=[]; while(s-->0) a.push(null); return a; })(dims);
+            for(let c: number = 0; c < coords.length; c++) {{
+                coords[c] = this.createAlgebraicNumberFromTD(nums[c]);
+            };}
+            return new com.vzome.core.algebra.AlgebraicVector(coords);
         }
 
         /**

--- a/online/src/worker/legacy/ts/com/vzome/core/editor/SymmetrySystem.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/editor/SymmetrySystem.ts
@@ -6,6 +6,10 @@ namespace com.vzome.core.editor {
             return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
         }
         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+        getOrientations$(): number[][] {
+            return this.getOrientations(false);
+        }
+        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
         public getOrientations(rowMajor?: any): number[][] {
             if (((typeof rowMajor === 'boolean') || rowMajor === null)) {
                 let __args = arguments;
@@ -73,10 +77,6 @@ namespace com.vzome.core.editor {
             embedding[14] = 0.0;
             embedding[15] = 1.0;
             return embedding;
-        }
-        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-        getOrientations$(): number[][] {
-            return this.getOrientations(false);
         }
         static logger: java.util.logging.Logger; public static logger_$LI$(): java.util.logging.Logger { if (SymmetrySystem.logger == null) { SymmetrySystem.logger = java.util.logging.Logger.getLogger("com.vzome.core.editor"); }  return SymmetrySystem.logger; }
 

--- a/online/src/worker/legacy/ts/com/vzome/core/edits/ReplaceWithShape.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/edits/ReplaceWithShape.ts
@@ -162,6 +162,10 @@ namespace com.vzome.core.edits {
                 return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
             }
             /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+            getOrientations$(): number[][] {
+                return this.getOrientations(false);
+            }
+            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
             public getOrientations(rowMajor?: any): number[][] {
                 if (((typeof rowMajor === 'boolean') || rowMajor === null)) {
                     let __args = arguments;
@@ -216,10 +220,6 @@ namespace com.vzome.core.edits {
                 embedding[14] = 0.0;
                 embedding[15] = 1.0;
                 return embedding;
-            }
-            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getOrientations$(): number[][] {
-                return this.getOrientations(false);
             }
             /**
              * 

--- a/online/src/worker/legacy/ts/com/vzome/core/render/RenderedModel.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/render/RenderedModel.ts
@@ -412,6 +412,10 @@ namespace com.vzome.core.render {
                 return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
             }
             /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+            getOrientations$(): number[][] {
+                return this.getOrientations(false);
+            }
+            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
             public getOrientations(rowMajor?: any): number[][] {
                 if (((typeof rowMajor === 'boolean') || rowMajor === null)) {
                     let __args = arguments;
@@ -468,10 +472,6 @@ namespace com.vzome.core.render {
                 embedding[14] = 0.0;
                 embedding[15] = 1.0;
                 return embedding;
-            }
-            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getOrientations$(): number[][] {
-                return this.getOrientations(false);
             }
             symmetry: com.vzome.core.math.symmetry.Symmetry;
 

--- a/online/src/worker/legacy/ts/com/vzome/jsweet/JsAlgebraicField.ts
+++ b/online/src/worker/legacy/ts/com/vzome/jsweet/JsAlgebraicField.ts
@@ -145,10 +145,12 @@ namespace com.vzome.jsweet {
          * @return {com.vzome.core.algebra.AlgebraicVector}
          */
         public createVectorFromTDs(nums: number[][]): com.vzome.core.algebra.AlgebraicVector {
-            const x: com.vzome.core.algebra.AlgebraicNumber = this.createAlgebraicNumberFromTD(nums[0]);
-            const y: com.vzome.core.algebra.AlgebraicNumber = this.createAlgebraicNumberFromTD(nums[1]);
-            const z: com.vzome.core.algebra.AlgebraicNumber = this.createAlgebraicNumberFromTD(nums[2]);
-            return new com.vzome.core.algebra.AlgebraicVector(x, y, z);
+            const dims: number = nums.length;
+            const coords: com.vzome.core.algebra.AlgebraicNumber[] = (s => { let a=[]; while(s-->0) a.push(null); return a; })(dims);
+            for(let c: number = 0; c < coords.length; c++) {{
+                coords[c] = this.createAlgebraicNumberFromTD(nums[c]);
+            };}
+            return new com.vzome.core.algebra.AlgebraicVector(coords);
         }
 
         /**

--- a/online/src/worker/legacy/ts/core-java.ts
+++ b/online/src/worker/legacy/ts/core-java.ts
@@ -1326,10 +1326,12 @@ namespace com.vzome.jsweet {
          * @return {com.vzome.core.algebra.AlgebraicVector}
          */
         public createVectorFromTDs(nums: number[][]): com.vzome.core.algebra.AlgebraicVector {
-            const x: com.vzome.core.algebra.AlgebraicNumber = this.createAlgebraicNumberFromTD(nums[0]);
-            const y: com.vzome.core.algebra.AlgebraicNumber = this.createAlgebraicNumberFromTD(nums[1]);
-            const z: com.vzome.core.algebra.AlgebraicNumber = this.createAlgebraicNumberFromTD(nums[2]);
-            return new com.vzome.core.algebra.AlgebraicVector(x, y, z);
+            const dims: number = nums.length;
+            const coords: com.vzome.core.algebra.AlgebraicNumber[] = (s => { let a=[]; while(s-->0) a.push(null); return a; })(dims);
+            for(let c: number = 0; c < coords.length; c++) {{
+                coords[c] = this.createAlgebraicNumberFromTD(nums[c]);
+            };}
+            return new com.vzome.core.algebra.AlgebraicVector(coords);
         }
 
         /**
@@ -4150,10 +4152,6 @@ namespace com.vzome.core.render {
 
         export class SymmetryOrbitSource implements com.vzome.core.editor.api.OrbitSource {
             /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
-                return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
-            }
-            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
             getEmbedding(): number[] {
                 const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
                 const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
@@ -4171,6 +4169,10 @@ namespace com.vzome.core.render {
                 embedding[14] = 0.0;
                 embedding[15] = 1.0;
                 return embedding;
+            }
+            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+            getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
+                return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
             }
             /* Default method injected from com.vzome.core.editor.api.OrbitSource */
             public getOrientations(rowMajor?: any): number[][] {
@@ -17071,10 +17073,6 @@ namespace com.vzome.core.editor {
 namespace com.vzome.core.editor {
     export class SymmetrySystem implements com.vzome.core.editor.api.OrbitSource {
         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-        getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
-            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
-        }
-        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
         getEmbedding(): number[] {
             const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
             const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
@@ -17092,6 +17090,10 @@ namespace com.vzome.core.editor {
             embedding[14] = 0.0;
             embedding[15] = 1.0;
             return embedding;
+        }
+        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+        getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
+            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
         }
         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
         public getOrientations(rowMajor?: any): number[][] {
@@ -19245,10 +19247,12 @@ namespace com.vzome.core.algebra {
          * @return {com.vzome.core.algebra.AlgebraicVector}
          */
         public createVectorFromTDs(nums: number[][]): com.vzome.core.algebra.AlgebraicVector {
-            const x: com.vzome.core.algebra.AlgebraicNumber = this.createAlgebraicNumberFromTD(nums[0]);
-            const y: com.vzome.core.algebra.AlgebraicNumber = this.createAlgebraicNumberFromTD(nums[1]);
-            const z: com.vzome.core.algebra.AlgebraicNumber = this.createAlgebraicNumberFromTD(nums[2]);
-            return new com.vzome.core.algebra.AlgebraicVector(x, y, z);
+            const dims: number = nums.length;
+            const coords: com.vzome.core.algebra.AlgebraicNumber[] = (s => { let a=[]; while(s-->0) a.push(null); return a; })(dims);
+            for(let c: number = 0; c < coords.length; c++) {{
+                coords[c] = this.createAlgebraicNumberFromTD(nums[c]);
+            };}
+            return new com.vzome.core.algebra.AlgebraicVector(coords);
         }
 
         /**
@@ -46121,10 +46125,6 @@ namespace com.vzome.core.edits {
         export class ReplaceWithShape$0 implements com.vzome.core.editor.api.OrbitSource {
             public __parent: any;
             /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
-                return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
-            }
-            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
             getEmbedding(): number[] {
                 const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
                 const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
@@ -46142,6 +46142,10 @@ namespace com.vzome.core.edits {
                 embedding[14] = 0.0;
                 embedding[15] = 1.0;
                 return embedding;
+            }
+            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+            getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
+                return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
             }
             /* Default method injected from com.vzome.core.editor.api.OrbitSource */
             public getOrientations(rowMajor?: any): number[][] {


### PR DESCRIPTION
The command now serializes with `scaleAndProject="true"` by default,
so that older files (without it) will open as before.

Online vZome has the same functionality, though it still has no UI for setting
scale and quaternion.
