### PR TITLE
Added per-shapes scaling

### DIFF
--- a/core/src/main/java/com/vzome/core/editor/api/Shapes.java
+++ b/core/src/main/java/com/vzome/core/editor/api/Shapes.java
@@ -27,6 +27,8 @@ public interface Shapes
     Color getColor( Direction dir );
 
 	boolean hasColors();
+
+    double getCmScaling();
 }
 
 

--- a/core/src/main/java/com/vzome/core/exporters/DxfExporter.java
+++ b/core/src/main/java/com/vzome/core/exporters/DxfExporter.java
@@ -27,6 +27,7 @@ public class DxfExporter extends GeometryExporter
 		
         NumberFormat format = NumberFormat .getNumberInstance( Locale .US );
         format .setMaximumFractionDigits( 6 );
+        double inchScaling = mModel .getCmScaling() / 2.54d;
 
         for (RenderedManifestation rm : mModel) {
             Manifestation man = rm .getManifestation();
@@ -38,7 +39,7 @@ public class DxfExporter extends GeometryExporter
                 AlgebraicVector start = ((Strut) man) .getLocation();
                 AlgebraicVector end = ((Strut) man) .getEnd();
                 RealVector rv = mModel .renderVector( start );
-                rv = rv .scale( RZOME_INCH_SCALING );
+                rv = rv .scale( inchScaling );
                 output .println( "10" );
                 output .println( format.format( rv .x ) );
                 output .println( "20" );
@@ -46,7 +47,7 @@ public class DxfExporter extends GeometryExporter
                 output .println( "30" );
                 output .println( format.format( rv .z ) );
                 rv = mModel .renderVector( end );
-                rv = rv .scale( RZOME_INCH_SCALING );
+                rv = rv .scale( inchScaling );
                 output .println( "11" );
                 output .println( format.format( rv .x ) );
                 output .println( "21" );

--- a/core/src/main/java/com/vzome/core/exporters/GeometryExporter.java
+++ b/core/src/main/java/com/vzome/core/exporters/GeometryExporter.java
@@ -5,11 +5,10 @@ import java.io.PrintWriter;
 import java.io.Writer;
 
 import com.vzome.core.render.Colors;
-import com.vzome.core.render.RealZomeScaling;
 import com.vzome.core.render.RenderedModel;
 import com.vzome.xml.ResourceLoader;
 
-public abstract class GeometryExporter implements RealZomeScaling
+public abstract class GeometryExporter
 {
 	protected transient PrintWriter output;
 	

--- a/core/src/main/java/com/vzome/core/exporters/OpenScadExporter.java
+++ b/core/src/main/java/com/vzome/core/exporters/OpenScadExporter.java
@@ -131,14 +131,16 @@ public class OpenScadExporter extends DocumentExporter
         }
         output .println();
 
-        String tipVertexString = super .mModel .renderVector( tipVertex ) .scale( RZOME_MM_SCALING ) .toString();
+        double mmScaling = mModel .getCmScaling() * 10d;
+
+        String tipVertexString = super .mModel .renderVector( tipVertex ) .scale( mmScaling ) .toString();
         output .println( "  tip_vertex = [ " + tipVertexString + " ];" );
         output .println();
         
         output .println( "  fixed_vertices = [ " );
         for ( AlgebraicVector vertex : sortedFixedVertexList ) {
             output .print( "[ " );
-            output .print( super .mModel .renderVector( vertex ) .scale( RZOME_MM_SCALING ) .toString() );
+            output .print( super .mModel .renderVector( vertex ) .scale( mmScaling ) .toString() );
             output .print( " ], " );
         }
         output .println( " ];" );
@@ -146,7 +148,7 @@ public class OpenScadExporter extends DocumentExporter
         output .println( "  floating_vertices = [ " );
         for ( AlgebraicVector vertex : sortedFloatingVertexList ) {
             output .print( "[ " );
-            output .print( super .mModel .renderVector( vertex ) .scale( RZOME_MM_SCALING ) .toString() );
+            output .print( super .mModel .renderVector( vertex ) .scale( mmScaling ) .toString() );
             output .print( " ], " );
         }
         output .println( " ];" );

--- a/core/src/main/java/com/vzome/core/exporters/StlExporter.java
+++ b/core/src/main/java/com/vzome/core/exporters/StlExporter.java
@@ -28,6 +28,7 @@ public class StlExporter extends GeometryExporter
             ((DecimalFormat) FORMAT) .applyPattern( "0.000000E00" );
         }
 
+        double mmScaling = mModel .getCmScaling() * 10d;
         output = new PrintWriter( writer );
         output .println( "solid vcg" );
         
@@ -40,7 +41,7 @@ public class StlExporter extends GeometryExporter
                 RealVector v0 = null, v1 = null;
                 for (AlgebraicVector vert : panel) {
                     RealVector vertex = mModel .renderVector( vert );
-                    vertex = vertex .scale( RZOME_MM_SCALING );
+                    vertex = vertex .scale( mmScaling );
                     if ( v0 == null )
                         v0 = vertex;
                     else if ( v1 == null )

--- a/core/src/main/java/com/vzome/core/kinds/RootTwoFieldApplication.java
+++ b/core/src/main/java/com/vzome/core/kinds/RootTwoFieldApplication.java
@@ -29,6 +29,7 @@ import com.vzome.core.tools.TetrahedralToolFactory;
 import com.vzome.core.tools.TranslationToolFactory;
 import com.vzome.core.viewing.AbstractShapes;
 import com.vzome.core.viewing.ExportedVEFShapes;
+import com.vzome.core.viewing.SchochShapes;
 
 /**
  * Everything here is stateless, or at worst, a cache (like Shapes).
@@ -56,9 +57,9 @@ public class RootTwoFieldApplication extends DefaultFieldApplication
         AbstractShapes defaultShapes = new ExportedVEFShapes( null, "rootTwoSmall", "small octahedra", "small connectors", symmetry );
         octahedralPerspective .setDefaultGeometry( defaultShapes );
         octahedralPerspective .addShapes( new ExportedVEFShapes( null, "rootTwoBig", "ornate", symmetry, defaultShapes ) );
-        AbstractShapes rootTwoShapes = new ExportedVEFShapes( null, "rootTwo", "Schoch solid", "Tesseractix", symmetry, defaultShapes );
+        AbstractShapes rootTwoShapes = new SchochShapes( null, "rootTwo", "Schoch solid", symmetry, defaultShapes );
         octahedralPerspective .addShapes( rootTwoShapes );
-        octahedralPerspective .addShapes( new ExportedVEFShapes( null, "root2Lifelike", "Schoch lifelike", symmetry, rootTwoShapes ) );
+        octahedralPerspective .addShapes( new SchochShapes( null, "root2Lifelike", "Schoch lifelike", symmetry, rootTwoShapes ) );
     }
 
     @Override

--- a/core/src/main/java/com/vzome/core/render/RealZomeScaling.java
+++ b/core/src/main/java/com/vzome/core/render/RealZomeScaling.java
@@ -1,5 +1,10 @@
 package com.vzome.core.render;
 
+/**
+ * This is no longer used statically everywhere.  Now, any Shapes subclass can override
+ * getCmScaling(), and RenderedModel exposes that in its own methods.  See the default
+ * implementation in AbstractShapes.
+ */
 public interface RealZomeScaling
 {
     double VZOME_BLUE_DIAMETER = 2.0d;

--- a/core/src/main/java/com/vzome/core/render/RenderedModel.java
+++ b/core/src/main/java/com/vzome/core/render/RenderedModel.java
@@ -435,9 +435,14 @@ public class RenderedModel implements ManifestationChanges, Iterable<RenderedMan
         return measureLengthCm( renderVector( c1 .getLocation() .minus( c2 .getLocation() ) ) );
     }
 
-    public static double measureLengthCm( RealVector rv )
+    public double getCmScaling()
     {
-        return rv.length() * RealZomeScaling.RZOME_CM_SCALING;
+        return this.mPolyhedra .getCmScaling();
+    }
+    
+    public double measureLengthCm( RealVector rv )
+    {
+        return rv.length() * this.mPolyhedra .getCmScaling();
     }
 
     public double measureLengthCm( Strut strut )

--- a/core/src/main/java/com/vzome/core/viewing/AbstractShapes.java
+++ b/core/src/main/java/com/vzome/core/viewing/AbstractShapes.java
@@ -24,6 +24,7 @@ import com.vzome.core.math.symmetry.Permutation;
 import com.vzome.core.math.symmetry.Symmetry;
 import com.vzome.core.parts.FastDefaultStrutGeometry;
 import com.vzome.core.parts.StrutGeometry;
+import com.vzome.core.render.RealZomeScaling;
 
 
 public abstract class AbstractShapes implements Shapes
@@ -251,5 +252,10 @@ public abstract class AbstractShapes implements Shapes
             map3 .put( canonicalVertices, shape );
         }
         return shape;
+    }
+
+    @Override
+    public double getCmScaling(){
+      return RealZomeScaling.RZOME_CM_SCALING;
     }
 }

--- a/core/src/main/java/com/vzome/core/viewing/SchochShapes.java
+++ b/core/src/main/java/com/vzome/core/viewing/SchochShapes.java
@@ -1,0 +1,21 @@
+package com.vzome.core.viewing;
+
+import java.io.File;
+
+import com.vzome.core.math.symmetry.AbstractSymmetry;
+
+public class SchochShapes extends ExportedVEFShapes
+{
+    private static final long serialVersionUID = 1L;
+
+    public SchochShapes( File prefsFolder, String name, String alias, AbstractSymmetry symmetry, AbstractShapes defaultShapes)
+    {
+      super( prefsFolder, name, alias, symmetry, defaultShapes );
+    }
+
+    @Override
+    public double getCmScaling()
+    {
+      return 1d; // "cubic" blue strut has internal length 2, and Linus wants that to be 2cm in reality
+    }
+}

--- a/desktop/src/main/java/com/vzome/desktop/awt/DocumentController.java
+++ b/desktop/src/main/java/com/vzome/desktop/awt/DocumentController.java
@@ -240,7 +240,7 @@ public class DocumentController extends DefaultGraphicsController implements Sce
         };
         this .documentModel .addSelectionListener( selectionRendering );
         
-        this .addSubController( "measure", new MeasureController( this .documentModel .getEditorModel(), this .documentModel .getRenderedModel() ) );
+        this .addSubController( "measure", new MeasureController( this .documentModel .getEditorModel(), this .mRenderedModel ) );
 
         this .articleChanges = new PropertyChangeListener()
         {   

--- a/online/build.gradle
+++ b/online/build.gradle
@@ -195,6 +195,7 @@ core.config {
     'com/vzome/core/viewing/CameraIntf.java',
     'com/vzome/core/viewing/Lights.java',
     'com/vzome/core/viewing/AbstractShapes.java',
+    'com/vzome/core/viewing/SchochShapes.java',
     'com/vzome/core/viewing/AntiprismShapes.java',
     'com/vzome/core/viewing/OctahedralShapes.java',
     'com/vzome/core/viewing/DodecagonalShapes.java',

--- a/online/src/worker/legacy/core-java.js
+++ b/online/src/worker/legacy/core-java.js
@@ -2917,7 +2917,6 @@ export var com;
                 }
                 exporters.GeometryExporter = GeometryExporter;
                 GeometryExporter["__class"] = "com.vzome.core.exporters.GeometryExporter";
-                GeometryExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
             })(exporters = core.exporters || (core.exporters = {}));
         })(core = vzome.core || (vzome.core = {}));
     })(vzome = com.vzome || (com.vzome = {}));
@@ -3902,13 +3901,26 @@ export var com;
                         return this.orbitSource.getSymmetry();
                     }
                     measureDistanceCm(c1, c2) {
-                        return RenderedModel.measureLengthCm(this.renderVector(c1.getLocation().minus(c2.getLocation())));
+                        return this.measureLengthCm$com_vzome_core_math_RealVector(this.renderVector(c1.getLocation().minus(c2.getLocation())));
                     }
-                    static measureLengthCm(rv) {
-                        return rv.length() * com.vzome.core.render.RealZomeScaling.RZOME_CM_SCALING;
+                    getCmScaling() {
+                        return this.mPolyhedra.getCmScaling();
                     }
-                    measureLengthCm(strut) {
-                        return RenderedModel.measureLengthCm(this.renderVector(strut.getOffset()));
+                    measureLengthCm$com_vzome_core_math_RealVector(rv) {
+                        return rv.length() * this.mPolyhedra.getCmScaling();
+                    }
+                    measureLengthCm(rv) {
+                        if (((rv != null && rv instanceof com.vzome.core.math.RealVector) || rv === null)) {
+                            return this.measureLengthCm$com_vzome_core_math_RealVector(rv);
+                        }
+                        else if (((rv != null && (rv.constructor != null && rv.constructor["__interfaces"] != null && rv.constructor["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0)) || rv === null)) {
+                            return this.measureLengthCm$com_vzome_core_model_Strut(rv);
+                        }
+                        else
+                            throw new Error('invalid overload');
+                    }
+                    measureLengthCm$com_vzome_core_model_Strut(strut) {
+                        return this.measureLengthCm$com_vzome_core_math_RealVector(this.renderVector(strut.getOffset()));
                     }
                     measureDihedralAngle(p1, p2) {
                         const v1 = p1['getNormal$com_vzome_core_math_symmetry_Embedding'](this.getEmbedding());
@@ -3960,31 +3972,12 @@ export var com;
                             this.orbits = new com.vzome.core.math.symmetry.OrbitSet(symmetry);
                         }
                         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                        getEmbedding() {
-                            const symmetry = this.getSymmetry();
-                            const field = symmetry.getField();
-                            const embedding = (s => { let a = []; while (s-- > 0)
-                                a.push(0); return a; })(16);
-                            for (let i = 0; i < 3; i++) {
-                                {
-                                    const columnSelect = field.basisVector(3, i);
-                                    const colRV = symmetry.embedInR3(columnSelect);
-                                    embedding[i * 4 + 0] = colRV.x;
-                                    embedding[i * 4 + 1] = colRV.y;
-                                    embedding[i * 4 + 2] = colRV.z;
-                                    embedding[i * 4 + 3] = 0.0;
-                                }
-                                ;
-                            }
-                            embedding[12] = 0.0;
-                            embedding[13] = 0.0;
-                            embedding[14] = 0.0;
-                            embedding[15] = 1.0;
-                            return embedding;
-                        }
-                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                         getZone(orbit, orientation) {
                             return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
+                        }
+                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                        getOrientations$() {
+                            return this.getOrientations(false);
                         }
                         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                         getOrientations(rowMajor) {
@@ -4041,8 +4034,27 @@ export var com;
                                 throw new Error('invalid overload');
                         }
                         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                        getOrientations$() {
-                            return this.getOrientations(false);
+                        getEmbedding() {
+                            const symmetry = this.getSymmetry();
+                            const field = symmetry.getField();
+                            const embedding = (s => { let a = []; while (s-- > 0)
+                                a.push(0); return a; })(16);
+                            for (let i = 0; i < 3; i++) {
+                                {
+                                    const columnSelect = field.basisVector(3, i);
+                                    const colRV = symmetry.embedInR3(columnSelect);
+                                    embedding[i * 4 + 0] = colRV.x;
+                                    embedding[i * 4 + 1] = colRV.y;
+                                    embedding[i * 4 + 2] = colRV.z;
+                                    embedding[i * 4 + 3] = 0.0;
+                                }
+                                ;
+                            }
+                            embedding[12] = 0.0;
+                            embedding[13] = 0.0;
+                            embedding[14] = 0.0;
+                            embedding[15] = 1.0;
+                            return embedding;
                         }
                         /**
                          *
@@ -4555,6 +4567,13 @@ export var com;
                             map3.put(canonicalVertices, shape);
                         }
                         return shape;
+                    }
+                    /**
+                     *
+                     * @return {number}
+                     */
+                    getCmScaling() {
+                        return com.vzome.core.render.RealZomeScaling.RZOME_CM_SCALING;
                     }
                 }
                 viewing.AbstractShapes = AbstractShapes;
@@ -16787,31 +16806,12 @@ export var com;
                         this.setStyle(styleName);
                     }
                     /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                    getEmbedding() {
-                        const symmetry = this.getSymmetry();
-                        const field = symmetry.getField();
-                        const embedding = (s => { let a = []; while (s-- > 0)
-                            a.push(0); return a; })(16);
-                        for (let i = 0; i < 3; i++) {
-                            {
-                                const columnSelect = field.basisVector(3, i);
-                                const colRV = symmetry.embedInR3(columnSelect);
-                                embedding[i * 4 + 0] = colRV.x;
-                                embedding[i * 4 + 1] = colRV.y;
-                                embedding[i * 4 + 2] = colRV.z;
-                                embedding[i * 4 + 3] = 0.0;
-                            }
-                            ;
-                        }
-                        embedding[12] = 0.0;
-                        embedding[13] = 0.0;
-                        embedding[14] = 0.0;
-                        embedding[15] = 1.0;
-                        return embedding;
-                    }
-                    /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                     getZone(orbit, orientation) {
                         return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
+                    }
+                    /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                    getOrientations$() {
+                        return this.getOrientations(false);
                     }
                     /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                     getOrientations(rowMajor) {
@@ -16889,8 +16889,27 @@ export var com;
                             throw new Error('invalid overload');
                     }
                     /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                    getOrientations$() {
-                        return this.getOrientations(false);
+                    getEmbedding() {
+                        const symmetry = this.getSymmetry();
+                        const field = symmetry.getField();
+                        const embedding = (s => { let a = []; while (s-- > 0)
+                            a.push(0); return a; })(16);
+                        for (let i = 0; i < 3; i++) {
+                            {
+                                const columnSelect = field.basisVector(3, i);
+                                const colRV = symmetry.embedInR3(columnSelect);
+                                embedding[i * 4 + 0] = colRV.x;
+                                embedding[i * 4 + 1] = colRV.y;
+                                embedding[i * 4 + 2] = colRV.z;
+                                embedding[i * 4 + 3] = 0.0;
+                            }
+                            ;
+                        }
+                        embedding[12] = 0.0;
+                        embedding[13] = 0.0;
+                        embedding[14] = 0.0;
+                        embedding[15] = 1.0;
+                        return embedding;
                     }
                     static logger_$LI$() { if (SymmetrySystem.logger == null) {
                         SymmetrySystem.logger = java.util.logging.Logger.getLogger("com.vzome.core.editor");
@@ -23194,9 +23213,6 @@ export var com;
             var exporters;
             (function (exporters) {
                 class OffExporter extends com.vzome.core.exporters.GeometryExporter {
-                    constructor() {
-                        super();
-                    }
                     static __static_initialize() { if (!OffExporter.__static_initialized) {
                         OffExporter.__static_initialized = true;
                         OffExporter.__static_initializer_0();
@@ -23293,7 +23309,6 @@ export var com;
                 OffExporter.__static_initialized = false;
                 exporters.OffExporter = OffExporter;
                 OffExporter["__class"] = "com.vzome.core.exporters.OffExporter";
-                OffExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
             })(exporters = core.exporters || (core.exporters = {}));
         })(core = vzome.core || (vzome.core = {}));
     })(vzome = com.vzome || (com.vzome = {}));
@@ -23306,9 +23321,6 @@ export var com;
             var exporters;
             (function (exporters) {
                 class OpenScadMeshExporter extends com.vzome.core.exporters.GeometryExporter {
-                    constructor() {
-                        super();
-                    }
                     static __static_initialize() { if (!OpenScadMeshExporter.__static_initialized) {
                         OpenScadMeshExporter.__static_initialized = true;
                         OpenScadMeshExporter.__static_initializer_0();
@@ -23387,7 +23399,6 @@ export var com;
                 OpenScadMeshExporter.__static_initialized = false;
                 exporters.OpenScadMeshExporter = OpenScadMeshExporter;
                 OpenScadMeshExporter["__class"] = "com.vzome.core.exporters.OpenScadMeshExporter";
-                OpenScadMeshExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
             })(exporters = core.exporters || (core.exporters = {}));
         })(core = vzome.core || (vzome.core = {}));
     })(vzome = com.vzome || (com.vzome = {}));
@@ -23400,9 +23411,6 @@ export var com;
             var exporters;
             (function (exporters) {
                 class PythonBuild123dExporter extends com.vzome.core.exporters.GeometryExporter {
-                    constructor() {
-                        super();
-                    }
                     static __static_initialize() { if (!PythonBuild123dExporter.__static_initialized) {
                         PythonBuild123dExporter.__static_initialized = true;
                         PythonBuild123dExporter.__static_initializer_0();
@@ -23481,7 +23489,6 @@ export var com;
                 PythonBuild123dExporter.__static_initialized = false;
                 exporters.PythonBuild123dExporter = PythonBuild123dExporter;
                 PythonBuild123dExporter["__class"] = "com.vzome.core.exporters.PythonBuild123dExporter";
-                PythonBuild123dExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
             })(exporters = core.exporters || (core.exporters = {}));
         })(core = vzome.core || (vzome.core = {}));
     })(vzome = com.vzome || (com.vzome = {}));
@@ -23521,7 +23528,7 @@ export var com;
                 }
                 exporters.DocumentExporter = DocumentExporter;
                 DocumentExporter["__class"] = "com.vzome.core.exporters.DocumentExporter";
-                DocumentExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling", "com.vzome.core.exporters.DocumentExporterIntf"];
+                DocumentExporter["__interfaces"] = ["com.vzome.core.exporters.DocumentExporterIntf"];
             })(exporters = core.exporters || (core.exporters = {}));
         })(core = vzome.core || (vzome.core = {}));
     })(vzome = com.vzome || (com.vzome = {}));
@@ -23605,13 +23612,9 @@ export var com;
                     getFileExtension() {
                         return "pdb";
                     }
-                    constructor() {
-                        super();
-                    }
                 }
                 exporters.PdbExporter = PdbExporter;
                 PdbExporter["__class"] = "com.vzome.core.exporters.PdbExporter";
-                PdbExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
                 (function (PdbExporter) {
                     class Atom {
                         constructor(__parent, location, i) {
@@ -23642,9 +23645,6 @@ export var com;
             var exporters;
             (function (exporters) {
                 class StlExporter extends com.vzome.core.exporters.GeometryExporter {
-                    constructor() {
-                        super();
-                    }
                     static FORMAT_$LI$() { if (StlExporter.FORMAT == null) {
                         StlExporter.FORMAT = java.text.NumberFormat.getNumberInstance(java.util.Locale.US);
                     } return StlExporter.FORMAT; }
@@ -23659,6 +23659,7 @@ export var com;
                         if (StlExporter.FORMAT_$LI$() != null && StlExporter.FORMAT_$LI$() instanceof java.text.DecimalFormat) {
                             StlExporter.FORMAT_$LI$().applyPattern("0.000000E00");
                         }
+                        const mmScaling = this.mModel.getCmScaling() * 10.0;
                         this.output = new java.io.PrintWriter(writer);
                         this.output.println$java_lang_Object("solid vcg");
                         for (let index = this.mModel.iterator(); index.hasNext();) {
@@ -23674,7 +23675,7 @@ export var com;
                                         let vert = index.next();
                                         {
                                             let vertex = this.mModel.renderVector(vert);
-                                            vertex = vertex.scale(com.vzome.core.render.RealZomeScaling.RZOME_MM_SCALING);
+                                            vertex = vertex.scale(mmScaling);
                                             if (v0 == null)
                                                 v0 = vertex;
                                             else if (v1 == null)
@@ -23708,7 +23709,6 @@ export var com;
                 }
                 exporters.StlExporter = StlExporter;
                 StlExporter["__class"] = "com.vzome.core.exporters.StlExporter";
-                StlExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
             })(exporters = core.exporters || (core.exporters = {}));
         })(core = vzome.core || (vzome.core = {}));
     })(vzome = com.vzome || (com.vzome = {}));
@@ -23747,13 +23747,9 @@ export var com;
                     getFileExtension() {
                         return "vef";
                     }
-                    constructor() {
-                        super();
-                    }
                 }
                 exporters.VefExporter = VefExporter;
                 VefExporter["__class"] = "com.vzome.core.exporters.VefExporter";
-                VefExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
             })(exporters = core.exporters || (core.exporters = {}));
         })(core = vzome.core || (vzome.core = {}));
     })(vzome = com.vzome || (com.vzome = {}));
@@ -23781,6 +23777,7 @@ export var com;
                         this.output.println$java_lang_Object("ENTITIES");
                         const format = java.text.NumberFormat.getNumberInstance(java.util.Locale.US);
                         format.setMaximumFractionDigits(6);
+                        const inchScaling = this.mModel.getCmScaling() / 2.54;
                         for (let index = this.mModel.iterator(); index.hasNext();) {
                             let rm = index.next();
                             {
@@ -23793,7 +23790,7 @@ export var com;
                                     const start = man.getLocation();
                                     const end = man.getEnd();
                                     let rv = this.mModel.renderVector(start);
-                                    rv = rv.scale(com.vzome.core.render.RealZomeScaling.RZOME_INCH_SCALING);
+                                    rv = rv.scale(inchScaling);
                                     this.output.println$java_lang_Object("10");
                                     this.output.println$java_lang_Object(format.format(rv.x));
                                     this.output.println$java_lang_Object("20");
@@ -23801,7 +23798,7 @@ export var com;
                                     this.output.println$java_lang_Object("30");
                                     this.output.println$java_lang_Object(format.format(rv.z));
                                     rv = this.mModel.renderVector(end);
-                                    rv = rv.scale(com.vzome.core.render.RealZomeScaling.RZOME_INCH_SCALING);
+                                    rv = rv.scale(inchScaling);
                                     this.output.println$java_lang_Object("11");
                                     this.output.println$java_lang_Object(format.format(rv.x));
                                     this.output.println$java_lang_Object("21");
@@ -23824,13 +23821,9 @@ export var com;
                     getFileExtension() {
                         return "dxf";
                     }
-                    constructor() {
-                        super();
-                    }
                 }
                 exporters.DxfExporter = DxfExporter;
                 DxfExporter["__class"] = "com.vzome.core.exporters.DxfExporter";
-                DxfExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
             })(exporters = core.exporters || (core.exporters = {}));
         })(core = vzome.core || (vzome.core = {}));
     })(vzome = com.vzome || (com.vzome = {}));
@@ -23915,7 +23908,6 @@ export var com;
                 }
                 exporters.SegExporter = SegExporter;
                 SegExporter["__class"] = "com.vzome.core.exporters.SegExporter";
-                SegExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
             })(exporters = core.exporters || (core.exporters = {}));
         })(core = vzome.core || (vzome.core = {}));
     })(vzome = com.vzome || (com.vzome = {}));
@@ -23933,9 +23925,6 @@ export var com;
                  * @extends com.vzome.core.exporters.GeometryExporter
                  */
                 class VRMLExporter extends com.vzome.core.exporters.GeometryExporter {
-                    constructor() {
-                        super();
-                    }
                     /*private*/ exportColor(name, color) {
                         this.output.println$java_lang_Object("PROTO " + name + " [] {");
                         this.output.print("    Appearance { material Material { diffuseColor ");
@@ -24060,7 +24049,6 @@ export var com;
                 VRMLExporter.SCALE = 0.35;
                 exporters.VRMLExporter = VRMLExporter;
                 VRMLExporter["__class"] = "com.vzome.core.exporters.VRMLExporter";
-                VRMLExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
             })(exporters = core.exporters || (core.exporters = {}));
         })(core = vzome.core || (vzome.core = {}));
     })(vzome = com.vzome || (com.vzome = {}));
@@ -32265,9 +32253,6 @@ export var com;
             var exporters;
             (function (exporters) {
                 class MathTableExporter extends com.vzome.core.exporters.GeometryExporter {
-                    constructor() {
-                        super();
-                    }
                     static X_$LI$() { if (MathTableExporter.X == null) {
                         MathTableExporter.X = com.vzome.core.algebra.AlgebraicVector.X;
                     } return MathTableExporter.X; }
@@ -32577,7 +32562,6 @@ export var com;
                 }
                 exporters.MathTableExporter = MathTableExporter;
                 MathTableExporter["__class"] = "com.vzome.core.exporters.MathTableExporter";
-                MathTableExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
             })(exporters = core.exporters || (core.exporters = {}));
         })(core = vzome.core || (vzome.core = {}));
     })(vzome = com.vzome || (com.vzome = {}));
@@ -34197,7 +34181,7 @@ export var com;
                                 }
                                 else if (struts === 1) {
                                     const strut = com.vzome.core.editor.api.Manifestations.getStruts$java_lang_Iterable(this.selection).next();
-                                    const cm = this.renderedModel.measureLengthCm(strut);
+                                    const cm = this.renderedModel.measureLengthCm$com_vzome_core_model_Strut(strut);
                                     this.measurements.put("length (cm)", this.twoPlaces.format(cm) + " cm");
                                     const inches = cm / 2.54;
                                     this.measurements.put("length (in)", this.twoPlaces.format(inches) + " in");
@@ -36494,7 +36478,6 @@ export var com;
                 PlyExporter.__static_initialized = false;
                 exporters.PlyExporter = PlyExporter;
                 PlyExporter["__class"] = "com.vzome.core.exporters.PlyExporter";
-                PlyExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
             })(exporters = core.exporters || (core.exporters = {}));
         })(core = vzome.core || (vzome.core = {}));
     })(vzome = com.vzome || (com.vzome = {}));
@@ -36861,7 +36844,8 @@ export var com;
                             this.output.println$java_lang_Object("  bottom_face_normal = [ " + bottomFaceDirection.toString$() + " ];");
                         }
                         this.output.println$();
-                        const tipVertexString = this.mModel.renderVector(tipVertex).scale(com.vzome.core.render.RealZomeScaling.RZOME_MM_SCALING).toString$();
+                        const mmScaling = this.mModel.getCmScaling() * 10.0;
+                        const tipVertexString = this.mModel.renderVector(tipVertex).scale(mmScaling).toString$();
                         this.output.println$java_lang_Object("  tip_vertex = [ " + tipVertexString + " ];");
                         this.output.println$();
                         this.output.println$java_lang_Object("  fixed_vertices = [ ");
@@ -36869,7 +36853,7 @@ export var com;
                             let vertex = index.next();
                             {
                                 this.output.print("[ ");
-                                this.output.print(this.mModel.renderVector(vertex).scale(com.vzome.core.render.RealZomeScaling.RZOME_MM_SCALING).toString$());
+                                this.output.print(this.mModel.renderVector(vertex).scale(mmScaling).toString$());
                                 this.output.print(" ], ");
                             }
                         }
@@ -36879,7 +36863,7 @@ export var com;
                             let vertex = index.next();
                             {
                                 this.output.print("[ ");
-                                this.output.print(this.mModel.renderVector(vertex).scale(com.vzome.core.render.RealZomeScaling.RZOME_MM_SCALING).toString$());
+                                this.output.print(this.mModel.renderVector(vertex).scale(mmScaling).toString$());
                                 this.output.print(" ], ");
                             }
                         }
@@ -36941,7 +36925,7 @@ export var com;
                 }
                 exporters.OpenScadExporter = OpenScadExporter;
                 OpenScadExporter["__class"] = "com.vzome.core.exporters.OpenScadExporter";
-                OpenScadExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling", "com.vzome.core.exporters.DocumentExporterIntf"];
+                OpenScadExporter["__interfaces"] = ["com.vzome.core.exporters.DocumentExporterIntf"];
             })(exporters = core.exporters || (core.exporters = {}));
         })(core = vzome.core || (vzome.core = {}));
     })(vzome = com.vzome || (com.vzome = {}));
@@ -37205,7 +37189,7 @@ export var com;
                 POVRayExporter.PREAMBLE_FILE = "com/vzome/core/exporters/povray/preamble.pov";
                 exporters.POVRayExporter = POVRayExporter;
                 POVRayExporter["__class"] = "com.vzome.core.exporters.POVRayExporter";
-                POVRayExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling", "com.vzome.core.exporters.DocumentExporterIntf"];
+                POVRayExporter["__interfaces"] = ["com.vzome.core.exporters.DocumentExporterIntf"];
             })(exporters = core.exporters || (core.exporters = {}));
         })(core = vzome.core || (vzome.core = {}));
     })(vzome = com.vzome || (com.vzome = {}));
@@ -37301,7 +37285,7 @@ export var com;
                 }
                 exporters.PartGeometryExporter = PartGeometryExporter;
                 PartGeometryExporter["__class"] = "com.vzome.core.exporters.PartGeometryExporter";
-                PartGeometryExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling", "com.vzome.core.exporters.DocumentExporterIntf"];
+                PartGeometryExporter["__interfaces"] = ["com.vzome.core.exporters.DocumentExporterIntf"];
             })(exporters = core.exporters || (core.exporters = {}));
         })(core = vzome.core || (vzome.core = {}));
     })(vzome = com.vzome || (com.vzome = {}));
@@ -37777,9 +37761,9 @@ export var com;
                         const defaultShapes = new com.vzome.core.viewing.ExportedVEFShapes(null, "rootTwoSmall", "small octahedra", "small connectors", symmetry);
                         octahedralPerspective.setDefaultGeometry(defaultShapes);
                         octahedralPerspective.addShapes(new com.vzome.core.viewing.ExportedVEFShapes(null, "rootTwoBig", "ornate", symmetry, defaultShapes));
-                        const rootTwoShapes = new com.vzome.core.viewing.ExportedVEFShapes(null, "rootTwo", "Schoch solid", "Tesseractix", symmetry, defaultShapes);
+                        const rootTwoShapes = new com.vzome.core.viewing.SchochShapes(null, "rootTwo", "Schoch solid", symmetry, defaultShapes);
                         octahedralPerspective.addShapes(rootTwoShapes);
-                        octahedralPerspective.addShapes(new com.vzome.core.viewing.ExportedVEFShapes(null, "root2Lifelike", "Schoch lifelike", symmetry, rootTwoShapes));
+                        octahedralPerspective.addShapes(new com.vzome.core.viewing.SchochShapes(null, "root2Lifelike", "Schoch lifelike", symmetry, rootTwoShapes));
                     }
                     /**
                      *
@@ -37951,6 +37935,33 @@ export var com;
                     RootTwoFieldApplication$1["__interfaces"] = ["com.vzome.core.editor.SymmetryPerspective"];
                 })(RootTwoFieldApplication = kinds.RootTwoFieldApplication || (kinds.RootTwoFieldApplication = {}));
             })(kinds = core.kinds || (core.kinds = {}));
+        })(core = vzome.core || (vzome.core = {}));
+    })(vzome = com.vzome || (com.vzome = {}));
+})(com || (com = {}));
+(function (com) {
+    var vzome;
+    (function (vzome) {
+        var core;
+        (function (core) {
+            var viewing;
+            (function (viewing) {
+                class SchochShapes extends com.vzome.core.viewing.ExportedVEFShapes {
+                    constructor(prefsFolder, name, alias, symmetry, defaultShapes) {
+                        super(prefsFolder, name, alias, symmetry, defaultShapes);
+                    }
+                    /**
+                     *
+                     * @return {number}
+                     */
+                    getCmScaling() {
+                        return 1.0;
+                    }
+                }
+                SchochShapes.serialVersionUID = 1;
+                viewing.SchochShapes = SchochShapes;
+                SchochShapes["__class"] = "com.vzome.core.viewing.SchochShapes";
+                SchochShapes["__interfaces"] = ["com.vzome.core.editor.api.Shapes"];
+            })(viewing = core.viewing || (core.viewing = {}));
         })(core = vzome.core || (vzome.core = {}));
     })(vzome = com.vzome || (com.vzome = {}));
 })(com || (com = {}));
@@ -48081,31 +48092,12 @@ export var com;
                             this.__parent = __parent;
                         }
                         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                        getEmbedding() {
-                            const symmetry = this.getSymmetry();
-                            const field = symmetry.getField();
-                            const embedding = (s => { let a = []; while (s-- > 0)
-                                a.push(0); return a; })(16);
-                            for (let i = 0; i < 3; i++) {
-                                {
-                                    const columnSelect = field.basisVector(3, i);
-                                    const colRV = symmetry.embedInR3(columnSelect);
-                                    embedding[i * 4 + 0] = colRV.x;
-                                    embedding[i * 4 + 1] = colRV.y;
-                                    embedding[i * 4 + 2] = colRV.z;
-                                    embedding[i * 4 + 3] = 0.0;
-                                }
-                                ;
-                            }
-                            embedding[12] = 0.0;
-                            embedding[13] = 0.0;
-                            embedding[14] = 0.0;
-                            embedding[15] = 1.0;
-                            return embedding;
-                        }
-                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                         getZone(orbit, orientation) {
                             return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
+                        }
+                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                        getOrientations$() {
+                            return this.getOrientations(false);
                         }
                         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                         getOrientations(rowMajor) {
@@ -48156,8 +48148,27 @@ export var com;
                                 throw new Error('invalid overload');
                         }
                         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                        getOrientations$() {
-                            return this.getOrientations(false);
+                        getEmbedding() {
+                            const symmetry = this.getSymmetry();
+                            const field = symmetry.getField();
+                            const embedding = (s => { let a = []; while (s-- > 0)
+                                a.push(0); return a; })(16);
+                            for (let i = 0; i < 3; i++) {
+                                {
+                                    const columnSelect = field.basisVector(3, i);
+                                    const colRV = symmetry.embedInR3(columnSelect);
+                                    embedding[i * 4 + 0] = colRV.x;
+                                    embedding[i * 4 + 1] = colRV.y;
+                                    embedding[i * 4 + 2] = colRV.z;
+                                    embedding[i * 4 + 3] = 0.0;
+                                }
+                                ;
+                            }
+                            embedding[12] = 0.0;
+                            embedding[13] = 0.0;
+                            embedding[14] = 0.0;
+                            embedding[15] = 1.0;
+                            return embedding;
                         }
                         /**
                          *

--- a/online/src/worker/legacy/ts/com/vzome/core/editor/SymmetrySystem.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/editor/SymmetrySystem.ts
@@ -2,12 +2,23 @@
 namespace com.vzome.core.editor {
     export class SymmetrySystem implements com.vzome.core.editor.api.OrbitSource {
         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-        getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
-            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
-        }
-        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-        getOrientations$(): number[][] {
-            return this.getOrientations(false);
+        getEmbedding(): number[] {
+            const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
+            const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
+            const embedding: number[] = (s => { let a=[]; while(s-->0) a.push(0); return a; })(16);
+            for(let i: number = 0; i < 3; i++) {{
+                const columnSelect: com.vzome.core.algebra.AlgebraicVector = field.basisVector(3, i);
+                const colRV: com.vzome.core.math.RealVector = symmetry.embedInR3(columnSelect);
+                embedding[i * 4 + 0] = colRV.x;
+                embedding[i * 4 + 1] = colRV.y;
+                embedding[i * 4 + 2] = colRV.z;
+                embedding[i * 4 + 3] = 0.0;
+            };}
+            embedding[12] = 0.0;
+            embedding[13] = 0.0;
+            embedding[14] = 0.0;
+            embedding[15] = 1.0;
+            return embedding;
         }
         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
         public getOrientations(rowMajor?: any): number[][] {
@@ -60,23 +71,12 @@ namespace com.vzome.core.editor {
             } else throw new Error('invalid overload');
         }
         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-        getEmbedding(): number[] {
-            const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
-            const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
-            const embedding: number[] = (s => { let a=[]; while(s-->0) a.push(0); return a; })(16);
-            for(let i: number = 0; i < 3; i++) {{
-                const columnSelect: com.vzome.core.algebra.AlgebraicVector = field.basisVector(3, i);
-                const colRV: com.vzome.core.math.RealVector = symmetry.embedInR3(columnSelect);
-                embedding[i * 4 + 0] = colRV.x;
-                embedding[i * 4 + 1] = colRV.y;
-                embedding[i * 4 + 2] = colRV.z;
-                embedding[i * 4 + 3] = 0.0;
-            };}
-            embedding[12] = 0.0;
-            embedding[13] = 0.0;
-            embedding[14] = 0.0;
-            embedding[15] = 1.0;
-            return embedding;
+        getOrientations$(): number[][] {
+            return this.getOrientations(false);
+        }
+        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+        getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
+            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
         }
         static logger: java.util.logging.Logger; public static logger_$LI$(): java.util.logging.Logger { if (SymmetrySystem.logger == null) { SymmetrySystem.logger = java.util.logging.Logger.getLogger("com.vzome.core.editor"); }  return SymmetrySystem.logger; }
 

--- a/online/src/worker/legacy/ts/com/vzome/core/editor/api/Shapes.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/editor/api/Shapes.ts
@@ -18,6 +18,8 @@ namespace com.vzome.core.editor.api {
         getColor(dir: com.vzome.core.math.symmetry.Direction): com.vzome.core.construction.Color;
 
         hasColors(): boolean;
+
+        getCmScaling(): number;
     }
 }
 

--- a/online/src/worker/legacy/ts/com/vzome/core/edits/ReplaceWithShape.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/edits/ReplaceWithShape.ts
@@ -158,12 +158,23 @@ namespace com.vzome.core.edits {
         export class ReplaceWithShape$0 implements com.vzome.core.editor.api.OrbitSource {
             public __parent: any;
             /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
-                return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
-            }
-            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getOrientations$(): number[][] {
-                return this.getOrientations(false);
+            getEmbedding(): number[] {
+                const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
+                const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
+                const embedding: number[] = (s => { let a=[]; while(s-->0) a.push(0); return a; })(16);
+                for(let i: number = 0; i < 3; i++) {{
+                    const columnSelect: com.vzome.core.algebra.AlgebraicVector = field.basisVector(3, i);
+                    const colRV: com.vzome.core.math.RealVector = symmetry.embedInR3(columnSelect);
+                    embedding[i * 4 + 0] = colRV.x;
+                    embedding[i * 4 + 1] = colRV.y;
+                    embedding[i * 4 + 2] = colRV.z;
+                    embedding[i * 4 + 3] = 0.0;
+                };}
+                embedding[12] = 0.0;
+                embedding[13] = 0.0;
+                embedding[14] = 0.0;
+                embedding[15] = 1.0;
+                return embedding;
             }
             /* Default method injected from com.vzome.core.editor.api.OrbitSource */
             public getOrientations(rowMajor?: any): number[][] {
@@ -203,23 +214,12 @@ namespace com.vzome.core.edits {
                 } else throw new Error('invalid overload');
             }
             /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getEmbedding(): number[] {
-                const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
-                const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
-                const embedding: number[] = (s => { let a=[]; while(s-->0) a.push(0); return a; })(16);
-                for(let i: number = 0; i < 3; i++) {{
-                    const columnSelect: com.vzome.core.algebra.AlgebraicVector = field.basisVector(3, i);
-                    const colRV: com.vzome.core.math.RealVector = symmetry.embedInR3(columnSelect);
-                    embedding[i * 4 + 0] = colRV.x;
-                    embedding[i * 4 + 1] = colRV.y;
-                    embedding[i * 4 + 2] = colRV.z;
-                    embedding[i * 4 + 3] = 0.0;
-                };}
-                embedding[12] = 0.0;
-                embedding[13] = 0.0;
-                embedding[14] = 0.0;
-                embedding[15] = 1.0;
-                return embedding;
+            getOrientations$(): number[][] {
+                return this.getOrientations(false);
+            }
+            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+            getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
+                return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
             }
             /**
              * 

--- a/online/src/worker/legacy/ts/com/vzome/core/exporters/DocumentExporter.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/exporters/DocumentExporter.ts
@@ -28,7 +28,7 @@ namespace com.vzome.core.exporters {
         }
     }
     DocumentExporter["__class"] = "com.vzome.core.exporters.DocumentExporter";
-    DocumentExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling","com.vzome.core.exporters.DocumentExporterIntf"];
+    DocumentExporter["__interfaces"] = ["com.vzome.core.exporters.DocumentExporterIntf"];
 
 
 }

--- a/online/src/worker/legacy/ts/com/vzome/core/exporters/DxfExporter.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/exporters/DxfExporter.ts
@@ -16,6 +16,7 @@ namespace com.vzome.core.exporters {
             this.output.println$java_lang_Object("ENTITIES");
             const format: java.text.NumberFormat = java.text.NumberFormat.getNumberInstance(java.util.Locale.US);
             format.setMaximumFractionDigits(6);
+            const inchScaling: number = this.mModel.getCmScaling() / 2.54;
             for(let index=this.mModel.iterator();index.hasNext();) {
                 let rm = index.next();
                 {
@@ -28,7 +29,7 @@ namespace com.vzome.core.exporters {
                         const start: com.vzome.core.algebra.AlgebraicVector = (<com.vzome.core.model.Strut><any>man).getLocation();
                         const end: com.vzome.core.algebra.AlgebraicVector = (<com.vzome.core.model.Strut><any>man).getEnd();
                         let rv: com.vzome.core.math.RealVector = this.mModel.renderVector(start);
-                        rv = rv.scale(com.vzome.core.render.RealZomeScaling.RZOME_INCH_SCALING);
+                        rv = rv.scale(inchScaling);
                         this.output.println$java_lang_Object("10");
                         this.output.println$java_lang_Object(format.format(rv.x));
                         this.output.println$java_lang_Object("20");
@@ -36,7 +37,7 @@ namespace com.vzome.core.exporters {
                         this.output.println$java_lang_Object("30");
                         this.output.println$java_lang_Object(format.format(rv.z));
                         rv = this.mModel.renderVector(end);
-                        rv = rv.scale(com.vzome.core.render.RealZomeScaling.RZOME_INCH_SCALING);
+                        rv = rv.scale(inchScaling);
                         this.output.println$java_lang_Object("11");
                         this.output.println$java_lang_Object(format.format(rv.x));
                         this.output.println$java_lang_Object("21");
@@ -60,14 +61,8 @@ namespace com.vzome.core.exporters {
         public getFileExtension(): string {
             return "dxf";
         }
-
-        constructor() {
-            super();
-        }
     }
     DxfExporter["__class"] = "com.vzome.core.exporters.DxfExporter";
-    DxfExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
-
 
 }
 

--- a/online/src/worker/legacy/ts/com/vzome/core/exporters/GeometryExporter.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/exporters/GeometryExporter.ts
@@ -1,6 +1,6 @@
 /* Generated from Java with JSweet 3.2.0-SNAPSHOT - http://www.jsweet.org */
 namespace com.vzome.core.exporters {
-    export abstract class GeometryExporter implements com.vzome.core.render.RealZomeScaling {
+    export abstract class GeometryExporter {
         output: java.io.PrintWriter;
 
         mColors: com.vzome.core.render.Colors;
@@ -48,8 +48,6 @@ namespace com.vzome.core.exporters {
         }
     }
     GeometryExporter["__class"] = "com.vzome.core.exporters.GeometryExporter";
-    GeometryExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
-
 
 }
 

--- a/online/src/worker/legacy/ts/com/vzome/core/exporters/MathTableExporter.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/exporters/MathTableExporter.ts
@@ -290,14 +290,8 @@ namespace com.vzome.core.exporters {
         public getContentType(): string {
             return "application/json";
         }
-
-        constructor() {
-            super();
-        }
     }
     MathTableExporter["__class"] = "com.vzome.core.exporters.MathTableExporter";
-    MathTableExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
-
 
 }
 

--- a/online/src/worker/legacy/ts/com/vzome/core/exporters/OffExporter.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/exporters/OffExporter.ts
@@ -88,14 +88,8 @@ namespace com.vzome.core.exporters {
         public getFileExtension(): string {
             return "off";
         }
-
-        constructor() {
-            super();
-        }
     }
     OffExporter["__class"] = "com.vzome.core.exporters.OffExporter";
-    OffExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
-
 
 }
 

--- a/online/src/worker/legacy/ts/com/vzome/core/exporters/OpenScadExporter.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/exporters/OpenScadExporter.ts
@@ -95,7 +95,8 @@ namespace com.vzome.core.exporters {
                 this.output.println$java_lang_Object("  bottom_face_normal = [ " + bottomFaceDirection.toString$() + " ];");
             }
             this.output.println$();
-            const tipVertexString: string = this.mModel.renderVector(tipVertex).scale(com.vzome.core.render.RealZomeScaling.RZOME_MM_SCALING).toString$();
+            const mmScaling: number = this.mModel.getCmScaling() * 10.0;
+            const tipVertexString: string = this.mModel.renderVector(tipVertex).scale(mmScaling).toString$();
             this.output.println$java_lang_Object("  tip_vertex = [ " + tipVertexString + " ];");
             this.output.println$();
             this.output.println$java_lang_Object("  fixed_vertices = [ ");
@@ -103,7 +104,7 @@ namespace com.vzome.core.exporters {
                 let vertex = index.next();
                 {
                     this.output.print("[ ");
-                    this.output.print(this.mModel.renderVector(vertex).scale(com.vzome.core.render.RealZomeScaling.RZOME_MM_SCALING).toString$());
+                    this.output.print(this.mModel.renderVector(vertex).scale(mmScaling).toString$());
                     this.output.print(" ], ");
                 }
             }
@@ -113,7 +114,7 @@ namespace com.vzome.core.exporters {
                 let vertex = index.next();
                 {
                     this.output.print("[ ");
-                    this.output.print(this.mModel.renderVector(vertex).scale(com.vzome.core.render.RealZomeScaling.RZOME_MM_SCALING).toString$());
+                    this.output.print(this.mModel.renderVector(vertex).scale(mmScaling).toString$());
                     this.output.print(" ], ");
                 }
             }
@@ -174,7 +175,7 @@ namespace com.vzome.core.exporters {
         }
     }
     OpenScadExporter["__class"] = "com.vzome.core.exporters.OpenScadExporter";
-    OpenScadExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling","com.vzome.core.exporters.DocumentExporterIntf"];
+    OpenScadExporter["__interfaces"] = ["com.vzome.core.exporters.DocumentExporterIntf"];
 
 
 }

--- a/online/src/worker/legacy/ts/com/vzome/core/exporters/OpenScadMeshExporter.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/exporters/OpenScadMeshExporter.ts
@@ -75,14 +75,8 @@ namespace com.vzome.core.exporters {
         public getFileExtension(): string {
             return "scad";
         }
-
-        constructor() {
-            super();
-        }
     }
     OpenScadMeshExporter["__class"] = "com.vzome.core.exporters.OpenScadMeshExporter";
-    OpenScadMeshExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
-
 
 }
 

--- a/online/src/worker/legacy/ts/com/vzome/core/exporters/POVRayExporter.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/exporters/POVRayExporter.ts
@@ -246,7 +246,7 @@ namespace com.vzome.core.exporters {
         }
     }
     POVRayExporter["__class"] = "com.vzome.core.exporters.POVRayExporter";
-    POVRayExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling","com.vzome.core.exporters.DocumentExporterIntf"];
+    POVRayExporter["__interfaces"] = ["com.vzome.core.exporters.DocumentExporterIntf"];
 
 
 }

--- a/online/src/worker/legacy/ts/com/vzome/core/exporters/PartGeometryExporter.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/exporters/PartGeometryExporter.ts
@@ -82,7 +82,7 @@ namespace com.vzome.core.exporters {
         }
     }
     PartGeometryExporter["__class"] = "com.vzome.core.exporters.PartGeometryExporter";
-    PartGeometryExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling","com.vzome.core.exporters.DocumentExporterIntf"];
+    PartGeometryExporter["__interfaces"] = ["com.vzome.core.exporters.DocumentExporterIntf"];
 
 
 }

--- a/online/src/worker/legacy/ts/com/vzome/core/exporters/PdbExporter.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/exporters/PdbExporter.ts
@@ -73,14 +73,8 @@ namespace com.vzome.core.exporters {
         public getFileExtension(): string {
             return "pdb";
         }
-
-        constructor() {
-            super();
-        }
     }
     PdbExporter["__class"] = "com.vzome.core.exporters.PdbExporter";
-    PdbExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
-
 
 
     export namespace PdbExporter {

--- a/online/src/worker/legacy/ts/com/vzome/core/exporters/PlyExporter.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/exporters/PlyExporter.ts
@@ -97,8 +97,6 @@ namespace com.vzome.core.exporters {
         }
     }
     PlyExporter["__class"] = "com.vzome.core.exporters.PlyExporter";
-    PlyExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
-
 
 }
 

--- a/online/src/worker/legacy/ts/com/vzome/core/exporters/PythonBuild123dExporter.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/exporters/PythonBuild123dExporter.ts
@@ -75,14 +75,8 @@ namespace com.vzome.core.exporters {
         public getFileExtension(): string {
             return "py";
         }
-
-        constructor() {
-            super();
-        }
     }
     PythonBuild123dExporter["__class"] = "com.vzome.core.exporters.PythonBuild123dExporter";
-    PythonBuild123dExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
-
 
 }
 

--- a/online/src/worker/legacy/ts/com/vzome/core/exporters/SegExporter.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/exporters/SegExporter.ts
@@ -79,8 +79,6 @@ namespace com.vzome.core.exporters {
         }
     }
     SegExporter["__class"] = "com.vzome.core.exporters.SegExporter";
-    SegExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
-
 
 }
 

--- a/online/src/worker/legacy/ts/com/vzome/core/exporters/StlExporter.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/exporters/StlExporter.ts
@@ -14,6 +14,7 @@ namespace com.vzome.core.exporters {
             if (StlExporter.FORMAT_$LI$() != null && StlExporter.FORMAT_$LI$() instanceof <any>java.text.DecimalFormat){
                 (<java.text.DecimalFormat>StlExporter.FORMAT_$LI$()).applyPattern("0.000000E00");
             }
+            const mmScaling: number = this.mModel.getCmScaling() * 10.0;
             this.output = new java.io.PrintWriter(writer);
             this.output.println$java_lang_Object("solid vcg");
             for(let index=this.mModel.iterator();index.hasNext();) {
@@ -29,7 +30,7 @@ namespace com.vzome.core.exporters {
                             let vert = index.next();
                             {
                                 let vertex: com.vzome.core.math.RealVector = this.mModel.renderVector(vert);
-                                vertex = vertex.scale(com.vzome.core.render.RealZomeScaling.RZOME_MM_SCALING);
+                                vertex = vertex.scale(mmScaling);
                                 if (v0 == null)v0 = vertex; else if (v1 == null)v1 = vertex; else {
                                     this.output.print("  facet normal ");
                                     this.output.println$java_lang_Object(StlExporter.FORMAT_$LI$().format(norm.x) + " " + StlExporter.FORMAT_$LI$().format(norm.y) + " " + StlExporter.FORMAT_$LI$().format(norm.z));
@@ -57,14 +58,8 @@ namespace com.vzome.core.exporters {
         public getFileExtension(): string {
             return "stl";
         }
-
-        constructor() {
-            super();
-        }
     }
     StlExporter["__class"] = "com.vzome.core.exporters.StlExporter";
-    StlExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
-
 
 }
 

--- a/online/src/worker/legacy/ts/com/vzome/core/exporters/VRMLExporter.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/exporters/VRMLExporter.ts
@@ -126,14 +126,8 @@ namespace com.vzome.core.exporters {
         public getFileExtension(): string {
             return "wrl";
         }
-
-        constructor() {
-            super();
-        }
     }
     VRMLExporter["__class"] = "com.vzome.core.exporters.VRMLExporter";
-    VRMLExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
-
 
 }
 

--- a/online/src/worker/legacy/ts/com/vzome/core/exporters/VefExporter.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/exporters/VefExporter.ts
@@ -28,14 +28,8 @@ namespace com.vzome.core.exporters {
         public getFileExtension(): string {
             return "vef";
         }
-
-        constructor() {
-            super();
-        }
     }
     VefExporter["__class"] = "com.vzome.core.exporters.VefExporter";
-    VefExporter["__interfaces"] = ["com.vzome.core.render.RealZomeScaling"];
-
 
 }
 

--- a/online/src/worker/legacy/ts/com/vzome/core/kinds/RootTwoFieldApplication.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/kinds/RootTwoFieldApplication.ts
@@ -24,9 +24,9 @@ namespace com.vzome.core.kinds {
             const defaultShapes: com.vzome.core.viewing.AbstractShapes = new com.vzome.core.viewing.ExportedVEFShapes(null, "rootTwoSmall", "small octahedra", "small connectors", symmetry);
             octahedralPerspective.setDefaultGeometry(defaultShapes);
             octahedralPerspective.addShapes(new com.vzome.core.viewing.ExportedVEFShapes(null, "rootTwoBig", "ornate", symmetry, defaultShapes));
-            const rootTwoShapes: com.vzome.core.viewing.AbstractShapes = new com.vzome.core.viewing.ExportedVEFShapes(null, "rootTwo", "Schoch solid", "Tesseractix", symmetry, defaultShapes);
+            const rootTwoShapes: com.vzome.core.viewing.AbstractShapes = new com.vzome.core.viewing.SchochShapes(null, "rootTwo", "Schoch solid", symmetry, defaultShapes);
             octahedralPerspective.addShapes(rootTwoShapes);
-            octahedralPerspective.addShapes(new com.vzome.core.viewing.ExportedVEFShapes(null, "root2Lifelike", "Schoch lifelike", symmetry, rootTwoShapes));
+            octahedralPerspective.addShapes(new com.vzome.core.viewing.SchochShapes(null, "root2Lifelike", "Schoch lifelike", symmetry, rootTwoShapes));
         }
 
         /**

--- a/online/src/worker/legacy/ts/com/vzome/core/render/RealZomeScaling.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/render/RealZomeScaling.ts
@@ -1,5 +1,11 @@
 /* Generated from Java with JSweet 3.2.0-SNAPSHOT - http://www.jsweet.org */
 namespace com.vzome.core.render {
+    /**
+     * This is no longer used statically everywhere.  Now, any Shapes subclass can override
+     * getCmScaling(), and RenderedModel exposes that in its own methods.  See the default
+     * implementation in AbstractShapes.
+     * @class
+     */
     export interface RealZomeScaling {    }
 
     export namespace RealZomeScaling {

--- a/online/src/worker/legacy/ts/com/vzome/core/render/RenderedModel.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/render/RenderedModel.ts
@@ -351,15 +351,27 @@ namespace com.vzome.core.render {
         }
 
         public measureDistanceCm(c1: com.vzome.core.model.Connector, c2: com.vzome.core.model.Connector): number {
-            return RenderedModel.measureLengthCm(this.renderVector(c1.getLocation().minus(c2.getLocation())));
+            return this.measureLengthCm$com_vzome_core_math_RealVector(this.renderVector(c1.getLocation().minus(c2.getLocation())));
         }
 
-        public static measureLengthCm(rv: com.vzome.core.math.RealVector): number {
-            return rv.length() * com.vzome.core.render.RealZomeScaling.RZOME_CM_SCALING;
+        public getCmScaling(): number {
+            return this.mPolyhedra.getCmScaling();
         }
 
-        public measureLengthCm(strut: com.vzome.core.model.Strut): number {
-            return RenderedModel.measureLengthCm(this.renderVector(strut.getOffset()));
+        public measureLengthCm$com_vzome_core_math_RealVector(rv: com.vzome.core.math.RealVector): number {
+            return rv.length() * this.mPolyhedra.getCmScaling();
+        }
+
+        public measureLengthCm(rv?: any): number {
+            if (((rv != null && rv instanceof <any>com.vzome.core.math.RealVector) || rv === null)) {
+                return <any>this.measureLengthCm$com_vzome_core_math_RealVector(rv);
+            } else if (((rv != null && (rv.constructor != null && rv.constructor["__interfaces"] != null && rv.constructor["__interfaces"].indexOf("com.vzome.core.model.Strut") >= 0)) || rv === null)) {
+                return <any>this.measureLengthCm$com_vzome_core_model_Strut(rv);
+            } else throw new Error('invalid overload');
+        }
+
+        public measureLengthCm$com_vzome_core_model_Strut(strut: com.vzome.core.model.Strut): number {
+            return this.measureLengthCm$com_vzome_core_math_RealVector(this.renderVector(strut.getOffset()));
         }
 
         public measureDihedralAngle(p1: com.vzome.core.model.Panel, p2: com.vzome.core.model.Panel): number {
@@ -408,12 +420,23 @@ namespace com.vzome.core.render {
 
         export class SymmetryOrbitSource implements com.vzome.core.editor.api.OrbitSource {
             /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
-                return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
-            }
-            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getOrientations$(): number[][] {
-                return this.getOrientations(false);
+            getEmbedding(): number[] {
+                const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
+                const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
+                const embedding: number[] = (s => { let a=[]; while(s-->0) a.push(0); return a; })(16);
+                for(let i: number = 0; i < 3; i++) {{
+                    const columnSelect: com.vzome.core.algebra.AlgebraicVector = field.basisVector(3, i);
+                    const colRV: com.vzome.core.math.RealVector = symmetry.embedInR3(columnSelect);
+                    embedding[i * 4 + 0] = colRV.x;
+                    embedding[i * 4 + 1] = colRV.y;
+                    embedding[i * 4 + 2] = colRV.z;
+                    embedding[i * 4 + 3] = 0.0;
+                };}
+                embedding[12] = 0.0;
+                embedding[13] = 0.0;
+                embedding[14] = 0.0;
+                embedding[15] = 1.0;
+                return embedding;
             }
             /* Default method injected from com.vzome.core.editor.api.OrbitSource */
             public getOrientations(rowMajor?: any): number[][] {
@@ -455,23 +478,12 @@ namespace com.vzome.core.render {
                 } else throw new Error('invalid overload');
             }
             /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getEmbedding(): number[] {
-                const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
-                const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
-                const embedding: number[] = (s => { let a=[]; while(s-->0) a.push(0); return a; })(16);
-                for(let i: number = 0; i < 3; i++) {{
-                    const columnSelect: com.vzome.core.algebra.AlgebraicVector = field.basisVector(3, i);
-                    const colRV: com.vzome.core.math.RealVector = symmetry.embedInR3(columnSelect);
-                    embedding[i * 4 + 0] = colRV.x;
-                    embedding[i * 4 + 1] = colRV.y;
-                    embedding[i * 4 + 2] = colRV.z;
-                    embedding[i * 4 + 3] = 0.0;
-                };}
-                embedding[12] = 0.0;
-                embedding[13] = 0.0;
-                embedding[14] = 0.0;
-                embedding[15] = 1.0;
-                return embedding;
+            getOrientations$(): number[][] {
+                return this.getOrientations(false);
+            }
+            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+            getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
+                return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
             }
             symmetry: com.vzome.core.math.symmetry.Symmetry;
 

--- a/online/src/worker/legacy/ts/com/vzome/core/viewing/AbstractShapes.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/viewing/AbstractShapes.ts
@@ -215,6 +215,14 @@ namespace com.vzome.core.viewing {
             }
             return shape;
         }
+
+        /**
+         * 
+         * @return {number}
+         */
+        public getCmScaling(): number {
+            return com.vzome.core.render.RealZomeScaling.RZOME_CM_SCALING;
+        }
     }
     AbstractShapes["__class"] = "com.vzome.core.viewing.AbstractShapes";
     AbstractShapes["__interfaces"] = ["com.vzome.core.editor.api.Shapes"];

--- a/online/src/worker/legacy/ts/com/vzome/core/viewing/SchochShapes.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/viewing/SchochShapes.ts
@@ -1,0 +1,23 @@
+/* Generated from Java with JSweet 3.2.0-SNAPSHOT - http://www.jsweet.org */
+namespace com.vzome.core.viewing {
+    export class SchochShapes extends com.vzome.core.viewing.ExportedVEFShapes {
+        static serialVersionUID: number = 1;
+
+        public constructor(prefsFolder: java.io.File, name: string, alias: string, symmetry: com.vzome.core.math.symmetry.AbstractSymmetry, defaultShapes: com.vzome.core.viewing.AbstractShapes) {
+            super(prefsFolder, name, alias, symmetry, defaultShapes);
+        }
+
+        /**
+         * 
+         * @return {number}
+         */
+        public getCmScaling(): number {
+            return 1.0;
+        }
+    }
+    SchochShapes["__class"] = "com.vzome.core.viewing.SchochShapes";
+    SchochShapes["__interfaces"] = ["com.vzome.core.editor.api.Shapes"];
+
+
+}
+

--- a/online/src/worker/legacy/ts/com/vzome/desktop/controller/MeasureController.ts
+++ b/online/src/worker/legacy/ts/com/vzome/desktop/controller/MeasureController.ts
@@ -75,7 +75,7 @@ namespace com.vzome.desktop.controller {
                         this.measurements.put("vertices", /* toString */(''+(panel.getVertexCount())));
                     } else if (struts === 1){
                         const strut: com.vzome.core.model.Strut = com.vzome.core.editor.api.Manifestations.getStruts$java_lang_Iterable(this.selection).next();
-                        const cm: number = this.renderedModel.measureLengthCm(strut);
+                        const cm: number = this.renderedModel.measureLengthCm$com_vzome_core_model_Strut(strut);
                         this.measurements.put("length (cm)", this.twoPlaces.format(cm) + " cm");
                         const inches: number = cm / 2.54;
                         this.measurements.put("length (in)", this.twoPlaces.format(inches) + " in");


### PR DESCRIPTION
Working for `MeasureController`, and STL, DXF, and OpenSCAD exporters,
the only ones who were using RealZomeScaling.

Both Schoch shapes now use 15mm for the ball diameter.  All others still use
the Zome scaling, even though it might be meaningless in a given field.

Works in online also, except for the known bug where values don't update
in the measure panel (unrelated).
