### PR TITLE
Fix failing unit test

### DIFF
--- a/core/src/test/java/com/vzome/core/exporters/ExporterTest.java
+++ b/core/src/test/java/com/vzome/core/exporters/ExporterTest.java
@@ -651,7 +651,7 @@ public class ExporterTest {
         String expected
                 = "OFF\n" + 
                 "# numVertices numFaces numEdges (numEdges is ignored)\n" + 
-                "25 14 0\n" + 
+                "25 14 6\n" + 
                 "\n" + 
                 "# Vertices.  Each line is the XYZ coordinates of one vertex.\n" + 
                 "0.0000000000000000 0.0000000000000000 0.0000000000000000\n" + 


### PR DESCRIPTION
The recent addition of half green struts requires undoing the change to the Exporter unit test in commit 44ad64b53770357e60495d00b54731a7f867fad9. The original unit test is now working again.
