### PR TITLE
Added "open as new design"

### DIFF
--- a/online/src/app/classic/context/commands.jsx
+++ b/online/src/app/classic/context/commands.jsx
@@ -34,7 +34,7 @@ export const CommandsProvider = props =>
           if ( state.fileHandle && !chooseFile )
             return saveTextFile( state.fileHandle, text, mimeType )
           else
-            return saveTextFileAs( name + '-ONLINE.vZome', text, mimeType );
+            return saveTextFileAs( name + '.vZome', text, mimeType );
         })
         .then( result => {
           const { handle, success } = result;

--- a/online/src/app/classic/menus/filemenu.jsx
+++ b/online/src/app/classic/menus/filemenu.jsx
@@ -58,15 +58,18 @@ export const FileMenu = () =>
     createDesign( field );
   }
 
-  const handleOpen = evt =>
+  const handleOpen = asNew => () =>
   {
     const fileType = { description: 'vZome design file', accept: { '*/*' : [ '.vZome' ] } }
     openFile( [fileType] )
       .then( file => {
         if ( !!file ) {
+          if ( asNew ) {
+            setState( 'ignoreDesignName', true );  // transient, means we'll still have an untitled design after the fetch
+            setState( 'designName', undefined ); // cooperatively managed by both worker and client
+          }
+          setState( 'fileHandle', asNew? undefined : file.handle );
           openDesignFile( file, false );
-          // TODO: re-enable this once we have more confidence in serialization
-          // setState( 'fileHandle', file.handle );
         }
       });
   }
@@ -184,11 +187,11 @@ export const FileMenu = () =>
           }</For>
         </SubMenu>
 
-        <MenuAction label="Open..."     onClick={() => guard(handleOpen)} />
+        <MenuAction label="Open..."     onClick={() => guard(handleOpen(false))} />
         <MenuAction label="Open URL..." onClick={() => guard(handleShowUrlDialog)} />
+        <MenuAction label="Open As New Design..."     onClick={() => guard(handleOpen(true))} />
         { dropboxEnabled &&
            <MenuAction label="Choose from Dropbox..." onClick={() => guard(showDropboxChooser)} /> }
-        <MenuItem disabled={true}>Open As New Model...</MenuItem>
 
         <Divider/>
 

--- a/online/src/app/framework/context/editor.jsx
+++ b/online/src/app/framework/context/editor.jsx
@@ -84,8 +84,8 @@ const EditorProvider = props =>
             name = name .substring( 0, name.length - 6 );
             setState( 'designName', name ); // cooperatively managed by both worker and client
             setState( 'sharing', { title: name .replaceAll( '-', ' ' ) } );
-            setState( 'ignoreDesignName', false );  // always reset to use the next name; see app/classic/menus/help.jsx
           }
+          setState( 'ignoreDesignName', false );  // always reset to use the next name; see app/classic/menus/help.jsx
         }
         break;
       }


### PR DESCRIPTION
I also enabled online vZome to "save" directly, since I now trust the serialization to not
lose data.

I fixed a defect wherein the design name would be ignored forever after one ignored
file load (help, or Dropbox, or open-as-new).
