### PR TITLE
Fixed simple mesh JSON import

### DIFF
--- a/core/src/main/java/com/vzome/core/edits/ImportSimpleMeshJson.java
+++ b/core/src/main/java/com/vzome/core/edits/ImportSimpleMeshJson.java
@@ -33,7 +33,6 @@ public class ImportSimpleMeshJson extends ImportMesh
         boolean wFirst = false;
 
         if ( ! this.scaleAndProject ) {
-            wFirst = true;
             AlgebraicField field = this.mManifestations .getField();
             this.scale = field.one();
             this .projection = new Projection.Default( field );


### PR DESCRIPTION
Was using `wFirst=true`, which was incorrect, for legacy documents (no
`scaleAndProject` behavior).
