### PR TITLE
Cleanup all Java Lint warnings after recently upgrading Java

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -110,6 +110,7 @@ gradle.projectsEvaluated {
 		<< "-Xlint:overrides" \
 		<< "-Xlint:path" \
 		<< "-Xlint:rawtypes" \
+		<< "-Xlint:-this-escape" /* A minus sign following the colon removes that check. */ \
 		<< "-Xlint:unchecked" \
 		<< "-Xlint:serial" 
 	}

--- a/core/src/main/java/com/vzome/api/Application.java
+++ b/core/src/main/java/com/vzome/api/Application.java
@@ -6,6 +6,7 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.util.Properties;
 
@@ -55,7 +56,7 @@ public class Application
     
     public Document loadUrl( String path ) throws Exception
     {
-        URL url = new URL( path );
+        URL url = (new URI( path )).toURL(); // Don't use URI.create( path ) with a user input path since the path has not been validated
         InputStream bytes= null;
         HttpURLConnection conn = (HttpURLConnection) url .openConnection();
         // See https://stackoverflow.com/questions/1884230/urlconnection-doesnt-follow-redirect

--- a/core/src/main/java/com/vzome/core/exporters/GitHubShare.java
+++ b/core/src/main/java/com/vzome/core/exporters/GitHubShare.java
@@ -119,8 +119,10 @@ public class GitHubShare
             componentTemplate = instructionsTemplate;
             postLayout = "zometool";
             simpleLayout = "zometool";
+            break;
         }
         default:
+        	break;
         }
 
         String siteUrl = "https://" + orgName + ".github.io/" + repoName;

--- a/core/src/main/java/com/vzome/core/exporters2d/Java2dSnapshot.java
+++ b/core/src/main/java/com/vzome/core/exporters2d/Java2dSnapshot.java
@@ -188,7 +188,7 @@ public class Java2dSnapshot
             float greenIntensity = ambient .getGreen() / 255f;
             float blueIntensity = ambient .getBlue() / 255f;
             for ( int i = 0; i < lightColors.length; i++ ) {
-                double intensity = Math .max( normal .dot( lightDirs[ i ] ), 0f );
+                float intensity = (float) Math .max( normal .dot( lightDirs[ i ] ), 0f );
                 redIntensity += intensity * ( lightColors[ i ].getRed() / 255f );
                 greenIntensity += intensity * ( lightColors[ i ].getGreen() / 255f );
                 blueIntensity += intensity * ( lightColors[ i ].getBlue() / 255f );

--- a/core/src/main/java/com/vzome/core/kinds/AbstractSymmetryPerspective.java
+++ b/core/src/main/java/com/vzome/core/kinds/AbstractSymmetryPerspective.java
@@ -99,7 +99,7 @@ public abstract class AbstractSymmetryPerspective implements SymmetryPerspective
         case "tetrasymm":
         {
             Symmetry symmetry = getSymmetry();
-            int[] closure = symmetry .subgroup( Symmetry.TETRAHEDRAL );
+            //int[] closure = symmetry .subgroup( Symmetry.TETRAHEDRAL );
 
             // This command will be available to all SymmetryPerspectives even if they are not Octahedral
             return new CommandTetrahedralSymmetry( symmetry );

--- a/core/src/main/java/com/vzome/core/viewing/SchochShapes.java
+++ b/core/src/main/java/com/vzome/core/viewing/SchochShapes.java
@@ -6,8 +6,6 @@ import com.vzome.core.math.symmetry.AbstractSymmetry;
 
 public class SchochShapes extends ExportedVEFShapes
 {
-    private static final long serialVersionUID = 1L;
-
     public SchochShapes( File prefsFolder, String name, String alias, AbstractSymmetry symmetry, AbstractShapes defaultShapes)
     {
       super( prefsFolder, name, alias, symmetry, defaultShapes );

--- a/core/src/regression/java/com/vzome/core/regression/TestVZomeFiles.java
+++ b/core/src/regression/java/com/vzome/core/regression/TestVZomeFiles.java
@@ -183,11 +183,11 @@ public class TestVZomeFiles extends FileSystemVisitor2 .Actor
             String pkgName = "noFolder";
             String className = "noFolder";
             File classFolder = file .getParentFile();
-            if ( ! classFolder .equals( baseFolder ) )
+            if ( ! classFolder.toPath() .equals( baseFolder ) )
             {
                 className = classFolder .getName();
                 File packageFolder = classFolder .getParentFile();
-                if ( ! packageFolder .equals( baseFolder ) )
+                if ( ! packageFolder.toPath() .equals( baseFolder ) )
                 {
                     String basePath = baseFolder .toAbsolutePath() .toString();
                     pkgName = packageFolder .getAbsolutePath() .substring( basePath .length() );

--- a/core/src/regression/java/com/vzome/core/regression/TestVZomeFiles.java
+++ b/core/src/regression/java/com/vzome/core/regression/TestVZomeFiles.java
@@ -221,7 +221,8 @@ public class TestVZomeFiles extends FileSystemVisitor2 .Actor
                     } finally {
                         histOut .close();
                     }
-                    Process process = Runtime .getRuntime() .exec( "diff " + goldenHistory .getAbsolutePath() + " " + testHistory .getAbsolutePath() );
+                    String[] cmdArray = { "diff", goldenHistory .getAbsolutePath(), testHistory .getAbsolutePath() };
+                    Process process = Runtime .getRuntime() .exec( cmdArray );
                     // any error message?
                     StreamGobbler errorGobbler = new 
                             StreamGobbler( process.getErrorStream(), "ERROR" );            

--- a/core/src/test/java/quickhull3d/QuickHull3D.java
+++ b/core/src/test/java/quickhull3d/QuickHull3D.java
@@ -346,12 +346,13 @@ public class QuickHull3D {
     }
 
     protected void setFromQhull(double[] coords, int nump, boolean triangulate) {
-        String commandStr = "./qhull i";
+    	String[] cmdArray = { "./qhull", "i" };
         if (triangulate) {
-            commandStr += " -Qt";
+        	String[] cmdArray2 = { cmdArray[0], cmdArray[1], "-Qt" };
+        	cmdArray = cmdArray2;
         }
         try {
-            Process proc = Runtime.getRuntime().exec(commandStr);
+            Process proc = Runtime.getRuntime().exec(cmdArray);
             PrintStream ps = new PrintStream(proc.getOutputStream());
             StreamTokenizer stok = new StreamTokenizer(new InputStreamReader(proc.getInputStream()));
 

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -167,6 +167,7 @@ gradle.projectsEvaluated {
 		<< "-Xlint:overrides" \
 		<< "-Xlint:path" \
 		<< "-Xlint:rawtypes" \
+		<< "-Xlint:-this-escape" /* A minus sign following the colon removes that check. */ \
 		<< "-Xlint:unchecked" \
 		<< "-Xlint:serial" 
 	}

--- a/desktop/src/main/java/com/vzome/desktop/awt/ApplicationController.java
+++ b/desktop/src/main/java/com/vzome/desktop/awt/ApplicationController.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -321,7 +322,8 @@ public class ApplicationController extends DefaultController
                 String path = action .substring( "openURL-" .length() );
                 docProps .setProperty( "window.title", path );
                 try {
-                    URL url = new URL( path );
+                	// Don't use URI.create( path ) with a user input path since the path has not been validated
+                	URL url = (new URI( path )).toURL();
                     InputStream bytes= null;
                     HttpURLConnection conn = (HttpURLConnection) url .openConnection();
                     // See https://stackoverflow.com/questions/1884230/urlconnection-doesnt-follow-redirect

--- a/desktop/src/main/java/org/vorthmann/j3d/Platform.java
+++ b/desktop/src/main/java/org/vorthmann/j3d/Platform.java
@@ -62,7 +62,8 @@ public class Platform
 		if ( isMac )
 			try {
 				String path = file .getAbsolutePath();
-				Runtime .getRuntime() .exec( "open " + path );
+				String[] cmdArray = { "open", path };
+				Runtime .getRuntime() .exec( cmdArray );
 			} catch ( IOException e ) {
 				System .err .println( "Runtime.exec() failed on " + file .getAbsolutePath() );
 				e .printStackTrace();

--- a/desktop/src/main/java/org/vorthmann/zome/render/jogl/JoglRenderingViewer.java
+++ b/desktop/src/main/java/org/vorthmann/zome/render/jogl/JoglRenderingViewer.java
@@ -480,8 +480,8 @@ public class JoglRenderingViewer implements RenderingViewer, GLEventListener
         //  HOWEVER, now we are never creating GLCanvas, so fixGLCanvasRescaling is always false.
         if(fixGLCanvasRescaling) {
         	AffineTransform t = canvas.getGraphicsConfiguration().getDefaultTransform(); 
-            mouseX *= t.getScaleX();
-            mouseY *= t.getScaleY();
+            mouseX *= Double.valueOf(t.getScaleX()).intValue();
+            mouseY *= Double.valueOf(t.getScaleY()).intValue();
         }
         // I wasted a lot of time here looking at the Java3d implementation, which had a bug.
         //  Furthermore, it was based on the Java3d notion of "image plate" coordinates, which

--- a/desktop/src/main/java/org/vorthmann/zome/ui/ApplicationUI.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/ApplicationUI.java
@@ -20,7 +20,6 @@ import java.lang.management.RuntimeMXBean;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -301,8 +300,8 @@ public final class ApplicationUI implements ApplicationController.UI, PropertyCh
                     try {
                         // standard Java 7 idiom for dealing with file URIs, which is what
                         //   Windows will pass when opening with double-click or drag-n-drop
-                        normalizedPath = Paths .get( new URL( arg ) .toURI() );
-                    } catch ( MalformedURLException | URISyntaxException e ) {
+                        normalizedPath = Paths .get( new URI( arg ) );
+                    } catch ( URISyntaxException e ) {
                         // probably just on Mac or Linux
                         normalizedPath = Paths .get( arg );
                     } catch ( FileSystemNotFoundException e ) {

--- a/desktop/src/main/java/org/vorthmann/zome/ui/ApplicationUI.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/ApplicationUI.java
@@ -641,10 +641,10 @@ public final class ApplicationUI implements ApplicationController.UI, PropertyCh
     public void runScript( String script, File file )
     {
         try {
-            Runtime .getRuntime() .exec( script + " " + file .getAbsolutePath(),
-                    null, file .getParentFile() );
+        	String[] cmdArray = { script, file .getAbsolutePath() };
+			Runtime .getRuntime() .exec( cmdArray, null, file .getParentFile() );
         } catch ( IOException e ) {
-            System .err .println( "Runtime.exec() failed on " + file .getAbsolutePath() );
+            System .err .println( "Runtime.exec() failed on " + script + " " + file .getAbsolutePath() );
             e .printStackTrace();
         }
     }

--- a/desktop/src/main/java/org/vorthmann/zome/ui/ContextualMenu.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/ContextualMenu.java
@@ -14,7 +14,7 @@ public class ContextualMenu extends JPopupMenu
 {
     private static final long serialVersionUID = 1L;
     
-    private final Map<String, JMenuItem> mActions = new HashMap<>();
+    private final transient Map<String, JMenuItem> mActions = new HashMap<>();
     
     private String[] mActionNames = null;
 

--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
@@ -57,15 +57,15 @@ public class DocumentFrame extends JFrame implements PropertyChangeListener, Con
 {
     private static final long serialVersionUID = 1L;
 
-    protected final GraphicsController mController;
+    protected final transient GraphicsController mController;
     
-    protected final Controller toolsController;
+    protected final transient Controller toolsController;
 
     private final ModelPanel modelPanel;
             
     private final JTabbedPane tabbedPane = new JTabbedPane();
     
-    private final ExclusiveAction.Excluder mExcluder = new ExclusiveAction.Excluder( this );
+    private final transient ExclusiveAction.Excluder mExcluder = new ExclusiveAction.Excluder( this );
 
     private boolean isEditor, fullPower, readerPreview, canSave;
 
@@ -85,7 +85,7 @@ public class DocumentFrame extends JFrame implements PropertyChangeListener, Con
 
     private JLabel statusText;
 
-    private GraphicsController lessonController, cameraController;
+    private transient GraphicsController lessonController, cameraController;
     
     private JDialog polytopesDialog, importScaleDialog;
     
@@ -93,19 +93,19 @@ public class DocumentFrame extends JFrame implements PropertyChangeListener, Con
 
 	private final boolean developerExtras;
 	
-	private final ActionListener localActions;
+	private final transient ActionListener localActions;
 	    
     private final FileDialog fileDialog = new FileDialog( this );
     
 	private File mFile = null;
 	
-	private final Controller.ErrorChannel errors;
+	private final transient Controller.ErrorChannel errors;
 
     private Snapshot2dFrame snapshot2dFrame;
 
-	private ControllerFileAction saveAsAction;
+	private transient ControllerFileAction saveAsAction;
 
-	private PropertyChangeListener appUI;
+	private transient PropertyChangeListener appUI;
     
     public ExclusiveAction.Excluder getExcluder()
     {

--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
@@ -465,10 +465,23 @@ public class DocumentFrame extends JFrame implements PropertyChangeListener, Con
                             return;
                         }
                         String cmdLine = cmd .substring( "execCommandLine/" .length() );
+                        // convert the space delimited cmdLine to an array of Strings
+                        // in order to avoid using the deprecated overload of exec()
+                        String[] cmdArray = cmdLine.split(" "); // No special quote handling, just a simple split.
+                        for(int i = 0; i<cmdArray.length; i++) {
+                        	if(cmdArray[i] == "{}") {
+                        		cmdArray[i] = mFile.getName();
+                        	}
+                        }
                         cmdLine = cmdLine .replace( "{}", mFile .getName() );
                         logger.log( Level.INFO, "executing command line: " + cmdLine );
+                        if(cmdLine.contains("\"") || cmdLine.contains("'")) {
+                        	logger.log( Level.WARNING, "execCommandLine does no special handling of quotes characters.\n" 
+                        			+ " If the quotes characters in this command do not perform as expected,"
+                        			+ " consider invoking a simple shell script that accepts just the vZome file name as an argument." );
+                        }
                         try {
-                            Runtime .getRuntime() .exec( cmdLine, null, mFile .getParentFile() );
+                            Runtime .getRuntime() .exec( cmdArray, null, mFile .getParentFile() );
                         } catch ( IOException ioe ) {
                             System .err .println( "Runtime.exec() failed on " + cmdLine );
                             ioe .printStackTrace();

--- a/desktop/src/main/java/org/vorthmann/zome/ui/DocumentMenuBar.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/DocumentMenuBar.java
@@ -45,11 +45,11 @@ public class DocumentMenuBar extends JMenuBar implements PropertyChangeListener
 
     private final JMenuItem setColorMenuItem, showToolsMenuItem, zomicMenuItem, zomodMenuItem, importVEFItem; //, pythonMenuItem
 
-    private final ControlActions actions;
+    private final transient ControlActions actions;
 
     private final boolean fullPower;
 
-    private final Controller controller;
+    private final transient Controller controller;
 
     public DocumentMenuBar( final Controller controller, ControlActions actions )
     {

--- a/desktop/src/main/java/org/vorthmann/zome/ui/MeasurePanel.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/MeasurePanel.java
@@ -18,7 +18,7 @@ import com.vzome.desktop.api.Controller;
 public class MeasurePanel extends JPanel
 {
     private static final long serialVersionUID = 1L;
-    private final Controller controller;
+    private final transient Controller controller;
     private final JTable measureTable;
     private final MeasureTableModel measureTableModel;
 

--- a/desktop/src/main/java/org/vorthmann/zome/ui/PartsPanel.java
+++ b/desktop/src/main/java/org/vorthmann/zome/ui/PartsPanel.java
@@ -36,7 +36,7 @@ import com.vzome.desktop.controller.PartsController.PartInfo;
 public class PartsPanel extends JPanel
 {
     private static final long serialVersionUID = 1L;
-    private final Controller controller;
+    private final transient Controller controller;
     private final JTable bomTable;
     private final PartsTableModel partsTableModel;
     private Point popupTriggerLocation = null;
@@ -284,9 +284,9 @@ public class PartsPanel extends JPanel
         private static final long serialVersionUID = 1L;
         private final String[] columnNames = { "count", "orbit", "size", "length (orbit units)" };
         private final TreeSet<PartsTableRow> tableRows = new TreeSet<>(); // self-sorting since PartsTableRow implements Comparable
-        private final PartsTableRow ballsTotalRow = new PartsTableRow("balls", Connector.class, 1 );
-        private final PartsTableRow strutsTotalRow = new PartsTableRow("struts", Strut.class, 0 );
-        private final PartsTableRow panelsTotalRow = new PartsTableRow("panels", Panel.class, 0 );
+        private final transient PartsTableRow ballsTotalRow = new PartsTableRow("balls", Connector.class, 1 );
+        private final transient PartsTableRow strutsTotalRow = new PartsTableRow("struts", Strut.class, 0 );
+        private final transient PartsTableRow panelsTotalRow = new PartsTableRow("panels", Panel.class, 0 );
 
         PartsTableModel() {
             tableRows.add(ballsTotalRow);
@@ -474,8 +474,8 @@ public class PartsPanel extends JPanel
     private final class ColorRenderer extends JLabel implements TableCellRenderer
     {
         private static final long serialVersionUID = 1L;
-        Border unselectedBorder = null;
-        Border selectedBorder = null;
+        transient Border unselectedBorder = null;
+        transient Border selectedBorder = null;
         boolean isBordered = true;
      
         public ColorRenderer( boolean isBordered ) {

--- a/desktop/src/test/java/org/vorthmann/zome/render/jogl/View3dActivity.java
+++ b/desktop/src/test/java/org/vorthmann/zome/render/jogl/View3dActivity.java
@@ -23,6 +23,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URL;
 
 import com.jogamp.opengl.GLAutoDrawable;
@@ -187,7 +188,8 @@ public class View3dActivity implements GLEventListener
     	}
 
         try {
-            URL url = new URL( urls[ 0 ] );
+            // Don't use URI.create( path ) with a user input path unless the path has been validated
+            URL url = (new URI( urls[ 0 ] )).toURL(); 
             System.out.println( "%%%%%%%%%%%%%%%% opening: " + url);
             InputStream instream = url.openStream();
             Document doc = vZome.loadDocument(instream);


### PR DESCRIPTION
All "this-escape" warnings are just ignored for now. All other warnings are fixed except for the unavoidable deprecation warnings in the zomic test cases.