### PR TITLE
Fixing 2D preview

### DIFF
--- a/online/src/app/classic/dialogs/svgpreview.jsx
+++ b/online/src/app/classic/dialogs/svgpreview.jsx
@@ -16,7 +16,7 @@ import { useCamera } from "../../../viewer/context/camera"
 const SvgPreviewDialog = props =>
 {
   const { rootController } = useEditor();
-  const { state } = useCamera();
+  const { state, mapViewToWorld } = useCamera();
   const [ useLighting, setUseLighting ] = createSignal( true );
   const [ useShapes, setUseShapes ] = createSignal( true );
   const [ drawOutlines, setDrawOutlines ] = createSignal( false );
@@ -30,6 +30,7 @@ const SvgPreviewDialog = props =>
     if ( props.open ) { // always regenerate when opening the dialog
       const camera = unwrap( untrack( () => state.camera ) );
       const lighting = unwrap( untrack( () => state.lighting ) );
+      lighting .directionalLights .forEach( light => light .worldDirection = mapViewToWorld( light.direction ) );
       const params = { camera, lighting,
         useShapes     : useShapes(),
         drawOutlines  : drawOutlines(),

--- a/online/src/worker/legacy/controllers/editor.js
+++ b/online/src/worker/legacy/controllers/editor.js
@@ -252,6 +252,7 @@ export class EditorController extends com.vzome.desktop.controller.DefaultContro
           }
 
           case 'pov': {
+            lighting .useWorldDirection = true;
             exported = export3dDocument( this.legacyDesign, camera, lighting, { format, height, width } );
             break;
           }

--- a/online/src/worker/legacy/exporters.js
+++ b/online/src/worker/legacy/exporters.js
@@ -44,13 +44,15 @@ const parseColor = input =>
 
 const createLights = lighting =>
 {
-  const { backgroundColor, ambientColor, directionalLights } = lighting;
+  const { backgroundColor, ambientColor, directionalLights, useWorldDirection } = lighting;
   const lights = new com.vzome.core.viewing.Lights();
   lights .setBackgroundColor( parseColor( backgroundColor ) );
   lights .setAmbientColor( parseColor( ambientColor ) );
-  for ( const { worldDirection: [x,y,z], color } of directionalLights ) {
-    // Because we are using worldDirection rather than direction, these vectors are in world coordinates already.
-    //  Apparently, POVRayExporter is the only exporter that uses directional lights.
+  for ( const light of directionalLights ) {
+    const { worldDirection, direction, color } = light;
+    //  Apparently, POVRayExporter is the only 3D exporter that uses directional lights, and it wants them in world coordinates.
+    //  For 2D export, we need the directions in view coordinates.
+    const [ x, y, z ] = useWorldDirection ? worldDirection : direction;
     lights .addDirectionLight( parseColor( color ), new com.vzome.core.math.RealVector( x, y, z ) );
   }
   return lights;


### PR DESCRIPTION
When I implemented POV-Ray export, I reused `createLights()`, but changed
it to use the `worldDirection` vector for each light, since that's what POV needs.
However, that function is also used for 2D export, which needs the view
coordinates.  I am now generating the world coordinates always, but only
using them for POV export.
