### PR TITLE
Aligned symm commands in menu with desktop

### DIFF
--- a/online/src/app/classic/context/commands.jsx
+++ b/online/src/app/classic/context/commands.jsx
@@ -21,7 +21,7 @@ export const CommandsProvider = props =>
   const { state: cameraState } = useCamera();
   const globalAction   = action => () => controllerAction( rootController(), action );
   const undoRedoAction = action => () => controllerAction( subController( rootController(), 'undoRedo' ), action );
-  const symmetryAction = action => () => controllerAction( symmetryController(), action );
+  const symmetryAction = ( symm, action ) => () => controllerAction( subController( rootController(), `symmetry.${symm}` ), action );
   
   const doSave = ( chooseFile = false ) =>
     {
@@ -175,9 +175,9 @@ export const CommandsProvider = props =>
   createCommand( 'panel',                  { mods:"⌘",  key:"P" } );
   createCommand( 'Parallelepiped',         { mods:"⇧⌘", key:"P" } );
 
-  createCommand( 'icosasymm',          { mods:"⌘",  key:"I" }, symmetryAction( 'icosasymm' ) );
-  createCommand( 'octasymm',           { mods:"⌥⌘", key:"C" }, symmetryAction( 'octasymm' ) );
-  createCommand( 'tetrasymm',          { mods:"⌥⌘", key:"T" }, symmetryAction( 'tetrasymm' ) );
+  createCommand( 'icosasymm',          { mods:"⌘",  key:"I" }, symmetryAction( 'icosahedral', 'icosasymm' ) );
+  createCommand( 'octasymm',           { mods:"⌥⌘", key:"C" }, symmetryAction( 'octahedral', 'octasymm' ) );
+  createCommand( 'tetrasymm',          { mods:"⌥⌘", key:"T" }, symmetryAction( 'octahedral', 'tetrasymm' ) );
   createCommand( 'showPolytopeDialog', { mods:"⌥⌘", key:"P" }, showPolytopesDialog );
 
   return (

--- a/online/src/app/classic/menus/toolsmenu.jsx
+++ b/online/src/app/classic/menus/toolsmenu.jsx
@@ -1,13 +1,27 @@
 
 import { CommandAction, Divider, Menu } from "../../framework/menus.jsx";
 
+import { controllerProperty, useEditor } from "../../framework/context/editor.jsx";
+
 export const ToolsMenu = () =>
 {
+  const { rootController } = useEditor();
+  const symmetries = () => controllerProperty( rootController(), 'symmetryPerspectives', 'symmetryPerspectives', true );
+  const hasIcosa = () => symmetries().includes( 'icosahedral' );
+  const hasOcta = () => symmetries().includes( 'octahedral' );
+  const hasTetra = () => hasIcosa() || hasOcta();
+
   return (
       <Menu label="Tools">
-        <CommandAction label="Icosahedral Symmetry"         action="icosasymm" />
-        <CommandAction label="Cubic / Octahedral Symmetry"  action="octasymm" />
-        <CommandAction label="Tetrahedral Symmetry"         action="tetrasymm" />
+        <Show when={ hasIcosa() }>
+          <CommandAction label="Icosahedral Symmetry"         action="icosasymm" />
+        </Show>
+        <Show when={ hasOcta() }>
+          <CommandAction label="Cubic / Octahedral Symmetry"  action="octasymm" />
+        </Show>
+        <Show when={ hasTetra() }>
+          <CommandAction label="Tetrahedral Symmetry"         action="tetrasymm" />
+        </Show>
 
         <CommandAction label="Point Reflection" action="pointsymm" />
 

--- a/online/src/worker/legacy/controllers/editor.js
+++ b/online/src/worker/legacy/controllers/editor.js
@@ -87,6 +87,7 @@ export class EditorController extends com.vzome.desktop.controller.DefaultContro
         }
         const symmController = new com.vzome.desktop.controller.SymmetryController( label, strutBuilder, system, renderedModel );
         strutBuilder .addSubController( `symmetry.${label}`, symmController );
+        this .addSubController( `symmetry.${label}`, symmController );
         this.symmetries[ label ] = symmController;
       }
     }

--- a/online/src/worker/legacy/core-java.js
+++ b/online/src/worker/legacy/core-java.js
@@ -2518,7 +2518,6 @@ export var com;
                             case "tetrasymm":
                                 {
                                     const symmetry = this.getSymmetry();
-                                    const closure = symmetry.subgroup(com.vzome.core.math.symmetry.Symmetry.TETRAHEDRAL);
                                     return new com.vzome.core.commands.CommandTetrahedralSymmetry(symmetry);
                                 }
                                 ;
@@ -2843,9 +2842,11 @@ export var com;
                                     componentTemplate = instructionsTemplate;
                                     postLayout = "zometool";
                                     simpleLayout = "zometool";
+                                    break;
                                 }
                                 ;
                             default:
+                                break;
                         }
                         const siteUrl = "https://" + orgName + ".github.io/" + repoName;
                         const repoUrl = "https://github.com/" + orgName + "/" + repoName;
@@ -3983,33 +3984,6 @@ export var com;
                             return this.getOrientations(false);
                         }
                         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                        getEmbedding() {
-                            const symmetry = this.getSymmetry();
-                            const field = symmetry.getField();
-                            const embedding = (s => { let a = []; while (s-- > 0)
-                                a.push(0); return a; })(16);
-                            for (let i = 0; i < 3; i++) {
-                                {
-                                    const columnSelect = field.basisVector(3, i);
-                                    const colRV = symmetry.embedInR3(columnSelect);
-                                    embedding[i * 4 + 0] = colRV.x;
-                                    embedding[i * 4 + 1] = colRV.y;
-                                    embedding[i * 4 + 2] = colRV.z;
-                                    embedding[i * 4 + 3] = 0.0;
-                                }
-                                ;
-                            }
-                            embedding[12] = 0.0;
-                            embedding[13] = 0.0;
-                            embedding[14] = 0.0;
-                            embedding[15] = 1.0;
-                            return embedding;
-                        }
-                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                        getZone(orbit, orientation) {
-                            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
-                        }
-                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                         getOrientations(rowMajor) {
                             if (((typeof rowMajor === 'boolean') || rowMajor === null)) {
                                 let __args = arguments;
@@ -4062,6 +4036,33 @@ export var com;
                             }
                             else
                                 throw new Error('invalid overload');
+                        }
+                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                        getEmbedding() {
+                            const symmetry = this.getSymmetry();
+                            const field = symmetry.getField();
+                            const embedding = (s => { let a = []; while (s-- > 0)
+                                a.push(0); return a; })(16);
+                            for (let i = 0; i < 3; i++) {
+                                {
+                                    const columnSelect = field.basisVector(3, i);
+                                    const colRV = symmetry.embedInR3(columnSelect);
+                                    embedding[i * 4 + 0] = colRV.x;
+                                    embedding[i * 4 + 1] = colRV.y;
+                                    embedding[i * 4 + 2] = colRV.z;
+                                    embedding[i * 4 + 3] = 0.0;
+                                }
+                                ;
+                            }
+                            embedding[12] = 0.0;
+                            embedding[13] = 0.0;
+                            embedding[14] = 0.0;
+                            embedding[15] = 1.0;
+                            return embedding;
+                        }
+                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                        getZone(orbit, orientation) {
+                            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
                         }
                         /**
                          *
@@ -14295,10 +14296,10 @@ export var com;
                             let blueIntensity = Math.fround(ambient.getBlue() / 255.0);
                             for (let i = 0; i < lightColors.length; i++) {
                                 {
-                                    const intensity = Math.max(normal.dot(lightDirs[i]), 0.0);
-                                    redIntensity += intensity * (Math.fround(lightColors[i].getRed() / 255.0));
-                                    greenIntensity += intensity * (Math.fround(lightColors[i].getGreen() / 255.0));
-                                    blueIntensity += intensity * (Math.fround(lightColors[i].getBlue() / 255.0));
+                                    const intensity = Math.fround(Math.max(normal.dot(lightDirs[i]), 0.0));
+                                    redIntensity += Math.fround(intensity * (Math.fround(lightColors[i].getRed() / 255.0)));
+                                    greenIntensity += Math.fround(intensity * (Math.fround(lightColors[i].getGreen() / 255.0)));
+                                    blueIntensity += Math.fround(intensity * (Math.fround(lightColors[i].getBlue() / 255.0)));
                                 }
                                 ;
                             }
@@ -16817,33 +16818,6 @@ export var com;
                         return this.getOrientations(false);
                     }
                     /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                    getEmbedding() {
-                        const symmetry = this.getSymmetry();
-                        const field = symmetry.getField();
-                        const embedding = (s => { let a = []; while (s-- > 0)
-                            a.push(0); return a; })(16);
-                        for (let i = 0; i < 3; i++) {
-                            {
-                                const columnSelect = field.basisVector(3, i);
-                                const colRV = symmetry.embedInR3(columnSelect);
-                                embedding[i * 4 + 0] = colRV.x;
-                                embedding[i * 4 + 1] = colRV.y;
-                                embedding[i * 4 + 2] = colRV.z;
-                                embedding[i * 4 + 3] = 0.0;
-                            }
-                            ;
-                        }
-                        embedding[12] = 0.0;
-                        embedding[13] = 0.0;
-                        embedding[14] = 0.0;
-                        embedding[15] = 1.0;
-                        return embedding;
-                    }
-                    /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                    getZone(orbit, orientation) {
-                        return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
-                    }
-                    /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                     getOrientations(rowMajor) {
                         if (((typeof rowMajor === 'boolean') || rowMajor === null)) {
                             let __args = arguments;
@@ -16917,6 +16891,33 @@ export var com;
                         }
                         else
                             throw new Error('invalid overload');
+                    }
+                    /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                    getEmbedding() {
+                        const symmetry = this.getSymmetry();
+                        const field = symmetry.getField();
+                        const embedding = (s => { let a = []; while (s-- > 0)
+                            a.push(0); return a; })(16);
+                        for (let i = 0; i < 3; i++) {
+                            {
+                                const columnSelect = field.basisVector(3, i);
+                                const colRV = symmetry.embedInR3(columnSelect);
+                                embedding[i * 4 + 0] = colRV.x;
+                                embedding[i * 4 + 1] = colRV.y;
+                                embedding[i * 4 + 2] = colRV.z;
+                                embedding[i * 4 + 3] = 0.0;
+                            }
+                            ;
+                        }
+                        embedding[12] = 0.0;
+                        embedding[13] = 0.0;
+                        embedding[14] = 0.0;
+                        embedding[15] = 1.0;
+                        return embedding;
+                    }
+                    /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                    getZone(orbit, orientation) {
+                        return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
                     }
                     static logger_$LI$() { if (SymmetrySystem.logger == null) {
                         SymmetrySystem.logger = java.util.logging.Logger.getLogger("com.vzome.core.editor");
@@ -37990,7 +37991,6 @@ export var com;
                         return 1.0;
                     }
                 }
-                SchochShapes.serialVersionUID = 1;
                 viewing.SchochShapes = SchochShapes;
                 SchochShapes["__class"] = "com.vzome.core.viewing.SchochShapes";
                 SchochShapes["__interfaces"] = ["com.vzome.core.editor.api.Shapes"];
@@ -48129,33 +48129,6 @@ export var com;
                             return this.getOrientations(false);
                         }
                         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                        getEmbedding() {
-                            const symmetry = this.getSymmetry();
-                            const field = symmetry.getField();
-                            const embedding = (s => { let a = []; while (s-- > 0)
-                                a.push(0); return a; })(16);
-                            for (let i = 0; i < 3; i++) {
-                                {
-                                    const columnSelect = field.basisVector(3, i);
-                                    const colRV = symmetry.embedInR3(columnSelect);
-                                    embedding[i * 4 + 0] = colRV.x;
-                                    embedding[i * 4 + 1] = colRV.y;
-                                    embedding[i * 4 + 2] = colRV.z;
-                                    embedding[i * 4 + 3] = 0.0;
-                                }
-                                ;
-                            }
-                            embedding[12] = 0.0;
-                            embedding[13] = 0.0;
-                            embedding[14] = 0.0;
-                            embedding[15] = 1.0;
-                            return embedding;
-                        }
-                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                        getZone(orbit, orientation) {
-                            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
-                        }
-                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                         getOrientations(rowMajor) {
                             if (((typeof rowMajor === 'boolean') || rowMajor === null)) {
                                 let __args = arguments;
@@ -48202,6 +48175,33 @@ export var com;
                             }
                             else
                                 throw new Error('invalid overload');
+                        }
+                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                        getEmbedding() {
+                            const symmetry = this.getSymmetry();
+                            const field = symmetry.getField();
+                            const embedding = (s => { let a = []; while (s-- > 0)
+                                a.push(0); return a; })(16);
+                            for (let i = 0; i < 3; i++) {
+                                {
+                                    const columnSelect = field.basisVector(3, i);
+                                    const colRV = symmetry.embedInR3(columnSelect);
+                                    embedding[i * 4 + 0] = colRV.x;
+                                    embedding[i * 4 + 1] = colRV.y;
+                                    embedding[i * 4 + 2] = colRV.z;
+                                    embedding[i * 4 + 3] = 0.0;
+                                }
+                                ;
+                            }
+                            embedding[12] = 0.0;
+                            embedding[13] = 0.0;
+                            embedding[14] = 0.0;
+                            embedding[15] = 1.0;
+                            return embedding;
+                        }
+                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                        getZone(orbit, orientation) {
+                            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
                         }
                         /**
                          *

--- a/online/src/worker/legacy/ts/com/vzome/core/editor/SymmetrySystem.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/editor/SymmetrySystem.ts
@@ -2,33 +2,6 @@
 namespace com.vzome.core.editor {
     export class SymmetrySystem implements com.vzome.core.editor.api.OrbitSource {
         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-        getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
-            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
-        }
-        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-        getEmbedding(): number[] {
-            const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
-            const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
-            const embedding: number[] = (s => { let a=[]; while(s-->0) a.push(0); return a; })(16);
-            for(let i: number = 0; i < 3; i++) {{
-                const columnSelect: com.vzome.core.algebra.AlgebraicVector = field.basisVector(3, i);
-                const colRV: com.vzome.core.math.RealVector = symmetry.embedInR3(columnSelect);
-                embedding[i * 4 + 0] = colRV.x;
-                embedding[i * 4 + 1] = colRV.y;
-                embedding[i * 4 + 2] = colRV.z;
-                embedding[i * 4 + 3] = 0.0;
-            };}
-            embedding[12] = 0.0;
-            embedding[13] = 0.0;
-            embedding[14] = 0.0;
-            embedding[15] = 1.0;
-            return embedding;
-        }
-        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-        getOrientations$(): number[][] {
-            return this.getOrientations(false);
-        }
-        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
         public getOrientations(rowMajor?: any): number[][] {
             if (((typeof rowMajor === 'boolean') || rowMajor === null)) {
                 let __args = arguments;
@@ -77,6 +50,33 @@ namespace com.vzome.core.editor {
             } else if (rowMajor === undefined) {
                 return <any>this.getOrientations$();
             } else throw new Error('invalid overload');
+        }
+        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+        getOrientations$(): number[][] {
+            return this.getOrientations(false);
+        }
+        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+        getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
+            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
+        }
+        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+        getEmbedding(): number[] {
+            const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
+            const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
+            const embedding: number[] = (s => { let a=[]; while(s-->0) a.push(0); return a; })(16);
+            for(let i: number = 0; i < 3; i++) {{
+                const columnSelect: com.vzome.core.algebra.AlgebraicVector = field.basisVector(3, i);
+                const colRV: com.vzome.core.math.RealVector = symmetry.embedInR3(columnSelect);
+                embedding[i * 4 + 0] = colRV.x;
+                embedding[i * 4 + 1] = colRV.y;
+                embedding[i * 4 + 2] = colRV.z;
+                embedding[i * 4 + 3] = 0.0;
+            };}
+            embedding[12] = 0.0;
+            embedding[13] = 0.0;
+            embedding[14] = 0.0;
+            embedding[15] = 1.0;
+            return embedding;
         }
         static logger: java.util.logging.Logger; public static logger_$LI$(): java.util.logging.Logger { if (SymmetrySystem.logger == null) { SymmetrySystem.logger = java.util.logging.Logger.getLogger("com.vzome.core.editor"); }  return SymmetrySystem.logger; }
 

--- a/online/src/worker/legacy/ts/com/vzome/core/edits/ReplaceWithShape.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/edits/ReplaceWithShape.ts
@@ -158,33 +158,6 @@ namespace com.vzome.core.edits {
         export class ReplaceWithShape$0 implements com.vzome.core.editor.api.OrbitSource {
             public __parent: any;
             /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
-                return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
-            }
-            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getEmbedding(): number[] {
-                const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
-                const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
-                const embedding: number[] = (s => { let a=[]; while(s-->0) a.push(0); return a; })(16);
-                for(let i: number = 0; i < 3; i++) {{
-                    const columnSelect: com.vzome.core.algebra.AlgebraicVector = field.basisVector(3, i);
-                    const colRV: com.vzome.core.math.RealVector = symmetry.embedInR3(columnSelect);
-                    embedding[i * 4 + 0] = colRV.x;
-                    embedding[i * 4 + 1] = colRV.y;
-                    embedding[i * 4 + 2] = colRV.z;
-                    embedding[i * 4 + 3] = 0.0;
-                };}
-                embedding[12] = 0.0;
-                embedding[13] = 0.0;
-                embedding[14] = 0.0;
-                embedding[15] = 1.0;
-                return embedding;
-            }
-            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getOrientations$(): number[][] {
-                return this.getOrientations(false);
-            }
-            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
             public getOrientations(rowMajor?: any): number[][] {
                 if (((typeof rowMajor === 'boolean') || rowMajor === null)) {
                     let __args = arguments;
@@ -220,6 +193,33 @@ namespace com.vzome.core.edits {
                 } else if (rowMajor === undefined) {
                     return <any>this.getOrientations$();
                 } else throw new Error('invalid overload');
+            }
+            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+            getOrientations$(): number[][] {
+                return this.getOrientations(false);
+            }
+            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+            getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
+                return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
+            }
+            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+            getEmbedding(): number[] {
+                const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
+                const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
+                const embedding: number[] = (s => { let a=[]; while(s-->0) a.push(0); return a; })(16);
+                for(let i: number = 0; i < 3; i++) {{
+                    const columnSelect: com.vzome.core.algebra.AlgebraicVector = field.basisVector(3, i);
+                    const colRV: com.vzome.core.math.RealVector = symmetry.embedInR3(columnSelect);
+                    embedding[i * 4 + 0] = colRV.x;
+                    embedding[i * 4 + 1] = colRV.y;
+                    embedding[i * 4 + 2] = colRV.z;
+                    embedding[i * 4 + 3] = 0.0;
+                };}
+                embedding[12] = 0.0;
+                embedding[13] = 0.0;
+                embedding[14] = 0.0;
+                embedding[15] = 1.0;
+                return embedding;
             }
             /**
              * 

--- a/online/src/worker/legacy/ts/com/vzome/core/exporters/GitHubShare.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/exporters/GitHubShare.ts
@@ -96,8 +96,10 @@ namespace com.vzome.core.exporters {
                     componentTemplate = instructionsTemplate;
                     postLayout = "zometool";
                     simpleLayout = "zometool";
+                    break;
                 };
             default:
+                break;
             }
             const siteUrl: string = "https://" + orgName + ".github.io/" + repoName;
             const repoUrl: string = "https://github.com/" + orgName + "/" + repoName;

--- a/online/src/worker/legacy/ts/com/vzome/core/exporters2d/Java2dSnapshot.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/exporters2d/Java2dSnapshot.ts
@@ -187,10 +187,10 @@ namespace com.vzome.core.exporters2d {
                 let greenIntensity: number = (<any>Math).fround(ambient.getGreen() / 255.0);
                 let blueIntensity: number = (<any>Math).fround(ambient.getBlue() / 255.0);
                 for(let i: number = 0; i < lightColors.length; i++) {{
-                    const intensity: number = Math.max(normal.dot(lightDirs[i]), 0.0);
-                    redIntensity += intensity * ((<any>Math).fround(lightColors[i].getRed() / 255.0));
-                    greenIntensity += intensity * ((<any>Math).fround(lightColors[i].getGreen() / 255.0));
-                    blueIntensity += intensity * ((<any>Math).fround(lightColors[i].getBlue() / 255.0));
+                    const intensity: number = (<any>Math).fround(Math.max(normal.dot(lightDirs[i]), 0.0));
+                    redIntensity += (<any>Math).fround(intensity * ((<any>Math).fround(lightColors[i].getRed() / 255.0)));
+                    greenIntensity += (<any>Math).fround(intensity * ((<any>Math).fround(lightColors[i].getGreen() / 255.0)));
+                    blueIntensity += (<any>Math).fround(intensity * ((<any>Math).fround(lightColors[i].getBlue() / 255.0)));
                 };}
                 const red: number = (<number>((<any>Math).fround(this.mPolyColor.getRed() * Math.min(redIntensity, 1.0)))|0);
                 const green: number = (<number>((<any>Math).fround(this.mPolyColor.getGreen() * Math.min(greenIntensity, 1.0)))|0);

--- a/online/src/worker/legacy/ts/com/vzome/core/kinds/AbstractSymmetryPerspective.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/kinds/AbstractSymmetryPerspective.ts
@@ -102,7 +102,6 @@ namespace com.vzome.core.kinds {
             case "tetrasymm":
                 {
                     const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
-                    const closure: number[] = symmetry.subgroup(com.vzome.core.math.symmetry.Symmetry.TETRAHEDRAL);
                     return new com.vzome.core.commands.CommandTetrahedralSymmetry(symmetry);
                 };
             default:

--- a/online/src/worker/legacy/ts/com/vzome/core/render/RenderedModel.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/render/RenderedModel.ts
@@ -420,33 +420,6 @@ namespace com.vzome.core.render {
 
         export class SymmetryOrbitSource implements com.vzome.core.editor.api.OrbitSource {
             /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
-                return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
-            }
-            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getEmbedding(): number[] {
-                const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
-                const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
-                const embedding: number[] = (s => { let a=[]; while(s-->0) a.push(0); return a; })(16);
-                for(let i: number = 0; i < 3; i++) {{
-                    const columnSelect: com.vzome.core.algebra.AlgebraicVector = field.basisVector(3, i);
-                    const colRV: com.vzome.core.math.RealVector = symmetry.embedInR3(columnSelect);
-                    embedding[i * 4 + 0] = colRV.x;
-                    embedding[i * 4 + 1] = colRV.y;
-                    embedding[i * 4 + 2] = colRV.z;
-                    embedding[i * 4 + 3] = 0.0;
-                };}
-                embedding[12] = 0.0;
-                embedding[13] = 0.0;
-                embedding[14] = 0.0;
-                embedding[15] = 1.0;
-                return embedding;
-            }
-            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getOrientations$(): number[][] {
-                return this.getOrientations(false);
-            }
-            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
             public getOrientations(rowMajor?: any): number[][] {
                 if (((typeof rowMajor === 'boolean') || rowMajor === null)) {
                     let __args = arguments;
@@ -484,6 +457,33 @@ namespace com.vzome.core.render {
                 } else if (rowMajor === undefined) {
                     return <any>this.getOrientations$();
                 } else throw new Error('invalid overload');
+            }
+            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+            getOrientations$(): number[][] {
+                return this.getOrientations(false);
+            }
+            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+            getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
+                return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
+            }
+            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+            getEmbedding(): number[] {
+                const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
+                const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
+                const embedding: number[] = (s => { let a=[]; while(s-->0) a.push(0); return a; })(16);
+                for(let i: number = 0; i < 3; i++) {{
+                    const columnSelect: com.vzome.core.algebra.AlgebraicVector = field.basisVector(3, i);
+                    const colRV: com.vzome.core.math.RealVector = symmetry.embedInR3(columnSelect);
+                    embedding[i * 4 + 0] = colRV.x;
+                    embedding[i * 4 + 1] = colRV.y;
+                    embedding[i * 4 + 2] = colRV.z;
+                    embedding[i * 4 + 3] = 0.0;
+                };}
+                embedding[12] = 0.0;
+                embedding[13] = 0.0;
+                embedding[14] = 0.0;
+                embedding[15] = 1.0;
+                return embedding;
             }
             symmetry: com.vzome.core.math.symmetry.Symmetry;
 

--- a/online/src/worker/legacy/ts/com/vzome/core/viewing/SchochShapes.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/viewing/SchochShapes.ts
@@ -1,8 +1,6 @@
 /* Generated from Java with JSweet 3.2.0-SNAPSHOT - http://www.jsweet.org */
 namespace com.vzome.core.viewing {
     export class SchochShapes extends com.vzome.core.viewing.ExportedVEFShapes {
-        static serialVersionUID: number = 1;
-
         public constructor(prefsFolder: java.io.File, name: string, alias: string, symmetry: com.vzome.core.math.symmetry.AbstractSymmetry, defaultShapes: com.vzome.core.viewing.AbstractShapes) {
             super(prefsFolder, name, alias, symmetry, defaultShapes);
         }

--- a/online/src/worker/legacy/ts/core-java.ts
+++ b/online/src/worker/legacy/ts/core-java.ts
@@ -2612,7 +2612,6 @@ namespace com.vzome.core.kinds {
             case "tetrasymm":
                 {
                     const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
-                    const closure: number[] = symmetry.subgroup(com.vzome.core.math.symmetry.Symmetry.TETRAHEDRAL);
                     return new com.vzome.core.commands.CommandTetrahedralSymmetry(symmetry);
                 };
             default:
@@ -2973,8 +2972,10 @@ namespace com.vzome.core.exporters {
                     componentTemplate = instructionsTemplate;
                     postLayout = "zometool";
                     simpleLayout = "zometool";
+                    break;
                 };
             default:
+                break;
             }
             const siteUrl: string = "https://" + orgName + ".github.io/" + repoName;
             const repoUrl: string = "https://github.com/" + orgName + "/" + repoName;
@@ -4172,29 +4173,6 @@ namespace com.vzome.core.render {
                 return this.getOrientations(false);
             }
             /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getEmbedding(): number[] {
-                const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
-                const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
-                const embedding: number[] = (s => { let a=[]; while(s-->0) a.push(0); return a; })(16);
-                for(let i: number = 0; i < 3; i++) {{
-                    const columnSelect: com.vzome.core.algebra.AlgebraicVector = field.basisVector(3, i);
-                    const colRV: com.vzome.core.math.RealVector = symmetry.embedInR3(columnSelect);
-                    embedding[i * 4 + 0] = colRV.x;
-                    embedding[i * 4 + 1] = colRV.y;
-                    embedding[i * 4 + 2] = colRV.z;
-                    embedding[i * 4 + 3] = 0.0;
-                };}
-                embedding[12] = 0.0;
-                embedding[13] = 0.0;
-                embedding[14] = 0.0;
-                embedding[15] = 1.0;
-                return embedding;
-            }
-            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
-                return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
-            }
-            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
             public getOrientations(rowMajor?: any): number[][] {
                 if (((typeof rowMajor === 'boolean') || rowMajor === null)) {
                     let __args = arguments;
@@ -4232,6 +4210,29 @@ namespace com.vzome.core.render {
                 } else if (rowMajor === undefined) {
                     return <any>this.getOrientations$();
                 } else throw new Error('invalid overload');
+            }
+            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+            getEmbedding(): number[] {
+                const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
+                const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
+                const embedding: number[] = (s => { let a=[]; while(s-->0) a.push(0); return a; })(16);
+                for(let i: number = 0; i < 3; i++) {{
+                    const columnSelect: com.vzome.core.algebra.AlgebraicVector = field.basisVector(3, i);
+                    const colRV: com.vzome.core.math.RealVector = symmetry.embedInR3(columnSelect);
+                    embedding[i * 4 + 0] = colRV.x;
+                    embedding[i * 4 + 1] = colRV.y;
+                    embedding[i * 4 + 2] = colRV.z;
+                    embedding[i * 4 + 3] = 0.0;
+                };}
+                embedding[12] = 0.0;
+                embedding[13] = 0.0;
+                embedding[14] = 0.0;
+                embedding[15] = 1.0;
+                return embedding;
+            }
+            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+            getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
+                return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
             }
             symmetry: com.vzome.core.math.symmetry.Symmetry;
 
@@ -14475,10 +14476,10 @@ namespace com.vzome.core.exporters2d {
                 let greenIntensity: number = (<any>Math).fround(ambient.getGreen() / 255.0);
                 let blueIntensity: number = (<any>Math).fround(ambient.getBlue() / 255.0);
                 for(let i: number = 0; i < lightColors.length; i++) {{
-                    const intensity: number = Math.max(normal.dot(lightDirs[i]), 0.0);
-                    redIntensity += intensity * ((<any>Math).fround(lightColors[i].getRed() / 255.0));
-                    greenIntensity += intensity * ((<any>Math).fround(lightColors[i].getGreen() / 255.0));
-                    blueIntensity += intensity * ((<any>Math).fround(lightColors[i].getBlue() / 255.0));
+                    const intensity: number = (<any>Math).fround(Math.max(normal.dot(lightDirs[i]), 0.0));
+                    redIntensity += (<any>Math).fround(intensity * ((<any>Math).fround(lightColors[i].getRed() / 255.0)));
+                    greenIntensity += (<any>Math).fround(intensity * ((<any>Math).fround(lightColors[i].getGreen() / 255.0)));
+                    blueIntensity += (<any>Math).fround(intensity * ((<any>Math).fround(lightColors[i].getBlue() / 255.0)));
                 };}
                 const red: number = (<number>((<any>Math).fround(this.mPolyColor.getRed() * Math.min(redIntensity, 1.0)))|0);
                 const green: number = (<number>((<any>Math).fround(this.mPolyColor.getGreen() * Math.min(greenIntensity, 1.0)))|0);
@@ -17109,29 +17110,6 @@ namespace com.vzome.core.editor {
             return this.getOrientations(false);
         }
         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-        getEmbedding(): number[] {
-            const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
-            const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
-            const embedding: number[] = (s => { let a=[]; while(s-->0) a.push(0); return a; })(16);
-            for(let i: number = 0; i < 3; i++) {{
-                const columnSelect: com.vzome.core.algebra.AlgebraicVector = field.basisVector(3, i);
-                const colRV: com.vzome.core.math.RealVector = symmetry.embedInR3(columnSelect);
-                embedding[i * 4 + 0] = colRV.x;
-                embedding[i * 4 + 1] = colRV.y;
-                embedding[i * 4 + 2] = colRV.z;
-                embedding[i * 4 + 3] = 0.0;
-            };}
-            embedding[12] = 0.0;
-            embedding[13] = 0.0;
-            embedding[14] = 0.0;
-            embedding[15] = 1.0;
-            return embedding;
-        }
-        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-        getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
-            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
-        }
-        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
         public getOrientations(rowMajor?: any): number[][] {
             if (((typeof rowMajor === 'boolean') || rowMajor === null)) {
                 let __args = arguments;
@@ -17180,6 +17158,29 @@ namespace com.vzome.core.editor {
             } else if (rowMajor === undefined) {
                 return <any>this.getOrientations$();
             } else throw new Error('invalid overload');
+        }
+        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+        getEmbedding(): number[] {
+            const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
+            const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
+            const embedding: number[] = (s => { let a=[]; while(s-->0) a.push(0); return a; })(16);
+            for(let i: number = 0; i < 3; i++) {{
+                const columnSelect: com.vzome.core.algebra.AlgebraicVector = field.basisVector(3, i);
+                const colRV: com.vzome.core.math.RealVector = symmetry.embedInR3(columnSelect);
+                embedding[i * 4 + 0] = colRV.x;
+                embedding[i * 4 + 1] = colRV.y;
+                embedding[i * 4 + 2] = colRV.z;
+                embedding[i * 4 + 3] = 0.0;
+            };}
+            embedding[12] = 0.0;
+            embedding[13] = 0.0;
+            embedding[14] = 0.0;
+            embedding[15] = 1.0;
+            return embedding;
+        }
+        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+        getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
+            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
         }
         static logger: java.util.logging.Logger; public static logger_$LI$(): java.util.logging.Logger { if (SymmetrySystem.logger == null) { SymmetrySystem.logger = java.util.logging.Logger.getLogger("com.vzome.core.editor"); }  return SymmetrySystem.logger; }
 
@@ -37169,8 +37170,6 @@ namespace com.vzome.core.kinds {
 }
 namespace com.vzome.core.viewing {
     export class SchochShapes extends com.vzome.core.viewing.ExportedVEFShapes {
-        static serialVersionUID: number = 1;
-
         public constructor(prefsFolder: java.io.File, name: string, alias: string, symmetry: com.vzome.core.math.symmetry.AbstractSymmetry, defaultShapes: com.vzome.core.viewing.AbstractShapes) {
             super(prefsFolder, name, alias, symmetry, defaultShapes);
         }
@@ -46154,29 +46153,6 @@ namespace com.vzome.core.edits {
                 return this.getOrientations(false);
             }
             /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getEmbedding(): number[] {
-                const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
-                const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
-                const embedding: number[] = (s => { let a=[]; while(s-->0) a.push(0); return a; })(16);
-                for(let i: number = 0; i < 3; i++) {{
-                    const columnSelect: com.vzome.core.algebra.AlgebraicVector = field.basisVector(3, i);
-                    const colRV: com.vzome.core.math.RealVector = symmetry.embedInR3(columnSelect);
-                    embedding[i * 4 + 0] = colRV.x;
-                    embedding[i * 4 + 1] = colRV.y;
-                    embedding[i * 4 + 2] = colRV.z;
-                    embedding[i * 4 + 3] = 0.0;
-                };}
-                embedding[12] = 0.0;
-                embedding[13] = 0.0;
-                embedding[14] = 0.0;
-                embedding[15] = 1.0;
-                return embedding;
-            }
-            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
-                return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
-            }
-            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
             public getOrientations(rowMajor?: any): number[][] {
                 if (((typeof rowMajor === 'boolean') || rowMajor === null)) {
                     let __args = arguments;
@@ -46212,6 +46188,29 @@ namespace com.vzome.core.edits {
                 } else if (rowMajor === undefined) {
                     return <any>this.getOrientations$();
                 } else throw new Error('invalid overload');
+            }
+            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+            getEmbedding(): number[] {
+                const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
+                const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
+                const embedding: number[] = (s => { let a=[]; while(s-->0) a.push(0); return a; })(16);
+                for(let i: number = 0; i < 3; i++) {{
+                    const columnSelect: com.vzome.core.algebra.AlgebraicVector = field.basisVector(3, i);
+                    const colRV: com.vzome.core.math.RealVector = symmetry.embedInR3(columnSelect);
+                    embedding[i * 4 + 0] = colRV.x;
+                    embedding[i * 4 + 1] = colRV.y;
+                    embedding[i * 4 + 2] = colRV.z;
+                    embedding[i * 4 + 3] = 0.0;
+                };}
+                embedding[12] = 0.0;
+                embedding[13] = 0.0;
+                embedding[14] = 0.0;
+                embedding[15] = 1.0;
+                return embedding;
+            }
+            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+            getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
+                return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
             }
             /**
              * 


### PR DESCRIPTION
First, I ran JSweet to catch up.

Everything now seems correct, and robust even if we have some field that
claims to not support octahedral symmetry.
