### PR TITLE
Outlines toggle now hidden when it is inoperative

### DIFF
--- a/online/src/viewer/cameramode.jsx
+++ b/online/src/viewer/cameramode.jsx
@@ -4,7 +4,7 @@ import { Switch } from "@kobalte/core/switch";
 
 import { useCamera } from "./context/camera.jsx";
 
-export const CameraModes = () =>
+export const CameraModes = props =>
 {
   const { togglePerspective, toggleOutlines, state } = useCamera();
 
@@ -17,13 +17,15 @@ export const CameraModes = () =>
           <Switch.Thumb class="switch__thumb" />
         </Switch.Control>
       </Switch>
-      <Switch checked={state.camera.outlines} onChange={toggleOutlines}>
-        <Switch.Label class="switch__label">Outlines</Switch.Label>
-        <Switch.Input class="switch__input" />
-        <Switch.Control class="switch__control">
-          <Switch.Thumb class="switch__thumb" />
-        </Switch.Control>
-      </Switch>
+      <Show when={props.showOutlines}>
+        <Switch checked={state.camera.outlines} onChange={toggleOutlines}>
+          <Switch.Label class="switch__label">Outlines</Switch.Label>
+          <Switch.Input class="switch__input" />
+          <Switch.Control class="switch__control">
+            <Switch.Thumb class="switch__thumb" />
+          </Switch.Control>
+        </Switch>
+      </Show>
     </div>
   );
 }

--- a/online/src/viewer/index.jsx
+++ b/online/src/viewer/index.jsx
@@ -34,7 +34,7 @@ const normalStyle = {
 
 const DesignViewer = ( props ) =>
 {
-  const config = mergeProps( { showScenes: 'none', useSpinner: false, allowFullViewport: false, download: true, showPerspective: true }, props.config );
+  const config = mergeProps( { showScenes: 'none', useSpinner: false, allowFullViewport: false, download: true, showPerspective: true, showOutlines: true }, props.config );
   const { scene, waiting } = useViewer();
   let rootRef;
   
@@ -102,7 +102,7 @@ const DesignViewer = ( props ) =>
       </Show>
 
       <Show when={config.showPerspective} >
-        <CameraModes/>
+        <CameraModes showOutlines={ scene?.polygons && config.showOutlines }/>
       </Show>
 
       <Show when={showSceneMenu()}>

--- a/online/src/wc/gltf/index.jsx
+++ b/online/src/wc/gltf/index.jsx
@@ -14,7 +14,7 @@ const renderGlTFViewer = ( container, config ) =>
   {
     return (
       <CameraProvider>
-        <DesignViewer config={ { ...config, allowFullViewport: true } }
+        <DesignViewer config={ { ...config, allowFullViewport: true, showOutlines: false } }
             componentRoot={container}
             children3d={ <GltfModel url={config.url} /> }
             height="100%" width="100%" >

--- a/online/src/wc/vrml/index.jsx
+++ b/online/src/wc/vrml/index.jsx
@@ -19,7 +19,7 @@ const renderVrmlViewer = ( container, src, config, store ) =>
   {
     return (
       <CameraProvider cameraStore={store}>
-        <DesignViewer config={ { ...config, allowFullViewport: true } }
+        <DesignViewer config={ { ...config, allowFullViewport: true, showOutlines: false } }
             componentRoot={container}
             children3d={ <VrmlModel url={src()} /> }
             height="100%" width="100%" >


### PR DESCRIPTION
The toggle is hidden unless there is polygon information in the scene, or when
it is forcibly disabled, as for glTF or VRML.  Technically, the former would be
sufficient.
