### PR TITLE
Catch doLoad() exceptions correctly when parsed file includes zomic.

### DIFF
--- a/online/src/worker/vzome-worker-static.js
+++ b/online/src/worker/vzome-worker-static.js
@@ -211,7 +211,11 @@ const openDesign = async ( xmlLoading, name, report, debug, polygons, shapshot=D
           const api = await legacy .initialize();
           const field = api .getField( 'golden' );
           field .setInterpreterModule( zomic, legacy .vzomePkg );
-          doLoad();
+          doLoad()
+            .catch( error => {
+              console.log( `openDesign failure: ${error.message}` );
+              report( { type: 'ALERT_RAISED', payload: `Failed to load vZome model: ${error.message}` } );
+            });
         })
         .catch( error => {
           console.log( `openDesign failure: ${error.message}` );


### PR DESCRIPTION
Catch block was missing when loading files with zomic, so exceptions that may have had nothing to do with zomic were not being caught.
