### PR TITLE
Viewer adoption of new instanced shader and WebGPU

### DIFF
--- a/online/developer-docs/symmetry-renderer-plan.md
+++ b/online/developer-docs/symmetry-renderer-plan.md
@@ -1,0 +1,223 @@
+# Plan: Replace `ShapedGeometry` with `symmetry-renderer.js`
+
+## Background: What Each System Does
+
+**`ShapedGeometry` (current)**
+- A SolidJS reactive component using solid-three
+- Per-shape, creates a `BufferGeometry` from `{vertices, faces}`
+- Per-instance, renders a `<T.Mesh>` with individual material + raycasting event handlers
+- No GPU instancing — every ball/strut is a separate Three.js object
+- `MeshLambertMaterial`, selection via emissive color
+- Interaction via solid-three raycasting events (hover, click, drag, contextMenu)
+
+**`createSymmetryRenderer` (target)**
+- Imperative Three.js API using `InstancedMesh` (GPU instancing)
+- Requires: symmetry groups with pre-registered `Matrix4[]` orientations
+- Instances reference an `orientationIndex` + `colorIndex` (not per-instance materials)
+- Uses WebGPU TSL materials (`MeshPhongNodeMaterial`)
+- GPU-based picking via offscreen rendering pass (`pickAt()`)
+- Highlight via `setInstanceHighlight()`
+
+---
+
+## Data Contract Gap (Worker → Client)
+
+Currently `prepareSceneResponse` sends each instance with a `rotation` (full 16-element matrix)
+but does **not** send the `orientations` array. The symmetry-renderer needs the orientations array
+upfront plus an index per instance.
+
+Each instance already carries `orientation` (index) in the raw data, so the only missing piece is
+the `orientations` array in the response payload.
+
+---
+
+## Migration Plan
+
+### Phase 1 — Extend the worker contract
+In `vzome-worker-static.js`, add `orientations` to the `prepareSceneResponse` return value
+(alongside `shapes`, `embedding`, `polygons`). The `rotation` matrix per instance can be dropped
+once the new renderer is proven, but keep it for now to avoid breaking anything.
+
+### Phase 2 — Extract geometry builder
+Move the `BufferGeometry`-building logic from `InstancedShape` in `geometry.jsx` into a standalone
+utility function `buildShapeGeometry(shape)`. This is the same logic, just decoupled from SolidJS.
+The outline geometry builder likewise.
+
+### Phase 3 — Create a `SymmetryGeometry` component
+A new SolidJS component (in `geometry.jsx` or a new file) that:
+1. Gets the Three.js `scene` via `useThree()`
+2. Calls `createSymmetryRenderer(scene)` on mount, stores it in a ref
+3. Registers one symmetry group from the `orientations` array (passed as a prop or from the scene store)
+4. Registers one style (`"default"`)
+5. For each shape: calls `registerShape(groupId, styleId, shapeId, geometry)`
+6. Calls `registerColor(color)` for each unique color seen across instances, builds a Map from CSS string → colorIndex
+7. Calls `switchSymmetryGroup(groupId)`
+8. Adds all instances via `addInstance(styleId, shapeId, { position, orientationIndex, colorIndex })`
+9. Reacts to instance changes (via `createEffect`) to call `removeAllInstances` + re-add
+
+**Embedding matrix**: Apply it directly to `symmetryRenderer.originGroup.matrix` using the same
+imperative `applyMatrix4` pattern already in `ShapedGeometry`.
+
+### Phase 4 — Handle polygon mode (styles)
+Register two styles: `"solid"` and `"polygons"`. Build both geometries per shape (current
+triangulated-fan vs. the existing polygon-mode path). React to `scene.polygons` signal by calling
+`switchStyle()`.
+
+### Phase 5 — Wire GPU picking for interaction
+This is the most architectural change. The `useInteractionTool` hook expects
+`(id, position, type, selected, label)` callbacks. Bridge:
+1. Maintain a Map from symmetry-renderer's integer `instanceId` → instance metadata `{id, position, type, selected, label}`
+2. On canvas `pointerdown`/`click`/`contextmenu`: call `pickAt(x, y, renderer, camera)` to get
+   `{shapeId, instanceId}` → look up metadata → call the appropriate tool handler
+3. Hover: call `pickAt` on `pointermove` (debounced) to get enter/leave events
+4. Drag: on `pointerdown` hit, start a drag tracking sequence
+
+This replaces all the per-mesh solid-three event handlers in `Instance`.
+
+### Phase 6 — Handle selected/highlight state
+React to `instance.selected` changes: call `setInstanceHighlight(shapeId, instanceId, 0.5)` or `0`
+accordingly.
+
+### Phase 7 — Labels
+Labels are currently rendered by `<Label>` positioned at `geometry.shapeCentroid`. This still
+works independently — the label system is in `labels.jsx` and doesn't depend on how geometry is
+rendered. We'd need to keep/replicate label placement for instances that have labels.
+
+### Phase 8 — Replace usages
+Once `SymmetryGeometry` is proven, replace `<ShapedGeometry>` in:
+- `online/src/viewer/scenecanvas.jsx`
+- `online/src/app/59icosahedra/stellation.jsx`
+
+---
+
+## Risk Areas / Open Questions
+
+| Issue | Difficulty | Notes |
+|-------|-----------|-------|
+| Worker contract change (add `orientations`) | Low | Additive only |
+| Geometry building (reuse existing logic) | Low | Already works |
+| Color palette registration | Low | Collect unique colors across all instances |
+| Embedding matrix on `originGroup` | Medium | `setOrigin` only does position; need to set `originGroup.matrix` directly like current code does |
+| Polygon mode via `switchStyle` | Medium | Requires two geometry builds per shape |
+| GPU picking vs. raycasting | High | Async API, requires canvas event wiring, replaces all per-instance events |
+| Drag interaction | High | Drag requires knowing what was hit at `pointerdown`, then tracking position |
+| Labels | Medium | Need alternate positioning mechanism not tied to per-mesh refs |
+| `stellation.jsx` (59 Icosahedra) — many scenes | Medium | Multiple `SceneProvider` instances, each needing its own renderer |
+
+---
+
+## Recommended Starting Point
+
+Start with Phase 1–3 rendering-only (no interaction), verified by visual inspection. Temporarily
+disable interaction for the new component (the existing `Instance` component with all its event
+handlers can stay in `geometry.jsx` as a fallback). Once you confirm the rendering matches, tackle
+Phase 5 (picking) as a self-contained effort.
+
+---
+
+## Viewer vs. Editor Integration
+
+### The Core Difference: Symmetry is Static vs. Dynamic
+
+**Viewer**: One symmetry group, fixed for the life of the scene. `SYMMETRY_CHANGED` fires once
+during file load (stored as `scene.orientations`), then never again.
+
+**Editor**: The user can switch symmetry at runtime (e.g. icosahedral → octahedral).
+`SYMMETRY_CHANGED` fires again with a completely new `orientations` array. After a switch,
+`SCENE_RENDERED` fires to replace all instances — the new instances reference orientation indices
+into the *new* orientations array.
+
+### What `SYMMETRY_CHANGED` Carries (That the Viewer Ignores)
+
+`SceneChangeListener` currently discards most of the `SYMMETRY_CHANGED` payload:
+```js
+subscribeFor( 'SYMMETRY_CHANGED', ( { orientations } ) => {
+  setScene( 'orientations', orientations );
+  // resourcePath, permutations, scalars, planes — all discarded
+});
+```
+The `resourcePath` (e.g. `"icosahedral"`, `"octahedral"`) uniquely identifies the symmetry
+perspective and is the natural **`groupId`** for `registerSymmetryGroup()`. It is currently lost.
+
+### The Update Pattern Difference
+
+| Event | Viewer uses | Editor uses |
+|-------|-------------|-------------|
+| `SCENE_RENDERED` | Always (full replace) | After load + after symmetry switch |
+| `INSTANCE_ADDED` / `INSTANCE_REMOVED` | Never (snapshot-based) | Every user edit |
+| `SELECTION_TOGGLED` | Never | Every selection change |
+| `SYMMETRY_CHANGED` | Once (orientation matrix) | On every symmetry switch |
+| `SHAPE_DEFINED` | Never | When a new shape type first appears |
+
+The editor's incremental events (`INSTANCE_ADDED`/`INSTANCE_REMOVED`) map **directly** to
+`addInstance()`/`removeInstance()` on the renderer — no need to rebuild the whole scene on each
+edit. This is the main performance win the editor can exploit that the viewer cannot.
+
+### `SELECTION_TOGGLED` → `setInstanceHighlight()`
+
+Currently `SELECTION_TOGGLED` rebuilds the entire instances array reactively. With the renderer,
+it maps directly to `setInstanceHighlight(shapeId, instanceId, intensity)` — no geometry rebuild,
+just a buffer update.
+
+---
+
+## Proposed Integration Architecture
+
+### No Canvas Nesting Conflict
+
+A naive design might put a bridge component *outside* `<Canvas>` that calls the renderer API
+created *inside* `<Canvas>`. That would fail because the renderer object never escapes Canvas
+scope.
+
+The resolution: **`useWorkerClient()` is just a regular SolidJS context. It can be called from
+inside Canvas components, exactly like `useScene()` already is in `ShapedGeometry`.** There is
+no Canvas boundary for SolidJS contexts — only for `useThree()` (which requires a Three.js
+Canvas provider). The two kinds of context are independent.
+
+Therefore `SymmetryGeometry` is a single component (inside Canvas) that calls both:
+- `useThree()` — to get the Three.js scene and create the renderer
+- `useWorkerClient()` + `subscribeFor()` — to subscribe to worker events directly
+
+All event wiring is co-located inside `SymmetryGeometry`. No external bridge component is needed.
+
+### Two Behavioural Modes Within One Component
+
+`SymmetryGeometry` selects its event-handling strategy via a `mode` prop (`"viewer"` or
+`"editor"`):
+
+**Viewer mode (simple)**
+1. On mount: register one group from `scene.orientations`, call `switchSymmetryGroup()`
+2. React to `scene.shapes` changes (full replace): clear + re-add all instances
+
+**Editor mode (incremental)**
+Subscribe to raw worker events and call the renderer API directly:
+
+| Worker event        | Renderer call |
+|---------------------|---------------|
+| `SHAPE_DEFINED`     | `buildShapeGeometry()` + `registerShape()` |
+| `INSTANCE_ADDED`    | `addInstance()` (also store metadata for picking) |
+| `INSTANCE_REMOVED`  | `removeInstance()` |
+| `SELECTION_TOGGLED` | `setInstanceHighlight()` |
+| `SYMMETRY_CHANGED`  | `registerSymmetryGroup()` (if new) + `switchSymmetryGroup(resourcePath)` |
+| `SCENE_RENDERED`    | `clearActiveInstances()` + re-add all |
+
+This also maintains the metadata map `(rendererInstanceId → {id, position, type, selected, label})`
+needed for GPU picking.
+
+### What Stays the Same in Both Modes
+- Geometry building (`buildShapeGeometry`) is identical
+- Embedding matrix application to `originGroup` is identical
+- Polygon mode (`switchStyle()`) works the same way
+
+---
+
+## Revised Phase Order
+
+**Phase 0 (editor-only prep — before Phase 3)**:
+- Pass `resourcePath` through `SYMMETRY_CHANGED` in the worker so `SymmetryGeometry` can use it
+  as `groupId` for `registerSymmetryGroup()`
+- Optionally: add a `SYMMETRIES_AVAILABLE` worker event at design load so all groups can be
+  pre-registered upfront (enables instant symmetry switching with no GPU recompilation mid-session)
+
+The viewer path (Phases 1–8) remains valid and simpler — it uses `scene.shapes` reactively since
+it always does full scene replaces.

--- a/online/developer-docs/symmetry-renderer-status.md
+++ b/online/developer-docs/symmetry-renderer-status.md
@@ -1,0 +1,738 @@
+# SymmetryGeometry Status — Phases 4/6/7 Complete; Phase 5 Deliberately Deferred
+
+Branch: `webgpu-try`. This document is a handoff snapshot for continuing this work in a
+fresh session. See also `symmetry-renderer-plan.md` (the original phase plan) and
+`worker-client-scene-protocol.md` (a deep dive on the worker↔client wire protocol, written
+partway through Phase 3 debugging — still accurate and worth reading before touching
+scene-loading code).
+
+## What's done
+
+**Phase 1 (worker contract)** — `prepareSceneResponse`/`prepareEditSceneResponse` in
+`online/src/worker/vzome-worker-static.js` return `orientations` alongside the existing
+per-instance `rotation` (still computed too, redundantly — see "Known redundancy" below).
+
+**Phase 2 (geometry extraction)** — `buildShapeGeometry`/`buildOutlineGeometry` extracted
+from `ShapedGeometry`'s reactive memo bodies into standalone, exported functions in
+`online/src/viewer/geometry.jsx`. Pure refactor, verified byte-identical logic.
+
+**Phase 3 (rendering-only `SymmetryGeometry`)** — **complete and verified working** on every
+canvas actually tested:
+- Trackball preview (`camera.jsx`'s `CameraControlsUI`)
+- Main classic editor canvas (`editor.jsx`)
+- Standalone viewer / web-component embed (`SceneViewer` in `online/src/viewer/index.jsx`),
+  including a named-scene-on-first-load case
+
+New file: `online/src/viewer/symmetry-geometry.jsx`. Wired in as an opt-in prop:
+`<SceneCanvas symmetryRenderer={true} ...>` in `online/src/viewer/scenecanvas.jsx` (default
+`false`, still using `ShapedGeometry`). As of Phase 7: polygon-mode fill + outline (Phase 4),
+selection highlight (Phase 6), and labels (Phase 7) are all done. Only picking/interaction
+(Phase 5) is not — deliberately deferred at the user's direction, since it's only needed for
+*editing* use cases (classic editor, `59icosahedra`), which stay on `ShapedGeometry` for now;
+`SymmetryGeometry` is being scoped for *viewer-only* (non-editing) release first. See the
+Phase 6/7 sections below for the full rationale and what (if anything) is still missing for
+that release.
+
+**Not yet tested**: the 59 Icosahedra stellation view (`online/src/app/59icosahedra/`), any
+other `<SceneCanvas>` call sites (`selectors.jsx`, `scenes.jsx` dialog).
+
+## Real bugs found and fixed along the way
+
+These were not hypothetical — each cost significant debugging time and is documented inline
+in the code with comments explaining the failure mode, specifically so they don't get
+"simplified away" by a future edit. Read the comments in place; this list is just an index.
+
+1. **Port bug**: `symmetry-renderer.js` (mechanically ported from `webxr-poc`) had a
+   duplicated-line typo in `registerSymmetryGroup`'s `Euler`-vs-`Matrix4` branch. Fixed.
+
+2. **Wrong import source**: `MeshBasicNodeMaterial`/`MeshPhongNodeMaterial` don't exist in
+   plain `"three"`, only `"three/webgpu"`. Fixed the import; confirmed the other classes
+   (`Matrix4`, `Vector3`, etc.) are the same class identities either way, so no
+   `instanceof`-mismatch risk from mixing sources with the rest of the app.
+
+3. **`orientations` missing on the wire in three separate client-side call sites** (a
+   structural flaw — no single "apply scene response" function; see
+   `worker-client-scene-protocol.md` for the full four-path breakdown):
+   - `online/src/app/classic/components/camera.jsx` — the trackball preview's own
+     `TRACKBALL_SCENE_LOADED` handler.
+   - `online/src/viewer/context/scene.jsx`'s `SceneChangeListener` (`SCENE_RENDERED`
+     subscription) — used by classic editor + buildplane apps.
+   - `online/src/viewer/context/scene.jsx`'s `SceneIndexingProvider.showIndexedScene` — used
+     by the standalone viewer / web-component path, which never mounts
+     `SceneChangeListener` at all.
+
+4. **`SceneTitlesProvider`'s `sceneTitle` signal frozen at `undefined` forever** — seeded
+   from `scenes` (async, from the worker) before that data arrives; SolidJS signals don't
+   re-run their initializer. `setSceneTitle` was exported but never called anywhere. Caused
+   named-scene loads to silently fall back to scene index 0 on first paint. Fixed with a
+   `createEffect` in `scene.jsx` that corrects it once `scenes` populates, guarded to not
+   clobber a deliberately-set value. **This is a general SolidJS foot-gun pattern** — any
+   other signal seeded from not-yet-loaded async `useViewer()` data is a candidate for the
+   same bug; worth a grep if time allows.
+
+5. **`originGroup.matrixAutoUpdate` needed to be `false`** — `createSymmetryRenderer`'s
+   `originGroup` is a plain `THREE.Group()`; without disabling auto-update, Three's per-frame
+   matrix recompute silently discards any `applyMatrix4`/`.matrix.copy()` we do for the
+   embedding transform. `ShapedGeometry`'s equivalent wrapper (`<T.Group
+   matrixAutoUpdate={false}>` in `geometry.jsx`) already does this — `symmetry-renderer.js`
+   didn't, and needed to.
+
+6. **The big one — `globalScale` not applied, everything silently clipped by the far
+   plane**: `ShapedGeometry`'s content gets scaled by `globalScale` (≈0.0088,
+   meters-per-vZome-unit) *implicitly*, as a side effect of being JSX-nested inside
+   `WebXRSupport`'s `<T.Group scale={globalScale}>` (`online/src/viewer/context/webxr.jsx`).
+   `SymmetryGeometry` instead attaches its `originGroup` straight to the raw Three.js
+   `scene` via `createSymmetryRenderer(scene) → scene.add(originGroup)`, bypassing that
+   wrapper entirely. Without compensating, vZome-unit-scale content (tens of units) sat far
+   outside the camera's meters-scaled near/far planes and was silently far-plane-clipped —
+   no error, no warning, correct-looking draw calls, compiled shaders, real buffer data,
+   just nothing on screen. **This single bug consumed the majority of the Phase 3
+   debugging session.** Fixed in `symmetry-geometry.jsx` by building `originGroup.matrix`
+   explicitly (required per #5): `globalScale * embeddingMatrix`, matching the same
+   effective transform order `ShapedGeometry` gets for free from its ancestor group. A
+   *first* attempt at this fix (`originGroup.scale.setScalar(globalScale)`) silently did
+   nothing at all, precisely because of #5 — matrixAutoUpdate being off means `.scale` is
+   never read. Both mistakes (and the working fix) are documented in
+   `symmetry-geometry.jsx`'s comments.
+
+7. **Frustum culling per shape class** — `InstancedMesh`'s default frustum culling computes
+   its bounding sphere from the un-instanced base geometry only (e.g. one ball near the
+   local origin), with no knowledge of the per-instance `instanceTranslation` scattering
+   applied in the `positionNode` vertex shader. Zooming in could tighten the frustum past
+   that tiny local bounding sphere well before the actual (scattered) instances left view,
+   culling **every instance of that one shape at once** — "all the balls disappear,
+   struts remain," at some zoom threshold, per shape class independently. Fixed by setting
+   `frustumCulled = false` on every mesh (and picking mesh) in both `createShapeEntry` and
+   `ensureShapeCapacity` (the capacity-growth path, whose replacement meshes don't inherit
+   the flag). **This fix has also been back-ported to `webxr-poc`** (the standalone POC,
+   easier to test in real XR) and confirmed fixed there by deployment/testing.
+
+## Known-open items — not yet fixed, flagged for later
+
+- **Labels don't appear in XR** — confirmed by the user. `labels.jsx`'s `Labels`/`Label`
+  render via `CSS2DRenderer` (`three-stdlib`), which positions plain DOM elements over the
+  canvas using CSS transforms computed from each object's projected screen position. This is
+  fundamentally a 2D-overlay technique tied to the regular (non-XR) canvas/DOM layer — it has
+  no meaning once a WebXR immersive session takes over the display, since there is no
+  screen-space DOM overlay to position elements within. Not a bug to fix in `labels.jsx`
+  itself; a real XR label solution would need to render label geometry directly in the 3D
+  scene (e.g. `CSS2DObject`'s sibling `CSS3DObject` doesn't help either, same limitation —
+  actual WebGL/WebGPU-rendered text/billboards, likely via `three-stdlib`'s `Text`/SDF-font
+  helpers or a custom textured-quad approach, would be needed). Out of scope for the current
+  viewer-only `SymmetryGeometry` release; flagged for whenever XR + labels together matters.
+
+- **Outline thickness is wrong at both zoom extremes** — confirmed by the user after Phase 4
+  outline toggling was verified working. `symmetry-renderer.js`'s outline mesh
+  (`makeOutlineMesh`, `isLineSegments`-forced `InstancedMesh`) renders as native GL lines,
+  which draw at a fixed **screen-space** pixel width, constant regardless of zoom or model
+  scale. User confirmed this is exactly the symptom: outlines look hairline/messy against a
+  zoomed-in (large on-screen) face, and look like a thick dominating smear against a
+  zoomed-out (small on-screen) face — i.e. the line's on-screen size never changes while the
+  polygon's does, so the *ratio* between them swings across the usable zoom range. Not a bug
+  in the sense of wrong output, just the wrong rendering technique for this use case — a
+  world-space-scaling ("model space") line was wanted, not a screen-space one, so it grows
+  and shrinks with the geometry the same way the fill does.
+
+  Two solution directions were discussed, not yet decided or implemented:
+  1. **World-space thickened outline** (leaning direction, not yet committed to). Replace the
+     bare `LineSegments`-mode geometry with an actual thin 3D ribbon/strip geometry along
+     each edge — built alongside or instead of `buildOutlineGeometry` in `geometry.jsx` —
+     sized as a fraction of the shape's own dimensions. Renders through the normal triangle
+     `InstancedMesh` pipeline like the fill does, so it would also retire the
+     `isLineSegments`-forcing hack in `makeOutlineMesh` entirely (see bug-3 writeup below for
+     why that hack exists) since it's no longer needed. More implementation work: new
+     geometry-building logic (ribbon/tube around each edge, care needed with mitering at
+     vertices), more triangles per shape, and the ribbon width itself becomes a new tunable
+     (probably relative to the shape's bounding sphere or a global outline-width setting).
+  2. **Fat screen-space lines via `three-stdlib`'s `Line2`/`LineMaterial`** (already a project
+     dependency — used elsewhere for `GLTFExporter` in `geometry.jsx`). This is the standard
+     three.js "fat line" technique (`LineSegmentsGeometry` + a screen-space-width shader) and
+     would make the pixel width at least *controllable*, but it is still fundamentally
+     screen-space — it would not fix the underlying complaint (ratio to polygon size swinging
+     with zoom), only let you pick a better-tuned fixed pixel width. Also not obviously
+     compatible with per-instance GPU instancing as currently architected (`Line2` is built
+     around a single non-instanced `LineSegmentsGeometry`); adapting it to
+     `symmetry-renderer.js`'s per-shape `InstancedMesh` model would need investigation, not
+     assumed to be straightforward.
+
+  Direction 1 is the more likely fix if/when this gets picked up, since it addresses the
+  actual complaint rather than a narrower version of it, but no decision has been made yet —
+  ask the user before implementing either.
+
+- **59 Icosahedra (`stellation.jsx`) `ShapedGeometry` renders nothing**, found while testing
+  Phase 3 on unrelated views. `stellation.jsx` and its dependency `state.jsx` are unmodified
+  relative to `main` (`git diff main -- online/src/app/59icosahedra/` is empty), and the
+  `SymmetryGeometry` work never touches this file. Strong suspicion: fallout from the
+  pre-existing `3bdfe6c98` ("Forcing WebGL") commit, which significantly restructured
+  `LightedTrackballCanvas`/`ltcanvas.jsx` (new `solid-three` XR context API,
+  `xr.Provider`/`createXR`) — `stellation.jsx` uses `LightedTrackballCanvas` directly. **Not
+  yet root-caused.** Set aside deliberately, at the user's direction, to keep Phase 3 scoped.
+
+- **Trackball preview drag gesture not working** under `symmetryRenderer={true}` — mentioned
+  once in passing during debugging, never followed up. Unclear if still an issue after later
+  fixes (in particular the frustum-culling fix landed after this was mentioned).
+
+- **`>180` `GL_INVALID_FRAMEBUFFER_OPERATION` warnings under `ShapedGeometry`** on the
+  trackball canvas specifically (confirmed absent under `SymmetryGeometry`) — noted once,
+  never investigated. Possibly related to the same `3bdfe6c98` WebGL-forcing changes.
+
+- **`worker-client-scene-protocol.md`'s own recommendations**, not yet acted on:
+  - No consolidated "apply scene response to store" helper — four independent call sites
+    (three plus the trackball's) each hand-write the same `setScene('embedding'/'polygons'/
+    'orientations', ...)` + `updateShapes(...)` sequence. A future wire-protocol field
+    addition means finding and fixing every one by hand again, exactly as `orientations`
+    did.
+  - No dev-mode assertion/warning for a mounted `SymmetryGeometry` observing populated
+    `shapes` but empty/undefined `orientations` after a reasonable delay — this is precisely
+    the failure signature that took longest to diagnose (silent, looks like a rendering bug,
+    is actually a data bug).
+  - `rotation` is still sent redundantly alongside `orientations` on every instance, per an
+    existing worker-code `TODO` (`vzome-worker-static.js`) — correct to keep for now since
+    `ShapedGeometry` still needs it, but real payload bloat once `ShapedGeometry` retires.
+  - The `SceneTitlesProvider` frozen-signal pattern (item 4 above) may have siblings
+    elsewhere in the codebase — not grepped for yet.
+
+## Phase 4 — polygon-mode outline overlay — COMPLETE
+
+**Status: done. User tested edge cases (capacity growth, rapid toggling) and is satisfied.**
+Fill geometry renders correctly, outline toggle (Settings dialog "Outlines" switch, gated on
+the scene actually having polygon data) shows/hides correctly. Three real bugs were found
+and fixed across three rounds of real-browser testing to get here; see the detailed writeup
+below for what they were, in case similar mistakes recur elsewhere in this codebase. One
+cosmetic issue remains, deliberately deferred rather than blocking Phase 4: outline line
+thickness (see "Known-open items" above) — wrong technique (screen-space GL lines) for the
+desired effect (thickness that scales with the model), not incorrect in the sense of broken
+output. Move on to Phase 5 next.
+
+**Scope grew beyond the original plan doc.** The plan's Phase 4 section called for two fill
+styles (`"solid"`/`"polygons"`) switched via `switchStyle()`. Actual `ShapedGeometry`
+(`InstancedShape` in `geometry.jsx`) does more in polygon mode, though: it also overlays a
+black wireframe outline (`buildOutlineGeometry`, true face-edge topology) on top of the fill.
+User confirmed (via `AskUserQuestion`) they wanted pixel-fidelity with `ShapedGeometry`, not
+just fill-switching, so outline support was added too.
+
+**Key technical finding, still believed correct**: `InstancedMesh` can't draw as
+`LineSegments` through any public Three.js API — there's no constructor for an instanced
+line-list mesh. But both render backends (`WebGPUUtils.getPrimitiveTopology` and the WebGL
+fallback's equivalent dispatch in `WebGLBackend.js`) select line-list topology by checking
+`object.isLineSegments` *before* `object.isMesh`, and `InstancedMesh extends Mesh` without
+setting `isLineSegments` itself — so forcing `mesh.isLineSegments = true` on an otherwise-
+normal `InstancedMesh` is sufficient to make it draw as instanced `GL_LINES`/`LineList`.
+Verified by reading both backends' dispatch source
+(`node_modules/three/src/renderers/webgpu/utils/WebGPUUtils.js:195`,
+`node_modules/three/src/renderers/webgl-fallback/WebGLBackend.js:1137`). This part held up —
+outlines rendered with correct edge topology on first real test, no diagonal-edge artifacts.
+
+**Bug 1 (crash on load)**: `registerShape` unconditionally did
+`entry.outlineMesh.visible = ...` right after `createShapeEntry`, but `entry.outlineMesh` is
+`null` whenever a shape's outline geometry hasn't been registered yet (the original two-loop
+structure in `symmetry-geometry.jsx` called `registerShape` for a shape *before*
+`registerOutline` for that same shape). `TypeError: Cannot set properties of null`. Fixed by
+guarding with `if (entry.outlineMesh)`.
+
+**Bug 2 (much bigger — bad initial design, not just a typo)**: the original Phase 4 design
+pre-built **two fill geometries** per shape — `buildShapeGeometry(shape, false)` for a
+`"solid"` style and `buildShapeGeometry(shape, true)` for a `"polygons"` style — on the
+assumption that these were two legitimate alternate looks, matching what the plan doc implied.
+They are not. Reading `buildShapeGeometry` in `geometry.jsx` closely: the `polygons=false`
+branch (`corners.forEach(addVertex)`) pushes each face's raw corner list straight into a flat
+`TRIANGLES`-mode position buffer with **no triangulation at all**. For a triangular face this
+happens to produce the right 3 vertices. For any face with more than 3 vertices (pentagons,
+hexagons — i.e. most real vZome part shapes), it produces garbage: wrong vertex groupings,
+wrong winding, visually "scattered triangles connecting the wrong vertices" (the user's exact
+words on the second test). `ShapedGeometry` never hits this because `InstancedShape` builds
+exactly *one* geometry, always from the live `scene.polygons` value — it only ever takes the
+`false` branch when the whole scene is genuinely in non-polygon mode, and apparently no shape
+in easy manual-testing reach has non-triangular faces in that mode, or this would have been
+caught long ago. The fan triangulation (`polygons=true`) is geometrically identical to the
+non-fan path for already-triangular faces and correct for every other case, so it is always
+safe to use unconditionally — **there is no legitimate reason for `SymmetryGeometry` to ever
+build the `polygons=false` geometry.** What actually varies with `scene.polygons` is only the
+outline overlay's visibility.
+
+Fixed by removing the two-style design entirely:
+- `online/src/viewer/symmetry-geometry.jsx` now registers a single style (`STYLE_ID =
+  "default"`, same as pre-Phase-4) and builds exactly one fill geometry per shape, always
+  `buildShapeGeometry(shape, true)`. `addInstance` always uses that one style, so the
+  `ensureStyleIsActiveForInstances`-side-effect footgun that motivated an earlier draft's
+  `currentStyleId` computation no longer exists — there's nothing to fight over.
+- `online/src/viewer/context/symmetry-renderer.js`: removed the now-pointless
+  `OUTLINE_STYLE_ID` export and the outline-visibility-follows-active-style logic in
+  `swapGeometriesForStyle`/`attachOutlineMeshToEntry`/`registerShape`. Added a small
+  dedicated `setOutlinesVisible(visible)` — loops the active group's `shapeEntries` and sets
+  `outlineMesh.visible` directly, independent of style. New outline meshes default to
+  `visible = false` at creation (in `makeOutlineMesh`); the three call sites that need
+  otherwise (capacity regrowth carrying over the previous mesh's visibility) set it
+  explicitly right after.
+- The pre-existing `registerStyle`/`switchStyle`/`swapGeometriesForStyle`/multi-style
+  machinery (built in Phase 3, general-purpose) was left in place, just unused by
+  `symmetry-geometry.jsx` now — it's still there for any future case where two fill styles
+  might legitimately diverge.
+
+**Remaining outline implementation notes (still accurate, unaffected by the fixes above)**:
+- `registerOutline(groupId, slotId, outlineGeometry)` registers one outline geometry per
+  shape, independent of style. Handles both call orderings: after `registerShape` (attaches
+  to the existing entry immediately via `attachOutlineMeshToEntry`) and before any GPU state
+  exists (stashed in `group.pendingOutlineGeometries`, picked up by `ensureGroupGpu`).
+- `makeOutlineMesh(...)` builds the forced-line-mode `InstancedMesh`. Its geometry is a
+  separate `BufferGeometry` from the fill mesh's (different vertex/index topology) but its
+  instanced attributes (`orientationIndex`, `instanceTranslation`, `highlightIntensity`,
+  `pickingId`; deliberately no `colorIndex` — outline is fixed black) wrap the *same*
+  underlying typed arrays as the fill mesh, so `syncShapeInstances` never writes instance
+  data twice, only flags `needsUpdate` on both geometries' attributes.
+- `createShapeEntry`, `ensureShapeCapacity` (capacity-growth path), `addGroupMeshesToScene`,
+  `setGroupMeshesCount`, and `disposeGroupGpu` are all threaded through to keep
+  `entry.outlineMesh` in sync (added to scene, capacity-grown, count-synced, disposed)
+  alongside the existing `mesh`/`pickingMesh` handling.
+- `createMaterialForGroup` also returns `outlineMaterial` — `MeshBasicNodeMaterial`, flat
+  black `colorNode`, sharing the same `rotatedPositionNode` transform as the other two
+  materials. Note: `Material.linewidth` has no effect on regular (non-`Line2`) line
+  rendering in WebGL or WebGPU, so outlines are a fixed ~1px regardless of `ShapedGeometry`'s
+  `linewidth={4.4}` — an already-existing limitation being carried over, not a regression.
+
+**Bug 3 (outlines never appear, even when the user asks for them)**: after fixing bug 2,
+`symmetry-geometry.jsx` called `renderer.setOutlinesVisible(!!props.polygons)` — outline
+visibility driven by `scene.polygons` alone, matching `InstancedShape`'s
+`showOutlines = () => scene.polygons` in `geometry.jsx` exactly. This looked right (it
+matches `ShapedGeometry`'s current code verbatim) but is semantically wrong. Per the user:
+`scene.polygons` is **only a capability flag** — whether this scene's face data is real
+polygon geometry at all (modern files) vs. pre-triangulated with no recoverable face
+structure (older files, `.shapes.json`'s `polygons` field). It is not the user-facing
+show/hide state. Confirmed by tracing the worker: `design.rendered.polygons` (decided at
+load time by `realizeShape`/`legacy.loadDesign`) flows unmodified through
+`prepareSceneResponse`/`prepareEditSceneResponse` into the client `scene` store — a
+per-file-format property, not a live toggle. The *actual* end-user preference is
+`state.outlines` in `online/src/viewer/context/camera.jsx` (default `false`,
+`toggleOutlines()`), surfaced as the "Outlines" switch in `online/src/viewer/settings.jsx`
+— which is itself gated on `scene.polygons` for whether to even show the switch
+(`showOutlines={scene?.polygons && dynConfig().showOutlines}` in `viewer/index.jsx`). Two
+independent conditions, both required: can we (capability) AND does the user want to
+(preference, default off).
+
+Notably, `ShapedGeometry`/`InstancedShape` does **not** currently read `state.outlines` at
+all — grepped for it, the only consumers of that state are SVG export
+(`app/classic/menus/filemenu.jsx`, `app/classic/dialogs/svgpreview.jsx`), not the live 3D
+view. So the "Outlines" switch in the Settings dialog currently does nothing for on-screen
+rendering in either `ShapedGeometry` or (pre-fix) `SymmetryGeometry` — a pre-existing gap.
+Per explicit user direction, `SymmetryGeometry` was fixed to actually honor it (a real
+behavior improvement, not just parity with `ShapedGeometry`'s current incomplete wiring):
+`online/src/viewer/symmetry-geometry.jsx` now destructures `state: cameraState` from
+`useCamera()` (alongside the already-used `globalScale`) and calls
+`renderer.setOutlinesVisible(!!props.polygons && !!cameraState.outlines)`. `state` is a
+SolidJS store (`createStore` in `camera.jsx`), so property access inside `createEffect`
+tracks reactively — toggling `state.outlines` via the Settings dialog now live-updates
+outline visibility without needing to touch `symmetry-renderer.js` at all.
+
+**Worth doing later, out of scope for this pass**: consider wiring `ShapedGeometry`'s
+`InstancedShape.showOutlines` (`geometry.jsx:182`) to `state.outlines` too, so the classic
+editor's non-`SymmetryGeometry` path gets the same fix and the Settings switch isn't
+silently inert there.
+
+**Remaining open items**: Phases 5-8 (picking/interaction, highlight, labels, replacing
+`ShapedGeometry` call sites) — unchanged from before, see below.
+
+## XR fix — `SymmetryGeometry` content wasn't visible/reachable in a real headset
+
+**Status: implemented (two rounds — first attempt broke the page entirely), not yet
+re-tested on-device.** Found by the user testing on a Meta Quest 3 (entering XR via the
+existing "Enter XR" button showed no model at all — a console warning about
+`menu_pressed_min` was a red herring, an unrelated controller-model-loader complaint).
+Root-caused by code reading, not yet confirmed fixed on the headset.
+
+**Root cause**: `createSymmetryRenderer`'s `originGroup` (in `symmetry-renderer.js`) attached
+directly to the raw Three.js `scene` (`scene.add(originGroup)`), bypassing
+`WebXRSupport`'s own `originGroup` (`online/src/viewer/context/webxr.jsx`, a `<T.Group
+scale={globalScale}>`) entirely — this was the Phase 3 fix for bug #6 above (`globalScale`
+needing to be manually baked into `SymmetryGeometry`'s matrix to compensate for not being
+nested inside that wrapper). What Phase 3 didn't account for: `WebXRSupport`'s `originGroup`
+is not just a scale wrapper — it's also the group that `online/src/xr/grip2move.jsx`
+(`XRGripToMove`) and `online/src/xr/scaling.jsx` (`XRScaling`) actively reposition and
+rescale during an XR session: `XRGripToMove.onViewerStart` places it ~0.7m in front of the
+headset at session start and lets the user grab-and-drag it via controller grip; `XRScaling`
+lets a two-handed squeeze resize it. Neither of those ever touches `SymmetryGeometry`'s
+separate `originGroup`, since they only know about `WebXRSupport`'s. So on entering XR, the
+model was very likely still rendering — just left at whatever position the desktop trackball
+camera's embedding transform put it, with no relationship to the headset's own tracking
+origin, almost certainly outside the visible frustum. `ShapedGeometry` never had this problem
+because it's JSX-nested directly inside `WebXRSupport`'s `<T.Group ref={originGroup}>`, so it
+moves for free whenever that group's transform changes.
+
+Confirmed `WebXRContext`/`setRootScene`/`useWebXRClient` (the mechanism that might have
+already solved this) has zero call sites anywhere in the codebase — dead code, comment says
+"only used by the glTF and VRML viewers," which don't appear to exist in this tree currently.
+
+**Fix**: parent `SymmetryGeometry`'s `originGroup` under `WebXRSupport`'s `originGroup`
+instead of the raw scene, so the exact same repositioning/rescaling `ShapedGeometry` gets for
+free now also applies here.
+- `online/src/viewer/context/symmetry-renderer.js`: `createSymmetryRenderer`'s parameter
+  renamed `scene` → `parent` (only ever used for one `.add()` call — any `Object3D` works,
+  not specifically a `Scene`).
+- `online/src/viewer/symmetry-geometry.jsx`: the matrix-building effect for
+  `renderer.originGroup.matrix` **no longer premultiplies by `globalScale`** — the parent
+  group (`WebXRSupport`'s) already supplies that via its own ordinary (auto-updating)
+  `.matrix`, computed fresh each frame from its `.position`/`.quaternion`/`.scale`, which is
+  exactly what `XRGripToMove`/`XRScaling` write to. `SymmetryGeometry`'s own `originGroup`
+  now only needs to encode the embedding transform.
+
+**First attempt at getting the parent group reference broke the page entirely** — worth
+recording since it's a second instance of the same "solid-three ref timing" class of
+mistake, distinct from bug #6's transform-composition mistake but easy to conflate with it.
+First attempt: exposed `getOriginGroup: () => originGroup` from `WebXRContext` (a closure
+over a plain `let originGroup` in `webxr.jsx`, assigned via `ref={originGroup}` on
+`WebXRSupport`'s `<T.Group>`) and called it **eagerly, synchronously**, at
+`SymmetryGeometry`'s own component-setup time: `createSymmetryRenderer(getOriginGroup())`.
+This crashed on load: `TypeError: Cannot read properties of null (reading 'add')` — deep
+inside `createSymmetryRenderer`'s `parent.add(originGroup)`. Root cause: solid-three's
+`T.Group` instance is constructed lazily behind an internal `createMemo`
+(`createEntity`/`useProps` in `solid-three`'s source), only forced once something reads it —
+which happens inside a `createRenderEffect`, not synchronously during the parent component's
+own body execution. So `ref={originGroup}` (a plain-variable ref) is **not** guaranteed
+assigned by the time a descendant component's top-level setup code runs, even though that
+descendant is JSX-nested inside the group and the group is its direct ancestor in the tree.
+This is exactly why `getRootGroup={() => originGroup}` already worked correctly for
+`StartXRButton` elsewhere in the same file — that closure is only ever *called* later, inside
+`onViewerStart`/frame callbacks, well after mount, never at setup time.
+
+**Fix for the fix**: `webxr.jsx` now also exposes a reactive `originGroupReady` **signal**
+(`createSignal(null)`), set via a `captureOriginGroup(g)` callback-form ref (`ref=
+{captureOriginGroup}`) that both assigns the existing plain `originGroup` variable (unchanged
+uses: `setRootScene`, `getRootGroup` for `StartXRButton`) and calls `setOriginGroupReady(g)`.
+`symmetry-geometry.jsx` was restructured into two components: the exported `SymmetryGeometry`
+now does nothing but `<Show when={originGroupReady()}>{parent => <SymmetryGeometryImpl
+{...props} parent={parent()} />}</Show>` — deferring everything else (creating the renderer,
+registering all effects) until the group signal actually resolves non-null. All the actual
+logic moved unchanged into a new internal `SymmetryGeometryImpl`, taking `props.parent`
+instead of calling `getOriginGroup()` itself.
+
+**Why this should be safe for the desktop (non-XR) path**: `WebXRSupport`'s `originGroup` has
+`position`/`quaternion` at identity and `scale = globalScale` outside of an XR session
+(`XRGripToMove`/`XRScaling`'s `onViewerEnd` handlers explicitly reset position and quaternion
+back; scale during a session is relative to a `sessionStartScale` snapshot, also restored).
+So the net transform `SymmetryGeometry`'s content sees outside XR should be identical to
+before this fix — `globalScale` still gets applied, just one level up in the hierarchy
+instead of baked into the leaf's own matrix. This has not yet been re-verified on the desktop
+canvases (trackball preview, classic editor, standalone viewer) after this change — do that
+before assuming no regression, the same way Phase 3's bug #6 fix needed careful before/after
+checking of exactly this kind of transform composition.
+
+**Not yet done**: actual on-device re-test on the Quest 3 to confirm the model now appears
+and is grip-movable/scalable. The user reported the original symptom but hasn't yet tried
+this fix.
+
+## Design decision: keep `solid-three`, but stay wary of its declarative/imperative seam
+
+After the two ref-timing crashes above (the `null.add()` crash and its fix), the user asked
+a good architectural question worth recording so it doesn't get re-litigated from scratch:
+is `solid-three` — specifically its declarative JSX scene graph (`<T.Group>`/`<T.Mesh>`/etc.,
+via `createT`) — actually worth its cost here, given how much trouble the imperative/
+declarative boundary has caused (this session alone: bug #6's transform-composition mistake,
+plus both `originGroup` ref-timing crashes)?
+
+**Considered and rejected: move rendering into the worker with `OffscreenCanvas`.** Would not
+actually remove the imperative/declarative tension (the imperative GPU-instancing core in
+`symmetry-renderer.js` is load-bearing for performance, not accidental complexity — it would
+still be imperative in a worker) and would forfeit XR entirely: `navigator.xr` / WebXR
+sessions require a window/main-thread context, there is no API for driving an XR session
+from inside a Worker. Since XR support is an active, tested requirement, this would mean
+maintaining a second full renderer for non-XR views only — more total complexity, not less.
+Not pursued.
+
+**Audited what `solid-three` is actually earning across the codebase** (grepped every file
+importing it, ~22 total): the framework genuinely earns its keep for `<Canvas>` itself
+(WebGPU/WebGL context creation, resize, the render loop), `useThree()`/`useFrame()`, and
+`xr.Provider`/`createXR()` (WebXR session lifecycle) — all expensive to hand-roll, all kept.
+It also genuinely earns its keep in `geometry.jsx`'s `Instance` component (`ShapedGeometry`'s
+per-mesh pointer event handlers — `onClick`/`onPointerEnter`/etc. — real raycasting +
+event-dispatch, would need hand-rolling otherwise; notably this is exactly what Phase 5's
+`pickAt`-based picking will hand-roll for `SymmetryGeometry`, since GPU-instanced meshes have
+no per-instance object for solid-three to raycast against).
+
+Everywhere else the declarative `<T.*>` layer is used (`webxr.jsx`'s `originGroup`,
+`perspectivecamera.jsx`, `orthographiccamera.jsx`), the actual pattern is: one or two
+reactive prop bindings (`scale=`, `position=`) on an object whose real behavior is driven
+entirely by hand-written imperative `createEffect`s reaching into a `ref` — not composed
+JSX children, not automatic resource lifecycle (every file that disposes anything, e.g.
+`geometry.jsx`'s `onCleanup(() => geometry.dispose())`, does so manually, not via
+solid-three). `webxr.jsx`'s `originGroup` is the sharpest example: the *only* thing `<T.Group
+scale={globalScale}>` contributes there is one reactive scale binding — in exchange, its
+lazy-construction-behind-a-memo timing model directly caused both crashes above, plus the
+`WebXRContext.Provider` that exists purely to smuggle the imperatively-needed group reference
+back out to code (`SymmetryGeometry`) that isn't part of that JSX tree.
+
+**Conclusion, not yet acted on beyond the `originGroupReady` signal fix already in place**:
+`solid-three`'s declarative scene graph is not, on the evidence in this codebase, earning
+enough to justify fighting its construction-timing model at every seam where imperative code
+needs to reach into a JSX-declared object. But `<T.Group originGroup>` specifically can't be
+fully eliminated either — solid-three has no working "wrap an externally-constructed
+instance and still let JSX children nest under it" escape hatch (`object` prop is declared
+in the type definitions but not actually implemented/read in the installed version — checked
+directly in `node_modules/solid-three/dist/index.js`), and `originGroup` genuinely needs
+both: real JSX children (camera, `TrackballControls`, `Labels`, `ShapedGeometry` all nest
+inside it) AND imperative reachability (`XRGripToMove`/`XRScaling`, `SymmetryGeometry`). So
+the `originGroupReady` signal + `Show`-gated `SymmetryGeometryImpl` split (implemented above)
+is the correct, minimal shape of the fix given that constraint — not a workaround to later
+replace, the actual right answer once the constraint is understood. If a similar seam comes
+up again (Phase 5's picking will add more imperative code reaching into solid-three-managed
+objects — the picking scene/camera sync in `pickAt`, for instance), expect the same tension
+and reach for the same pattern (a ready-signal gate) rather than assuming synchronous ref
+availability.
+
+## Shading fix — `MeshPhongNodeMaterial` → `MeshLambertNodeMaterial`
+
+**Status: done, user-confirmed ("Looks great").** User reported the Phong specular highlight
+(shininess 55, a fairly bright bluish specular color) was too strong — distracting up close,
+overwhelming from a distance. Checked what `ShapedGeometry` actually uses
+(`geometry.jsx`'s `InstancedShape`): plain `MeshLambertMaterial`, no specular term at all.
+The Phong material was a carry-over from the `webxr-poc` port this file started from, never
+actually meant to match the app's look. Fixed in `online/src/viewer/context/symmetry-renderer.js`'s
+`createMaterialForGroup`: swapped to `MeshLambertNodeMaterial` (import changed too), dropped
+`shininess`/`specular` entirely (Lambert has no specular term), kept `flatShading: true` and
+the same `positionNode`/`colorNode`/`emissiveNode` TSL hooks — all still supported. Simple,
+low-risk, exact-parity fix.
+
+## Phase 6 — selection highlight — COMPLETE
+
+**Status: implemented, not yet manually verified on-screen** (syntax-checked only as of this
+writing). Done ahead of Phase 5 at the user's explicit direction: Phase 5 (GPU picking) is
+only needed for *editing* use cases (the classic editor, `59icosahedra`), which are staying
+on `ShapedGeometry` for now; Phase 6 (highlight) and would-be Phase 7 (labels, **not** done —
+see below) are needed to release `SymmetryGeometry` for *viewer-only* (non-editing) use
+cases, which don't need picking at all. No architectural reason 6 had to follow 5 — checked
+`setInstanceHighlight(shapeId, instanceId, intensity)` in `symmetry-renderer.js` and
+confirmed it takes the renderer's own ids directly, nothing picking-specific.
+
+**What changed** (`online/src/viewer/symmetry-geometry.jsx`):
+- New `SELECTED_HIGHLIGHT = 0xc8/0xff` constant (≈0.784) — matches `ShapedGeometry`'s
+  `InstancedShape` exactly, which shows selection as a binary emissive swap between
+  `"#c8c8c8"` and `"black"` (not the plan doc's placeholder suggestion of `0.5` — that was
+  never based on the actual color, just a rough guess). `symmetry-renderer.js`'s
+  `highlightIntensity` attribute feeds `emissiveNode = white * highlightIntensity`, so this
+  value reproduces the same visual result.
+- New `instanceRefById` (vZome instance `id` → `{shapeId, instanceId}`) and
+  `lastSelectedById` (vZome instance `id` → last-seen `boolean`) maps, both rebuilt from
+  scratch every time the existing instance-registration effect runs (not updated
+  incrementally — see the "known limitation" below for why).
+- New dedicated `createEffect` that diffs `instance.selected` against `lastSelectedById` and
+  calls `renderer.setInstanceHighlight(shapeId, instanceId, ...)` **only** for instances
+  whose selection actually changed — this is the O(changed instances) behavior discussed and
+  chosen over just folding `highlight: instance.selected ? ... : 0` into the existing
+  `addInstance` call (which would be correct but silently ride along on that effect's
+  existing full-rebuild-every-time behavior, discussed next).
+- The instance-registration effect's `addInstance` call also now sets the *initial*
+  `highlight` value directly, so a freshly-registered selected instance never flashes
+  unhighlighted for a frame before the diff effect catches up.
+
+**Known limitation, deliberately not fixed in this pass**: `online/src/viewer/context/scene.jsx`'s
+`SELECTION_TOGGLED` handler replaces `scene.shapes` with an entirely new object/array tree on
+every single toggle (`setScene({...scene, shapes})` with new identities all the way down —
+not a fine-grained per-instance SolidJS store mutation). Since `symmetry-geometry.jsx`'s
+instance-registration effect depends on `props.shapes` as a whole, **every selection click
+still triggers that effect's full `removeAllInstances` + re-add loop across every shape** —
+this was true before Phase 6 and is not something Phase 6 introduced or attempts to fix. The
+new targeted highlight effect avoids *adding* a second full rebuild on top of that, and is
+correct/complete on its own terms, but doesn't make selection toggling cheap in the way
+`ShapedGeometry` gets for free (its `<Instance>` components are individually fine-grained
+SolidJS components, so only the one instance whose `selected` prop changed re-renders).
+Fixing this properly would mean giving `scene.jsx`'s store finer granularity (e.g. a nested
+per-instance signal instead of replacing the whole `shapes` tree) — flagged as a real
+follow-up item, out of scope here since it touches shared worker-client state, not just
+`SymmetryGeometry`. Worth measuring whether this is an actual problem on realistically large
+models before spending time on it.
+
+**Phase 7 (labels) was done in a follow-up pass — see its own section below.**
+
+## Phase 7 — labels — COMPLETE AND VERIFIED
+
+**Status: user-confirmed working on-screen, appear and disappear both verified correct.**
+Done directly after Phase 6, completing the feature set needed to release `SymmetryGeometry`
+for viewer-only (non-editing) use cases — Phase 5 (picking) remains the only
+deliberately-deferred phase, needed only for editing use cases. Verification took much
+longer than expected because it uncovered two independent, real, pre-existing bugs in
+shared label infrastructure (`labels.jsx`) that had nothing to do with `SymmetryGeometry`
+itself — see the two "shared bug" subsections below. Both are fixed and confirmed: a label
+now appears correctly when its scene is shown, and disappears correctly (rather than
+freezing in place) when switching away from that scene.
+
+**Key finding while scoping this**: `online/src/viewer/labels.jsx`'s `Label` component is
+*not* a `<T.*>` solid-three element — no JSX-child-nesting requirement, unlike `webxr.jsx`'s
+`originGroup` (see the "Design decision" section above). It's a plain component that
+imperatively does `props.parent.add(label)` inside `onMount`, so it can be used directly by
+`SymmetryGeometry`'s already-imperative code without fighting the declarative/imperative
+seam that caused trouble elsewhere in this migration. In the end, `symmetry-geometry.jsx`
+doesn't actually render `<Label>` (the JSX component) at all — it builds `CSS2DObject`s
+directly, for the same reason the instance-registration effect already does everything else
+imperatively: labels need to be rebuilt in the same full-teardown-and-rebuild cycle as
+instances (see Phase 6's `instanceRefById` comment for why), and there's no meaningful
+benefit to wrapping that in a `<For>`/JSX layer just to immediately imperatively mutate the
+result.
+
+**The actual problem to solve**: `ShapedGeometry` gets a label's position for free via real
+Three.js parenting — `<Label parent={meshRef} position={shapeCentroid}>` in `geometry.jsx`,
+where `shapeCentroid` is a *local*-space offset within that one instance's own mesh, and the
+label inherits the mesh's rotation/translation automatically by being its scene-graph child.
+`SymmetryGeometry` has no per-instance mesh (everything is GPU-instanced into a handful of
+shared `InstancedMesh`es), so there's no scene-graph node to hang a label off and get its
+position "for free." Fixed by computing each label's position explicitly in JS, replicating
+what the GPU vertex shader already does per-vertex (`rotatedPositionNode` in
+`symmetry-renderer.js`'s `createMaterialForGroup`: `orientation * localVertex +
+instanceTranslation`) — just once per label, using the shape's centroid as `localVertex`,
+on the CPU instead of per-vertex on the GPU. All labels are parented directly to
+`renderer.originGroup`, which is exactly the space instance positions are already expressed
+in, so no further transform juggling is needed.
+
+**What changed** (`online/src/viewer/symmetry-geometry.jsx`):
+- New import: `CSS2DObject` from `three-stdlib` (same class `labels.jsx`'s `Label` uses).
+- `orientationMatrices` (the `Matrix4[]` built from `props.orientations`) is now retained
+  across the group-registration effect instead of being a throwaway local — needed for the
+  CPU-side position math above. Minor simplification as a side effect: it's computed once
+  and reused for `registerSymmetryGroup`, rather than being recomputed a second time.
+- New `shapeCentroidById` map (`shapeId` → `{x,y,z}`), populated at shape-registration time
+  from `geometry.shapeCentroid` (set by `buildShapeGeometry` in `geometry.jsx`, already
+  existed, just never previously retained by `symmetry-geometry.jsx`).
+- New `labelById` map (vZome instance `id` → `CSS2DObject`), rebuilt in the same pass as
+  `instanceRefById`/`lastSelectedById` inside the instance-registration effect: for each
+  instance with a truthy `label` field, reuse the existing `CSS2DObject` if one already
+  exists for that instance id (avoids DOM element churn on every rebuild), otherwise create
+  one (`className='vzome-label'`, `id='vzome-label-${label}'`, matching `Label`'s own DOM
+  conventions exactly for CSS/testing compatibility), update its `.position`, and add it to
+  `renderer.originGroup` if new. Whatever's left in the *previous* `labelById` after the pass
+  (instances that were removed, or lost their label) gets `renderer.originGroup.remove(...)`
+  — `CSS2DObject`'s own `"removed"` event listener (see `three-stdlib`'s
+  `CSS2DRenderer.js`) handles detaching the DOM element, no manual DOM cleanup needed.
+
+**Update: the "`Label` has no `onCleanup`" gap noted above turned out to be a real,
+user-visible bug, not just a theoretical leak — see "Second shared bug" below.** It's now
+fixed. The remaining item — `SymmetryGeometryImpl` overall has no `onCleanup` disposing
+`renderer`'s GPU resources or `originGroup`'s children on unmount (e.g. switching
+`symmetryRenderer` off, navigating away) — is still unfixed, out of scope, pre-existing from
+before Phase 6/7. Worth fixing eventually if `SymmetryGeometry` instances are ever
+mounted/unmounted repeatedly in the same session (e.g. switching between scenes with
+different `<SceneCanvas>` instances) rather than once per page load.
+
+### Second shared bug found during verification — `Label` never removed its `CSS2DObject`
+
+**Status: fixed, user-confirmed reproduced then fixed.** Found immediately after fixing the
+stale-camera bug above, while re-verifying: switching from the default scene (which has the
+one labeled instance) to a different named scene made the label **freeze in place** instead
+of disappearing — still visible, just no longer tracking the camera. This is a second,
+independent bug in the same shared `labels.jsx` file, affecting `ShapedGeometry` (this is
+its own component, `Label`, used directly) — and would have affected `SymmetryGeometry`'s
+own scene-switch behavior too, had its Phase 7 code not already handled removal explicitly
+(see `labelById`'s stale-entry cleanup above, added independently, before this bug was known).
+
+**Root cause**: `Label`'s `CSS2DObject` is added to its parent mesh imperatively
+(`props.parent.add(label)` inside `onMount`) — this happens entirely outside solid-three's
+own scene-graph reconciliation (`useSceneGraph` in `solid-three`'s source), which only
+tracks and auto-removes objects that appear as *declared JSX children* of a `<T.*>`
+element. Confirmed by tracing `<Instance>`'s unmount sequence directly: `<Instance>` (and
+its `<T.Mesh>`) *does* correctly unmount and get detached from its own parent group when a
+scene switch removes that instance — but the `CSS2DObject` label, still a child of that now
+newly-orphaned mesh, was never told to leave. It keeps existing, with a `matrixWorld` that's
+simply never recomputed or traversed again, because `CSS2DRenderer.render()`'s traversal
+starts from the *live* scene and can no longer reach an orphaned subtree — so it never
+touches (or hides) that DOM element's `transform`/`display` again. Net visible effect: the
+label freezes at its last on-screen position instead of disappearing.
+
+**Fix**: `Label` now has `onCleanup(() => label?.parent?.remove(label))`. Removing the
+`CSS2DObject` from its parent also fires its own `"removed"` event listener (see
+`three-stdlib`'s `CSS2DRenderer.js`, read directly during the first bug's investigation),
+which automatically detaches the DOM element too — no manual DOM cleanup needed, matching
+the pattern `SymmetryGeometry`'s own Phase 7 label code already used for exactly this reason.
+
+**Duplicate-label-text caveat, matched intentionally rather than fixed**: both `Label` and
+this new code use `label` text as part of the DOM element's `id` attribute
+(`vzome-label-${label}`) — if two instances share the same label text, they'd collide on DOM
+id. This is pre-existing behavior in `ShapedGeometry`'s `Label` usage, not something Phase 7
+introduces; matched for consistency rather than silently diverging, but worth knowing if it
+ever surfaces as a real bug report.
+
+### Shared bug found during verification — `Labels` used a stale, one-time-destructured camera
+
+**Status: fixed, user-confirmed working.** Fixed in `online/src/viewer/labels.jsx`, affects
+**both** `ShapedGeometry` and `SymmetryGeometry` equally — this was in shared rendering
+infrastructure, not either renderer's own code, so it's recorded here in detail since it cost
+by far the most time in this pass and the failure mode is worth recognizing quickly if it
+(or something shaped like it) recurs.
+
+**Symptom, exactly as first reported**: a labeled instance's DOM element (`.vzome-label`)
+existed in the `.labels` container div, with a plausible-looking `transform` positioning it,
+but nothing was visible on screen. No console error anywhere. This is what made it hard to
+find — every individual piece looked correct in isolation:
+- `Label`'s `onMount` fired, `props.parent` (`meshRef`) was already a real, valid `Mesh`
+  (not the ref-timing-null bug from `webxr.jsx`'s history — that specific failure mode was
+  the leading hypothesis at first, and was directly ruled out by observing no thrown error).
+- The `CSS2DObject` was correctly `.add()`'d to the mesh, and the mesh's own ancestor chain,
+  walked by hand, terminated at a real `Scene` with a matching `uuid` to the one `Labels`
+  itself held.
+- `scene.traverse()` from `Labels`' own `useFrame` found the `CSS2DObject` — proving it was
+  a genuine, connected descendant of the live scene graph, not orphaned.
+- `CSS2DRenderer`'s own per-object visibility check (`object.visible`, `layers.test`) passed.
+
+**The actual, easy-to-miss cause**: `CSS2DRenderer.render()`'s remaining check —
+`_vector.z >= -1 && _vector.z <= 1` after projecting the object's world position through
+`camera.projectionMatrix * camera.matrixWorldInverse` — was failing. Projecting the label's
+*parent mesh's* world position through the same matrices produced `NaN`/`-Infinity`, and
+`camera.position` read out as `[0, 0, 0]` — which looked like "the camera is at the origin,
+coincident with the geometry," a real and plausible-sounding bug on its own. **This was a
+red herring**, caught only because the 3D scene visibly rendered correctly (a camera
+genuinely at the origin, inside/on top of the geometry, would look obviously wrong — extreme
+distortion or clipping — and it didn't). The user caught this distinction and pushed back
+correctly rather than accepting the origin-camera explanation.
+
+**Root cause**: `online/src/viewer/context/camera.jsx`'s `ControlledPerspectiveCamera`
+builds its own `PerspectiveCamera` instance and registers it as the active render camera via
+solid-three's `setCamera(cam)` (which pushes onto an internal `cameraStack`) — but only
+*after* that component itself mounts. `Labels` (`labels.jsx`) did `const { scene, camera,
+canvas } = useThree();` at its own setup time — a **destructure**, which evaluates
+`useThree().camera` exactly once, capturing whatever it returns *at that instant*. But
+`.camera` is a **live getter** on the object `useThree()` returns
+(`get camera() { return cameraStack.peek() ?? camera(); }` — confirmed by reading
+`node_modules/solid-three/dist/index.js` directly). If `Labels` mounts and destructures
+before `ControlledPerspectiveCamera`'s `setCamera(cam)` call has run, the destructured
+`camera` binding is permanently pinned to solid-three's internal fallback default camera
+(sitting at the origin) for the rest of `Labels`' lifetime — while the actual WebGL render
+path, which re-reads the same getter fresh via solid-three's own internals every frame, sees
+the correctly-registered, correctly-positioned camera. Net effect: the 3D scene renders
+perfectly (real camera), but `CSS2DRenderer.render(scene, camera)` inside `Labels`' own
+`useFrame` used the stale one — degenerate projection math against a camera at/near the
+scene's own geometry, every label failing the clip-space z-range check, `display: none`,
+silently, forever, no error.
+
+This is precisely the same *class* of mistake already called out in this document's
+"Debugging technique notes" section below (`useThree().camera` being a getter, destructuring
+== staleness) — but that note was about reading a stale camera *within a single frame's
+logic*; this instance is subtler, because the staleness is locked in permanently at
+component-setup time, not just momentarily within one callback.
+
+**Fix**: keep the full `useThree()` result (`const three = useThree()`) instead of
+destructuring `camera` out of it, and read `three.camera` fresh inside the `useFrame`
+callback each frame (`labelRenderer.render(scene, three.camera)`). `scene`/`canvas` were left
+destructured — `canvas` is a plain property (not a getter, confirmed in source, genuinely
+constant for the component's lifetime), and `scene` was never observed to actually go stale
+in practice here, though the same risk technically exists for it if it's ever swapped later
+in some other code path.
+
+**How this was actually found**: not by more static code reading, but by adding temporary,
+targeted `console.log`s at each hypothesis in sequence (parent validity → scene-graph
+connectivity → traversal reachability → per-object visibility flags → the projected z/x/y
+values and camera position themselves) and letting the *data* rule hypotheses out one at a
+time, rather than continuing to reason abstractly about solid-three's internals. The
+projected-position numbers were what finally made the real cause legible — everything before
+that was consistent with several different explanations.
+
+## Debugging technique notes for whoever continues this
+
+The Phase 3 debugging session (item 6 above especially) went through a long sequence of
+GPU-level diagnostics — shader source dumps via a patched `gl.linkProgram`, draw-call
+interception, frustum-containment tests, `useFrame`-based live camera sampling — before
+finding that the actual defect was a missing scale factor, not anything GPU/shader-related.
+In hindsight, the fastest diagnostic that actually worked was: temporarily strip the
+material down to something with zero dependencies (no `positionNode`, or a `MeshBasicMaterial`
+with no custom nodes at all) and confirm *something* renders, establishing that the camera/
+geometry/draw-call pipeline is sound — then reintroduce one piece of the custom shader logic
+at a time. Camera-position/orientation diagnostics captured via `useThree()` destructured
+once at component setup are unreliable — `useThree().camera` is a getter, and code that reads
+it *after* destructuring gets a stale/wrong value if the underlying camera object is replaced
+later (as happens during normal camera-provider setup). Re-fetch it fresh (`three.camera`,
+not a destructured `camera`) or sample from inside `useFrame`, which always sees the live
+value.

--- a/online/developer-docs/worker-client-scene-protocol.md
+++ b/online/developer-docs/worker-client-scene-protocol.md
@@ -1,0 +1,276 @@
+# Worker ↔ Client Scene Rendering Protocol
+
+This document describes how scene data (shapes, instances, orientations, embedding) flows
+from the web worker (which owns the loaded design) to the client (which renders it via
+Three.js), as of the `webgpu-try` branch's work adopting `SymmetryGeometry` alongside the
+existing `ShapedGeometry`. It also records known redundancies and flaws surfaced while
+debugging that renderer's rollout — several of which cost significant time to track down
+because they fail *silently* (no console error, no thrown exception, just wrong or missing
+rendering).
+
+## Two transport mechanisms
+
+`online/src/viewer/context/worker.jsx` exposes two ways for the client to receive data from
+the worker:
+
+- **Broadcast** (`subscribeFor(type, callback)`): the worker calls `report({ type, payload })`
+  (via `postMessage`) whenever it wants; every subscribed client callback for that `type`
+  fires. No correlation to a specific client action — purely event-driven.
+- **Request/response** (`postRequest(action)` / `workerAction(...)`): the client sends a
+  message tagged with a `requestId`; `onWorkerMessage` special-cases messages carrying a
+  `requestId` and resolves a pending Promise instead of broadcasting to subscribers
+  (`worker.jsx:77-85`). `SNAPSHOT_SELECTED` (used for scene switching) goes through this path.
+
+These two mechanisms carry structurally identical payloads (`{ scene: {...} }` in most
+cases) but are consumed by *completely different client-side code paths* — this is the root
+of most of the redundancy described below.
+
+## The core payload-building functions
+
+Both live in `online/src/worker/vzome-worker-static.js` and are the single source of truth
+for what a "scene response" contains:
+
+```js
+const prepareSceneResponse = ( design, snapshot ) =>
+{
+  const { embedding, polygons, snapshots, orientations, instances } = design.rendered;
+  const snapshotInstances = ( snapshot === DEFAULT_SNAPSHOT )? instances : snapshots[ snapshot ];
+  const shapes = {};
+  for ( const instance of snapshotInstances ) {
+    const rotation = [ ...( orientations[ instance.orientation ] || IDENTITY_MATRIX ) ];
+    if ( ! shapes[ instance.shapeId ] ) {
+      shapes[ instance.shapeId ] = { ...design.rendered.shapes[ instance.shapeId ], instances: [] };
+    }
+    shapes[ instance.shapeId ].instances.push( { ...instance, rotation } );
+  }
+  const parts = createPartsList( shapes, design.wrapper?.controller?.symmController );
+  return { shapes, embedding, polygons, parts, orientations };
+}
+```
+
+```js
+const prepareEditSceneResponse = ( design, edit, before ) =>
+{
+  // ... resolves sceneInstances from design.wrapper.getScene(edit, before) ...
+  const { polygons, orientations } = design.rendered;
+  const shapes = {};
+  for ( const instance of Object.values( sceneInstances ) ) {
+    const rotation = [ ...( orientations[ instance.orientation ] || IDENTITY_MATRIX ) ];
+    // ... builds shapes[shapeId].instances with { ...instance, rotation } ...
+  }
+  return { scene: { shapes, polygons, orientations }, edit };
+}
+```
+
+Note both functions do the **same redundant computation**: for every instance, they look up
+`orientations[instance.orientation]` and bake the result into a per-instance `rotation`
+matrix — *and* they also return the raw `orientations` array itself, unmodified, alongside
+the shapes. This is intentional, transitional redundancy (see "Redundancy" below), not an
+oversight — `ShapedGeometry` needs `rotation`; `SymmetryGeometry` needs `orientations` +
+`instance.orientation`. Both are sent on every response so either renderer can consume the
+same wire payload.
+
+## Four independent scene-loading paths, worker side
+
+There is no single "load a scene" function. Four separate code paths in the worker build and
+send scene data, and they don't share client-side handling:
+
+1. **`openDesign` → legacy Java `loadDesign`/`newDesign`** — used by the classic editor when
+   opening a design from XML. The legacy Java bridge (via the `clientEvents(report)` object
+   passed into it) is the *only* thing that calls `symmetryChanged()`
+   (`vzome-worker-static.js:114`), which fires `SYMMETRY_CHANGED`. This happens once, at
+   design-load time, from Java code not visible in the JS source — the call site is opaque
+   to static analysis of the JS files.
+
+2. **`urlLoader`'s `preview: true` branch** — used by the standalone viewer / web-component
+   embed (`UrlViewer`, since `index.jsx:184` passes `preview: true` by default). This fetches
+   a pre-baked `.shapes.json` file and calls `events.sceneChanged(prepareSceneResponse(...))`
+   directly — it **never calls `symmetryChanged()`**, so `SYMMETRY_CHANGED` never fires on
+   this path, even though `prepareSceneResponse`'s returned `orientations` field is fully
+   populated. This asymmetry — one loading path fires `SYMMETRY_CHANGED`, the other doesn't,
+   while both send `orientations` in-band on `SCENE_RENDERED` regardless — was the single
+   biggest source of "why is this blank" bugs while integrating `SymmetryGeometry` (see
+   Debugging Pain Points below).
+
+3. **`SNAPSHOT_SELECTED`** (request/response) — used by both apps for scene switching
+   (previous/next scene, or programmatic scene selection):
+   ```js
+   case 'SNAPSHOT_SELECTED': {
+     if ( !design?.rendered?.snapshots ) break;
+     const { snapshot } = payload;
+     const scene = prepareSceneResponse( design, snapshot );
+     sendToClient( { type: 'SCENE_RENDERED', payload: { scene } } );
+     break;
+   }
+   ```
+   This reuses `prepareSceneResponse`, so `orientations` is present — but this response is
+   consumed via the request/response mechanism (resolving a `postRequest` Promise), not via
+   `subscribeFor('SCENE_RENDERED', ...)`. A client component that only subscribes to the
+   broadcast `SCENE_RENDERED` event will never see this data; it has to be the caller of
+   `postRequest` itself.
+
+4. **`TRACKBALL_SCENE_LOADED`** — a *fully separate* mechanism used only by the classic
+   editor's small trackball orientation preview widget (`camera.jsx`'s `CameraControlsUI`).
+   `connectTrackballScene`/`fetchTrackballScene` (`vzome-worker-static.js:134-162`) load an
+   **independent design object** (`trackballDesign`, distinct from the main `design`) via a
+   fresh `legacy.loadDesign(xml, false, polygons, clientEvents(()=>{}))` call whose `report`
+   callback is a no-op — so any `SYMMETRY_CHANGED`/`SHAPE_DEFINED`/etc. events the Java loader
+   fires internally for *this* design are silently swallowed. The trackball design's
+   `prepareSceneResponse(...)` result is sent as one single `TRACKBALL_SCENE_LOADED` message,
+   picked up by `subscribeFor('TRACKBALL_SCENE_LOADED', ...)` in `camera.jsx`, into its own
+   `passive={true}` `SceneProvider` (an isolated scene store, not the app's main one).
+
+## Client-side consumers — three independent places set `scene.orientations`
+
+Because of the four worker-side paths above, and because two different apps use different
+subsets of them, there end up being **three separate client-side call sites** that
+independently read `orientations` off a response and call `setScene('orientations', ...)`.
+All three were found and fixed over the course of adding `SymmetryGeometry` — each was an
+instance of the same class of bug (a call site added before `SymmetryGeometry` existed, when
+nothing needed `orientations` client-side, so nobody had reason to plumb it through):
+
+| # | File:line | Component | Fires from | Notes |
+|---|-----------|-----------|-------------|-------|
+| 1 | `scene.jsx:182-184` | `SceneChangeListener` | `SYMMETRY_CHANGED` broadcast | The "intended" source — fires once at design load, only on the legacy Java path |
+| 2 | `scene.jsx:198-199` | `SceneChangeListener` | `SCENE_RENDERED` broadcast | Guarded (`if (scene.orientations)`) so it doesn't clobber #1 with `undefined` on paths where `SYMMETRY_CHANGED` already set it correctly |
+| 3 | `scene.jsx:83-84` | `SceneIndexingProvider.showIndexedScene` | `SNAPSHOT_SELECTED` response | Needed because this whole component is never reached by `SceneChangeListener` at all (see below) |
+| 4 | `camera.jsx:46` | `CameraControlsUI`'s `TRACKBALL_SCENE_LOADED` handler | `TRACKBALL_SCENE_LOADED` broadcast, isolated `passive` scene store | A fourth, fully separate scene store from the other three |
+
+(`camera.jsx`'s trackball handler and `SceneIndexingProvider`'s handler are *not* mutually
+redundant with each other or with `SceneChangeListener` — they operate on different `scene`
+stores entirely, per the app-mounting differences below. They're each other's closest analog,
+not duplicates of the same store.)
+
+**This is a real structural flaw, not just incidental duplication**: there is no single
+function like `applySceneResponse(setScene, updateShapes, sceneResponse)` that all four
+call sites funnel through. Each was written by hand, slightly differently, at a different
+time, for a different app. Adding a new field to the wire protocol (as `orientations`
+effectively was, retroactively, for `SymmetryGeometry`) means finding and fixing every one
+of these by hand, with no compiler or lint rule to catch a missed site — the failure mode is
+a silently-blank canvas, not an error.
+
+## Classic editor vs. viewer/preview: which listener is mounted where
+
+`SceneChangeListener` — the component with the richest event handling (incremental
+`SHAPE_DEFINED`/`INSTANCE_ADDED`/`INSTANCE_REMOVED`/`SELECTION_TOGGLED` subscriptions, in
+addition to `SYMMETRY_CHANGED`/`SCENE_RENDERED`) — is mounted in exactly two places:
+
+- `online/src/app/classic/index.jsx:81` — the classic editor
+- `online/src/app/buildplane/index.jsx:56` — the buildplane app
+
+It is **never mounted** by `online/src/viewer/index.jsx`'s `SceneViewer` / `DesignViewer` /
+`UrlViewer` tree — the standalone viewer and web-component embed path. That tree instead
+relies entirely on `SceneIndexingProvider`'s `showIndexedScene` (itself driven by
+`InitializeScene` calling `showTitledScene`/`showIndexedScene` once at mount, and again on
+any subsequent scene navigation).
+
+Practical consequence: the incremental edit events
+(`SHAPE_DEFINED`/`INSTANCE_ADDED`/`INSTANCE_REMOVED`/`SELECTION_TOGGLED`) are **editor-only
+concepts** at the client level — the viewer path has no equivalent and doesn't need one,
+since it never mutates a design, only ever swaps between whole, pre-rendered snapshots via
+`SNAPSHOT_SELECTED`. The plan doc for `SymmetryGeometry`
+(`online/developer-docs/symmetry-renderer-plan.md`) frames this as "viewer is static, editor
+is dynamic" — that's accurate at the level of *what the renderer needs to support*, but the
+plumbing difference actually goes one level deeper: the viewer and editor don't share a
+scene-loading code path at all, worker or client side, except for the pure data-shaping
+functions (`prepareSceneResponse`/`prepareEditSceneResponse`).
+
+## The `rotation` vs `orientations`+index redundancy
+
+`ShapedGeometry` (`online/src/viewer/geometry.jsx`) renders one `THREE.Mesh` per instance and
+reads `instance.rotation` directly — a full, pre-resolved 16-element matrix, ready to feed
+into `Matrix4.set(...)`. It never looks at `orientations` or `instance.orientation` at all.
+
+`SymmetryGeometry` (`online/src/viewer/symmetry-geometry.jsx`) renders via GPU instancing
+(`createSymmetryRenderer`) and does the opposite: it registers the *shared* `orientations`
+array once, as a symmetry group (`registerSymmetryGroup`), then references each instance by
+its `orientation` **index** into that shared array (`addInstance({ orientationIndex: ... })`).
+It never reads `instance.rotation`.
+
+Both fields are present on every instance in every response, all the time, regardless of
+which renderer (if either) is actually mounted for a given canvas — there's no negotiation of
+"which shape does this client want." A `TODO` comment already in the worker code
+(`vzome-worker-static.js:22-23`) flags this as known, deliberate, and temporary:
+
+```js
+// TODO: once SymmetryGeometry replaces ShapedGeometry, stop sending rotation
+//   matrices per-instance and have the client resolve them from orientations.
+```
+
+This is the right call for now — it kept `ShapedGeometry` completely unmodified and working
+throughout `SymmetryGeometry`'s development — but it's worth being explicit that it is a
+**real, measurable bandwidth cost**: every instance carries a redundant 16-float matrix that
+is fully derivable from its own `orientation` index plus the shared table already present in
+the same payload. For designs with many instances this roughly doubles the per-instance
+transform payload size for no reason once `SymmetryGeometry` is the only consumer.
+
+## Async-handling issues found while debugging (from this session)
+
+These aren't purely protocol-shape issues, but they're squarely in "client-side async
+handling of scene data" and cost real debugging time, so they belong in this document:
+
+1. **`showIndexedScene`'s two-phase update is not atomic.** `scene.jsx:68-91` sets
+   `embedding`/`polygons`/`orientations` synchronously in the `postRequest(...).then(...)`
+   callback, but defers `updateShapes(scene.shapes)` — the call that actually populates
+   `scene.shapes` and makes `SymmetryGeometry`'s `hasInstances` check pass — behind an
+   additional `setTimeout` *and* a `tweenCamera(...).then(...)` chain. This ordering is
+   intentional (so the camera can finish animating before geometry pops in), but it means
+   `orientations` and `shapes` can be visibly out of sync for a nontrivial span of wall-clock
+   time. `SymmetryGeometry` is written defensively against this (it gates registration on
+   *both* being present before doing anything), but a naive consumer reading the store
+   mid-transition would see a `shapes` store from the *previous* scene alongside the *new*
+   scene's `orientations` (or vice versa) for one or more frames.
+
+2. **`sceneTitle` is a signal frozen at its own initializer, permanently, on the
+   viewer/web-component path.** `SceneTitlesProvider` (`scene.jsx:137-146`) computes its
+   initial `sceneTitle` value from `sceneTitles()[0]`, which itself depends on `scenes` (from
+   `useViewer()`) — a list that is populated asynchronously by a `SCENES_DISCOVERED` message
+   from the worker. SolidJS's `createSignal(initialValue)` evaluates `initialValue` exactly
+   once, at signal-creation time; it does **not** re-run if whatever the initializer read
+   later changes. Since `SceneTitlesProvider` mounts well before `scenes` has any data
+   (that's an inherent race between component mount and worker roundtrip, not something
+   fixable by reordering local code), `sceneTitle()` was `undefined` forever, and
+   `setSceneTitle` — the only way to correct it — was exported from the context but never
+   called anywhere in the codebase. This meant `InitializeScene`'s
+   `showTitledScene(sceneTitle())` call always resolved to `undefined`, which
+   `getSceneTitleIndex` treats as "index 0" (`scene.jsx:116-117`: `if (!title) return 0`) —
+   silently loading the *wrong* named scene on first paint, correcting itself only once the
+   user navigated to a different scene and back (which calls `showTitledScene`/
+   `showIndexedScene` with an explicit, non-stale argument, bypassing the frozen signal
+   entirely). This is a general SolidJS foot-gun (a signal seeded from a value that depends
+   on not-yet-arrived async data) with a straightforward fix — a `createEffect` that corrects
+   `sceneTitle` once `scenes` actually has content, guarded so it doesn't clobber a
+   deliberately-set later value — but the bug itself predates this session and affects
+   `ShapedGeometry` identically; it was simply much harder to notice there, since one scene's
+   geometry can look superficially plausible in place of another's.
+
+3. **Symptom shape common to both bugs above: silent, not loud.** Neither issue produces a
+   console error, a warning, or a rejected Promise anywhere in the chain — both manifest as
+   "the wrong (or no) content is on screen," which is exactly the failure mode that's hardest
+   to distinguish from a genuine rendering bug (shader, GPU state, camera math, scale) without
+   deliberately checking the data layer first. Concretely, this repo's debugging session for
+   `SymmetryGeometry` spent a long time inspecting shader compilation, draw calls, GL state,
+   frustum culling, and camera transforms on `webgpu-try` *before* discovering that the actual
+   defect was a request racing past a guard clause and an `undefined` scene title — because
+   every one of those lower-level checks passed individually, and the render pipeline really
+   was working correctly on the data it was given; the data itself was simply wrong or absent.
+   There is no structural way, currently, to distinguish "the renderer is broken" from "the
+   data feeding the renderer is stale/missing/wrong" without manual, per-layer instrumentation
+   — no assertion or dev-mode warning fires when `scene.orientations` is `undefined` while a
+   consumer that needs it is mounted, for instance.
+
+## Summary of concrete recommendations
+
+- Consolidate the four "apply a scene response to the store" call sites (`scene.jsx` ×3,
+  `camera.jsx` ×1) into one shared function once the third one (`SceneIndexingProvider`) is
+  confirmed stable, so future wire-protocol fields only need to be added in one place.
+- Consider a dev-mode assertion/warning when a mounted `SymmetryGeometry` observes
+  `props.shapes` with instances but `props.orientations` still empty/undefined after some
+  reasonable delay — surfacing exactly the failure mode that took the longest to diagnose.
+- When `ShapedGeometry` is fully retired, drop `rotation` from `prepareSceneResponse` /
+  `prepareEditSceneResponse` per the existing `TODO`, and have any remaining consumer resolve
+  `rotation` from `orientations[instance.orientation]` client-side if still needed anywhere
+  (e.g. for BOM/export tooling, if any exists outside the renderers).
+- Fix (or at least flag) the `SceneTitlesProvider` frozen-signal pattern generally — any other
+  signal in this codebase seeded from `useViewer().scenes` before that data has arrived is a
+  candidate for the same bug.

--- a/online/package.json
+++ b/online/package.json
@@ -23,7 +23,7 @@
     "i": "^0.3.7",
     "npm": "^11.13.0",
     "solid-js": "^1.9.10",
-    "solid-three": "https://pkg.pr.new/solid-three@4fe9e16",
+    "solid-three": "https://pkg.pr.new/solid-three@8348eb8",
     "three": "^0.184.0",
     "three-stdlib": "^2.36.0",
     "txml": "^5.1.1",

--- a/online/package.json
+++ b/online/package.json
@@ -23,7 +23,7 @@
     "i": "^0.3.7",
     "npm": "^11.13.0",
     "solid-js": "^1.9.10",
-    "solid-three": "https://pkg.pr.new/solid-three@8348eb8",
+    "solid-three": "https://pkg.pr.new/solid-three@824aea9",
     "three": "^0.184.0",
     "three-stdlib": "^2.36.0",
     "txml": "^5.1.1",

--- a/online/scripts/test-https.mjs
+++ b/online/scripts/test-https.mjs
@@ -26,6 +26,8 @@ ctx .serve( { servedir: 'serve' } )
 
   // Then start a proxy server on port 8532
   https.createServer( security, (req, res) => {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+
     const options = {
       hostname: host,
       port: port,
@@ -38,13 +40,19 @@ ctx .serve( { servedir: 'serve' } )
     const proxyReq = http.request( options, proxyRes => {
       // If esbuild returns "not found", send a custom 404 page
       if (proxyRes.statusCode === 404) {
-        res.writeHead(404, { 'Content-Type': 'text/html' });
+        res.writeHead(404, {
+          'Content-Type': 'text/html',
+          'Access-Control-Allow-Origin': '*'
+        });
         res.end('<h1>A wacky custom 404 page</h1>');
         return;
       }
 
       // Otherwise, forward the response from esbuild to the client
-      res.writeHead( proxyRes.statusCode, proxyRes.headers );
+      res.writeHead( proxyRes.statusCode, {
+        ...proxyRes.headers,
+        'access-control-allow-origin': '*'
+      } );
       proxyRes.pipe( res, { end: true } );
     });
 

--- a/online/serve/app/test/cases/labels/index.html
+++ b/online/serve/app/test/cases/labels/index.html
@@ -24,7 +24,7 @@
 <body>
   <article>
     <section>
-      <vzome-viewer src="./test-show-scenes.vZome" id="testShowScenes" show-scenes="named" labels="true" >
+      <vzome-viewer src="./test-show-scenes.vZome" id="testShowScenes" show-scenes="all" labels="true" >
       </vzome-viewer>
     </section>
   </article>

--- a/online/src/app/classic/components/camera.jsx
+++ b/online/src/app/classic/components/camera.jsx
@@ -39,6 +39,11 @@ export const CameraControlsUI = (props) =>
     }
     setScene( 'embedding', scene.embedding );
     setScene( 'polygons', scene.polygons );
+    // Needed by SymmetryGeometry (see scenecanvas.jsx's symmetryRenderer prop). This
+    // trackball preview has its own scene-loading path, separate from the main
+    // SCENE_RENDERED/SYMMETRY_CHANGED events in scene.jsx's SceneChangeListener, and it
+    // was dropping `orientations` even though prepareSceneResponse() sends it.
+    setScene( 'orientations', scene.orientations );
     updateShapes( scene.shapes );
   });
 
@@ -65,7 +70,7 @@ export const CameraControlsUI = (props) =>
       <div id="ball-and-slider">
         <div id="camera-trackball">
           <CameraProvider name='trackball' outlines={false} context={context}>
-            <SceneCanvas height="200px" width="240px" rotationOnly={true} rotateSpeed={0.7}/>
+            <SceneCanvas symmetryRenderer={true} height="200px" width="240px" rotationOnly={true} rotateSpeed={0.7}/>
           </CameraProvider>
         </div>
         <div id='zoom-slider' >

--- a/online/src/app/classic/components/editor.jsx
+++ b/online/src/app/classic/components/editor.jsx
@@ -105,7 +105,7 @@ export const SceneEditor = ( props ) =>
       <LabelDialog open={!!labeling()} close={hideLabelDialog} id={labeling()} label={label()} />
       <InteractionToolProvider>
         <ContextualMenuArea menu={<ContextualMenu showDialog={showDialog} />} class="absolute-0" disabled={viewing()} onOpenChange={resetPicked}>
-          <SceneCanvas height="100%" width="100%" scene={scene} rotationOnly={false} >
+          <SceneCanvas symmetryRenderer={false} height="100%" width="100%" scene={scene} rotationOnly={false} >
             {/* The group is only necessary because of https://github.com/solidjs-community/solid-three/issues/11 */}
             <T.Group>
               <Switch fallback={

--- a/online/src/app/classic/dialogs/scenes.jsx
+++ b/online/src/app/classic/dialogs/scenes.jsx
@@ -274,7 +274,7 @@ const ScenesDialog = props =>
                 <div class='absolute-0'>
                   <SceneProvider config={{ labels: props.config?.labels }}>
                     <SceneIndexingProvider index={ sceneIndex() }>
-                      <SceneCanvas height="100%" width="100%" />
+                      <SceneCanvas symmetryRenderer={true} height="100%" width="100%" />
                     </SceneIndexingProvider>
                   </SceneProvider>
                   <Stack class='scene-actions'>

--- a/online/src/viewer/context/scene.jsx
+++ b/online/src/viewer/context/scene.jsx
@@ -76,6 +76,12 @@ const SceneIndexingProvider = ( props ) =>
       setLastSceneIndex( sceneIndex );
       setScene( 'embedding', reconcile( scene.embedding ) );
       setScene( 'polygons', scene.polygons );
+      // Needed by SymmetryGeometry -- see the longer comment on the SCENE_RENDERED
+      // subscription below. This is the SceneViewer/DesignViewer/UrlViewer scene-loading
+      // path (via InitializeScene -> showIndexedScene), which never mounts
+      // SceneChangeListener at all, so that comment's fix doesn't reach this path either.
+      if ( scene.orientations )
+        setScene( 'orientations', scene.orientations );
       const { camera } = config || { camera: true };
       setTimeout( () => {
         ( camera? tweenCamera( scenes[ sceneIndex ] .camera ) : Promise.resolve() )
@@ -87,7 +93,7 @@ const SceneIndexingProvider = ( props ) =>
   createEffect( () => {
     if ( props.index !== undefined ) {
       // if index is given, show that scene
-      console.log( `SceneIndexingProvider effect showing ${props.index}` );     
+      console.log( `SceneIndexingProvider effect showing ${props.index}` );
       showIndexedScene( props.index );
     }
   } );
@@ -138,7 +144,21 @@ const SceneTitlesProvider = (props) =>
     : ( props.show === 'titled' )? namedScenes()
     : scenes .map( (scene,index) => scene.title?.trim() || (( index === 0 )? "default scene" : `#${index}`) );
   const [ sceneTitle, setSceneTitle ] = createSignal(( props.show === 'given' )? props.title : sceneTitles()[0] );
-  
+
+  // `scenes` (from useViewer()) loads asynchronously from the worker, so it's almost
+  // always still empty at the createSignal() call above, freezing sceneTitle at
+  // sceneTitles()[0] === undefined forever (signals don't recompute their initializer).
+  // setSceneTitle was never called anywhere to correct this once scenes actually arrive,
+  // so InitializeScene's showTitledScene(sceneTitle()) call would silently fall back to
+  // scene index 0 ("default scene") on first paint instead of the scene actually wanted.
+  if ( props.show !== 'given' ) {
+    createEffect( () => {
+      if ( sceneTitle() === undefined && scenes.length > 0 ) {
+        setSceneTitle( sceneTitles()[0] );
+      }
+    } );
+  }
+
   const showTitledScene = ( name, config ) =>
   {
     const index = getSceneTitleIndex( scenes, name );
@@ -166,6 +186,17 @@ const SceneChangeListener = () =>
   subscribeFor( 'SCENE_RENDERED', ( { scene } ) => {
     setScene( 'embedding', reconcile( scene.embedding ) );
     setScene( 'polygons', scene.polygons );
+    // Needed by SymmetryGeometry. SYMMETRY_CHANGED (above) is the usual source of
+    // scene.orientations, but the legacy Java loadDesign/newDesign path is the only one
+    // that fires it. SCENE_RENDERED always carries `orientations` too though (see
+    // prepareSceneResponse in vzome-worker-static.js), so read it here as well. Note:
+    // this SceneChangeListener component is only mounted by the classic editor and
+    // buildplane apps (see their index.jsx) -- the SceneViewer/DesignViewer/UrlViewer
+    // path (the "viewer"/web-component embed) never mounts it at all, and gets its scene
+    // data through SceneIndexingProvider's showIndexedScene() instead, which needed the
+    // identical fix separately (see below).
+    if ( scene.orientations )
+      setScene( 'orientations', scene.orientations );
     updateShapes( scene.shapes );
     // logShapes();
   } );

--- a/online/src/viewer/context/symmetry-renderer.js
+++ b/online/src/viewer/context/symmetry-renderer.js
@@ -1,0 +1,994 @@
+
+// MeshBasicNodeMaterial/MeshLambertNodeMaterial (and the rest of the Node-material family)
+// only exist in the three/webgpu build, not the plain "three" entry point -- the POC this
+// was ported from imported everything via `import * as THREE from "three/webgpu"`. The
+// other classes here (Matrix4, Vector3, etc.) are the same class identities either way,
+// so importing them from three/webgpu too keeps this file on a single consistent source.
+import {
+  Group,
+  InstancedMesh,
+  Matrix4,
+  MeshBasicNodeMaterial,
+  MeshLambertNodeMaterial,
+  RenderTarget,
+  Scene,
+  Vector3,
+  Color,
+  InstancedBufferAttribute,
+  Euler,
+  BufferGeometry,
+  UnsignedByteType,
+  RGBAFormat,
+} from "three/webgpu";
+import {
+  Fn,
+  attribute,
+  float,
+  floor,
+  mod,
+  positionLocal,
+  uniformArray,
+  vec3,
+  vec4
+} from "three/tsl";
+
+export const INITIAL_SHAPE_CAPACITY = 64;
+
+
+// parent is whatever Object3D the managed originGroup should attach under -- the raw
+// Three.js scene for the non-XR desktop path, or WebXRSupport's own originGroup (see
+// symmetry-geometry.jsx) so that XRGripToMove/XRScaling, which reposition/rescale that
+// group on XR session start, carry this renderer's content along automatically instead of
+// leaving it stranded at whatever desktop-camera-relative transform it had before entering XR.
+export function createSymmetryRenderer(parent)
+{
+  // Create a group to hold all managed meshes. matrixAutoUpdate must be off: callers
+  // (e.g. symmetry-geometry.jsx, for the embedding matrix) set originGroup.matrix directly
+  // via .matrix.copy()/applyMatrix4(), and Three's default per-frame auto-update would
+  // silently overwrite that with an identity/position-quaternion-scale recompute.
+  // ShapedGeometry's equivalent wrapper group in geometry.jsx sets the same T.Group
+  // matrixAutoUpdate={false} for the same reason.
+  const originGroup = new Group();
+  originGroup.matrixAutoUpdate = false;
+  parent.add(originGroup);
+
+  const colorMatrices = [];
+  let colorPalette = null;
+
+  const symmetryGroups = new Map();
+  let activeGroupId = null;
+  let discardInactiveShaders = false;
+
+  function registerSymmetryGroup(groupId, orientations) {
+    if (symmetryGroups.has(groupId)) {
+      throw new Error(`Symmetry group '${groupId}' already exists.`);
+    }
+    if (!Array.isArray(orientations) || orientations.length === 0) {
+      throw new Error("A symmetry group needs at least one orientation.");
+    }
+
+    const orientationMatrices = orientations.map((item) => {
+      if (item instanceof Matrix4) {
+        return item.clone();
+      }
+      if (item instanceof Euler) {
+        return new Matrix4().makeRotationFromEuler(item);
+      }
+      throw new Error("Orientation must be a Euler or Matrix4.");
+    });
+
+    const group = {
+      id: groupId,
+      orientations: orientationMatrices,
+      styles: new Map(),
+      slots: new Set(),
+      activeStyleId: null,
+      instancesByShape: new Map(),
+      nextInstanceId: 1,
+      gpu: null
+    };
+
+    symmetryGroups.set(groupId, group);
+    return group;
+  }
+
+  function registerStyle(groupId, styleId) {
+    const group = getSymmetryGroup(groupId);
+    if (group.styles.has(styleId)) {
+      throw new Error(`Style '${styleId}' is already registered in group '${groupId}'.`);
+    }
+    group.styles.set(styleId, { id: styleId, geometries: new Map() });
+    if (group.activeStyleId === null) {
+      group.activeStyleId = styleId;
+    }
+  }
+
+  function registerShape(groupId, styleId, slotId, geometry) {
+    if (!(geometry instanceof BufferGeometry)) {
+      throw new Error("Shape geometry must be a BufferGeometry.");
+    }
+    const group = getSymmetryGroup(groupId);
+    const style = getStyle(group, styleId);
+    if (style.geometries.has(slotId)) {
+      throw new Error(`Geometry for slot '${slotId}' is already registered in style '${styleId}'.`);
+    }
+
+    style.geometries.set(slotId, geometry);
+    group.slots.add(slotId);
+
+    if (group.gpu) {
+      // Add to the geometry cache for this slot/style
+      let slotCache = group.gpu.cachedGeometries.get(slotId);
+      if (!slotCache) {
+        slotCache = new Map();
+        group.gpu.cachedGeometries.set(slotId, slotCache);
+      }
+      slotCache.set(styleId, geometry.clone());
+
+      // Create shape entry only if this is a brand-new slot
+      if (!group.gpu.shapeEntries.has(slotId)) {
+        const activeGeom = (group.activeStyleId && slotCache.get(group.activeStyleId))
+          ?? slotCache.values().next().value;
+        const outlineGeom = group.gpu.outlineGeometries.get(slotId) ?? null;
+        const entry = createShapeEntry(slotId, activeGeom, outlineGeom, group.gpu.material, group.gpu.pickingMaterial, group.gpu.outlineMaterial);
+        group.gpu.shapeEntries.set(slotId, entry);
+        if (group.id === activeGroupId) {
+          originGroup.add(entry.mesh);
+          group.gpu.pickingOriginGroup.add(entry.pickingMesh);
+          if (entry.outlineMesh) {
+            originGroup.add(entry.outlineMesh);
+          }
+        }
+      }
+    }
+  }
+
+  // Outline (wireframe) geometry is registered per-shape. Every registered outline mesh
+  // starts hidden (see makeOutlineMesh); call setOutlinesVisible() to show them -- this is
+  // independent of fill style (see the comment on setOutlinesVisible).
+  function registerOutline(groupId, slotId, outlineGeometry) {
+    if (!(outlineGeometry instanceof BufferGeometry)) {
+      throw new Error("Outline geometry must be a BufferGeometry.");
+    }
+    const group = getSymmetryGroup(groupId);
+    if (group.gpu && group.gpu.outlineGeometries.has(slotId)) {
+      throw new Error(`Outline geometry for slot '${slotId}' is already registered in group '${groupId}'.`);
+    }
+
+    if (group.gpu) {
+      group.gpu.outlineGeometries.set(slotId, outlineGeometry.clone());
+      const entry = group.gpu.shapeEntries.get(slotId);
+      if (entry && !entry.outlineMesh) {
+        attachOutlineMeshToEntry(group, entry, slotId);
+      }
+    } else {
+      // No GPU state yet: stash for ensureGroupGpu to pick up when it builds shape entries.
+      group.pendingOutlineGeometries = group.pendingOutlineGeometries ?? new Map();
+      group.pendingOutlineGeometries.set(slotId, outlineGeometry.clone());
+    }
+  }
+
+  function switchSymmetryGroup(groupId, options = {}) {
+    const {
+      discardUnusedShaders = discardInactiveShaders
+    } = options;
+    const nextGroup = getSymmetryGroup(groupId);
+
+    if (activeGroupId === groupId) {
+      return;
+    }
+
+    if (activeGroupId !== null) {
+      const previous = symmetryGroups.get(activeGroupId);
+      setGroupMeshesCount(previous, 0);
+    }
+
+    ensureGroupGpu(nextGroup);
+    ensureGroupHasActiveStyle(nextGroup);
+    addGroupMeshesToScene(nextGroup);
+    activeGroupId = groupId;
+    syncAllInstancesForGroup(nextGroup);
+
+    if (discardUnusedShaders) {
+      for (const group of symmetryGroups.values()) {
+        if (group.id !== activeGroupId) {
+          disposeGroupGpu(group);
+        }
+      }
+    }
+  }
+
+  function setDiscardInactiveShaders(enabled) {
+    discardInactiveShaders = Boolean(enabled);
+  }
+
+  function switchStyle(styleId) {
+    const group = getActiveGroup();
+    getStyle(group, styleId);
+    if (group.activeStyleId === styleId) {
+      return;
+    }
+    group.activeStyleId = styleId;
+    if (group.gpu) {
+      swapGeometriesForStyle(group, styleId);
+    }
+  }
+
+  function swapGeometriesForStyle(group, styleId) {
+    for (const [slotId, entry] of group.gpu.shapeEntries) {
+      swapBaseGeometry(entry, slotId, styleId, group.gpu.cachedGeometries);
+    }
+  }
+
+  // Independent of styles/switchStyle: shows or hides every registered outline mesh on the
+  // active group. Outline visibility is not tied to which fill style is active -- a single
+  // fill geometry (the fan-triangulated one; see the long comment where symmetry-geometry.jsx
+  // builds it) is correct for every shape regardless of outline visibility, so there is no
+  // reason to route this through a style switch.
+  function setOutlinesVisible(visible) {
+    const group = getActiveGroup();
+    if (!group.gpu) return;
+    for (const entry of group.gpu.shapeEntries.values()) {
+      if (entry.outlineMesh) {
+        entry.outlineMesh.visible = visible;
+      }
+    }
+  }
+
+  // Move instanced attributes from the current mesh geometry to the cached geometry
+  // for newStyleId, then point the mesh at that geometry.
+  // No cloning and no disposal: the old cached geometry stays alive for future switches.
+  function swapBaseGeometry(entry, slotId, newStyleId, cachedGeometries) {
+    const slotCache = cachedGeometries.get(slotId);
+    if (!slotCache) return;
+    const newGeom = slotCache.get(newStyleId);
+    if (!newGeom) return;
+    const oldGeom = entry.mesh.geometry;
+    if (oldGeom === newGeom) return;
+
+    for (const name of ["orientationIndex", "instanceTranslation", "colorIndex", "highlightIntensity", "pickingId"]) {
+      const attr = oldGeom.getAttribute(name);
+      if (attr) {
+        oldGeom.deleteAttribute(name);
+        newGeom.setAttribute(name, attr);
+      }
+    }
+    entry.mesh.geometry = newGeom;
+    if (entry.pickingMesh) {
+      entry.pickingMesh.geometry = newGeom;
+    }
+    // oldGeom is still in the cache with only base vertex data, ready for the next switch back
+  }
+
+  function registerColor(colorInput) {
+    const color = normalizeColorInput(colorInput);
+    colorMatrices.push(color);
+    colorPalette = uniformArray(colorMatrices);
+    return colorMatrices.length - 1;
+  }
+
+  function addInstance(styleId, shapeId, instanceOptions = {}) {
+    const group = getActiveGroup();
+    getStyle(group, styleId);
+    ensureStyleIsActiveForInstances(group, styleId);
+    const shapeMap = getOrCreateShapeInstanceMap(group, shapeId);
+
+    const position = instanceOptions.position ?? new Vector3();
+    const orientationIndex = normalizeOrientationIndex(group, instanceOptions.orientationIndex);
+    const colorIndex = normalizeColorIndex(instanceOptions.colorIndex);
+    const highlight = instanceOptions.highlight ?? 0;
+
+    const id = group.nextInstanceId;
+    group.nextInstanceId += 1;
+    shapeMap.set(id, {
+      position,
+      orientationIndex,
+      colorIndex,
+      highlight
+    });
+
+    syncShapeInstances(group, shapeId);
+    return id;
+  }
+
+  function removeInstance(styleId, shapeId, instanceId) {
+    const group = getActiveGroup();
+    const shapeMap = group.instancesByShape.get(shapeId);
+    if (!shapeMap) {
+      return false;
+    }
+    const removed = shapeMap.delete(instanceId);
+    if (removed) {
+      syncShapeInstances(group, shapeId);
+    }
+    return removed;
+  }
+
+  function removeAllInstances(styleId, shapeId) {
+    const group = getActiveGroup();
+    group.instancesByShape.delete(shapeId);
+    syncShapeInstances(group, shapeId);
+  }
+
+  function clearActiveInstances() {
+    const group = getActiveGroup();
+    clearGroupInstances(group);
+    setGroupMeshesCount(group, 0);
+  }
+
+
+  function createMaterialForGroup(group) {
+    const orientationUniform = uniformArray(group.orientations);
+    const orientationIndexNode = attribute("orientationIndex", "float");
+    const instanceTranslationNode = attribute("instanceTranslation", "vec3");
+    const colorIndexNode = attribute("colorIndex", "float");
+
+    const highlightIntensityNode = attribute("highlightIntensity", "float");
+
+    const rotatedPositionNode = Fn(() => {
+      const orientationMat = orientationUniform.element(orientationIndexNode.toInt());
+      return orientationMat.mul(vec4(positionLocal, 1.0)).xyz.add(instanceTranslationNode);
+    })();
+    const indexedColorNode = colorPalette.element(colorIndexNode.toInt());
+
+    // MeshLambertNodeMaterial (diffuse only, no specular term) to match ShapedGeometry's
+    // MeshLambertMaterial exactly -- see geometry.jsx's InstancedShape. The original
+    // MeshPhongNodeMaterial (shininess:55, a fairly bright bluish specular) came from the
+    // webxr-poc port this file started from and was never meant to match the app's actual
+    // look; it made flat-faceted low-poly shapes show a distracting specular highlight that
+    // ShapedGeometry never had.
+    const material = new MeshLambertNodeMaterial({
+      flatShading: true,
+    });
+    material.positionNode = rotatedPositionNode;
+    material.colorNode = indexedColorNode;
+    // Use white for emissive light, modulated by highlight intensity
+    material.emissiveNode = vec4(1.0, 1.0, 1.0, 1.0).xyz.mul(highlightIntensityNode);
+
+    // Picking material: encodes per-instance ID into RGB, shares the same vertex transform
+    const pickingIdNode = attribute("pickingId", "float");
+    // R = id % 256, G = floor(id/256) % 256, B = floor(id/65536)
+    const pickingColorNode = vec3(
+      mod(pickingIdNode, float(256.0)).div(255.0),
+      mod(floor(pickingIdNode.div(float(256.0))), float(256.0)).div(255.0),
+      floor(pickingIdNode.div(float(65536.0))).div(255.0)
+    );
+    const pickingMaterial = new MeshBasicNodeMaterial({ toneMapped: false });
+    pickingMaterial.positionNode = rotatedPositionNode;
+    pickingMaterial.colorNode = pickingColorNode;
+
+    // Outline material: plain black lines, shares the same per-instance vertex transform.
+    // ShapedGeometry's equivalent (geometry.jsx) uses LineBasicMaterial with linewidth=4.4,
+    // but WebGL/WebGPU both ignore Material.linewidth for regular (non-Line2) line
+    // rendering, so it's a fixed 1px line here regardless -- same visual limitation
+    // ShapedGeometry already silently has.
+    const outlineMaterial = new MeshBasicNodeMaterial({ toneMapped: false });
+    outlineMaterial.positionNode = rotatedPositionNode;
+    outlineMaterial.colorNode = vec3(0, 0, 0);
+
+    return { material, pickingMaterial, outlineMaterial };
+  }
+
+  // meshGeometry is a pre-cloned cached geometry; it is used directly (not cloned again).
+  // outlineGeometry (also pre-cloned, or null if none registered yet) gets its own
+  // InstancedMesh forced into line-list draw mode -- see makeOutlineMesh below.
+  function createShapeEntry(slotId, meshGeometry, outlineGeometry, material, pickingMaterial, outlineMaterial) {
+    const mesh = new InstancedMesh(meshGeometry, material, INITIAL_SHAPE_CAPACITY);
+    const orientBuffer = new Float32Array(INITIAL_SHAPE_CAPACITY);
+    const translationBuffer = new Float32Array(INITIAL_SHAPE_CAPACITY * 3);
+    const colorIndexBuffer = new Float32Array(INITIAL_SHAPE_CAPACITY);
+    const highlightBuffer = new Float32Array(INITIAL_SHAPE_CAPACITY);
+    const pickingIdBuffer = new Float32Array(INITIAL_SHAPE_CAPACITY);
+    attachAttributes(mesh.geometry, orientBuffer, translationBuffer, colorIndexBuffer, highlightBuffer, pickingIdBuffer);
+    initializeIdentityMatrices(mesh, INITIAL_SHAPE_CAPACITY);
+    mesh.count = 0;
+    // Three's default frustum culling uses meshGeometry's bounding sphere, which only
+    // covers the single un-instanced base shape (e.g. one ball near the local origin) --
+    // it knows nothing about the per-instance translation applied in the vertex shader via
+    // positionNode. As the camera frustum tightens (e.g. zooming in), that tiny bounding
+    // sphere can fall outside it well before the actual (scattered) instances do, causing
+    // Three to cull the whole mesh at once -- every instance of this shape disappears
+    // together, while other shapes with different local bounding spheres stay visible.
+    // Disabling frustum culling here trades a small amount of GPU work (never culled, even
+    // when genuinely off-screen) for correctness.
+    mesh.frustumCulled = false;
+
+    // Picking mesh shares the same geometry (and therefore all instanced attributes)
+    const pickingMesh = new InstancedMesh(meshGeometry, pickingMaterial, INITIAL_SHAPE_CAPACITY);
+    initializeIdentityMatrices(pickingMesh, INITIAL_SHAPE_CAPACITY);
+    pickingMesh.count = 0;
+    pickingMesh.frustumCulled = false;
+
+    const outlineMesh = outlineGeometry
+      ? makeOutlineMesh(outlineGeometry, outlineMaterial, INITIAL_SHAPE_CAPACITY, orientBuffer, translationBuffer, highlightBuffer, pickingIdBuffer)
+      : null;
+
+    return {
+      slotId,
+      capacity: INITIAL_SHAPE_CAPACITY,
+      mesh,
+      pickingMesh,
+      outlineMesh,
+      orientBuffer,
+      translationBuffer,
+      colorIndexBuffer,
+      highlightBuffer,
+      pickingIdBuffer,
+    };
+  }
+
+  // Builds an InstancedMesh that draws as GL_LINES instead of triangles. WebGPUUtils'
+  // getPrimitiveTopology (and the WebGL fallback backend's equivalent dispatch) both check
+  // object.isLineSegments *before* object.isMesh, and InstancedMesh extends Mesh without
+  // setting isLineSegments itself -- so forcing that flag true here is enough to make an
+  // *instanced* line-list mesh, which Three's public API has no constructor for. Instancing
+  // itself (drawIndexed/instanceCount) is orthogonal to topology, so this is safe.
+  // outlineGeometry is a plain (non-instanced-attribute) BufferGeometry from
+  // buildOutlineGeometry; the instanced attributes are attached here from buffers the
+  // fill mesh already owns, so per-instance data (position/orientation/highlight/picking
+  // id) never needs writing twice -- both geometries' attributes wrap the same arrays.
+  function makeOutlineMesh(outlineGeometry, outlineMaterial, capacity, orientBuffer, translationBuffer, highlightBuffer, pickingIdBuffer) {
+    outlineGeometry.setAttribute("orientationIndex", new InstancedBufferAttribute(orientBuffer, 1));
+    outlineGeometry.setAttribute("instanceTranslation", new InstancedBufferAttribute(translationBuffer, 3));
+    outlineGeometry.setAttribute("highlightIntensity", new InstancedBufferAttribute(highlightBuffer, 1));
+    outlineGeometry.setAttribute("pickingId", new InstancedBufferAttribute(pickingIdBuffer, 1));
+
+    const outlineMesh = new InstancedMesh(outlineGeometry, outlineMaterial, capacity);
+    outlineMesh.isLineSegments = true;
+    initializeIdentityMatrices(outlineMesh, capacity);
+    outlineMesh.count = 0;
+    outlineMesh.frustumCulled = false;
+    // Default hidden; callers that need it visible (e.g. ensureShapeCapacity's
+    // regrowth path, carrying over the previous mesh's visibility) set this after return.
+    outlineMesh.visible = false;
+    return outlineMesh;
+  }
+
+  function ensureGroupGpu(group) {
+    if (group.gpu) {
+      return;
+    }
+
+    const { material, pickingMaterial, outlineMaterial } = createMaterialForGroup(group);
+
+    // Pre-clone one geometry per slot per style so style switches need no allocation
+    const cachedGeometries = new Map();
+    for (const slotId of group.slots) {
+      const slotCache = new Map();
+      for (const [styleId, style] of group.styles) {
+        if (style.geometries.has(slotId)) {
+          slotCache.set(styleId, style.geometries.get(slotId).clone());
+        }
+      }
+      cachedGeometries.set(slotId, slotCache);
+    }
+
+    // outlineGeometries carries over anything registered via registerOutline() before this
+    // group had GPU state yet (see the pendingOutlineGeometries stash in registerOutline).
+    const outlineGeometries = group.pendingOutlineGeometries ?? new Map();
+    group.pendingOutlineGeometries = undefined;
+
+    // Build shape entries using the active style's cached geometry
+    const shapeEntries = new Map();
+    for (const slotId of group.slots) {
+      const slotCache = cachedGeometries.get(slotId);
+      if (!slotCache) continue;
+      const geom = (group.activeStyleId && slotCache.get(group.activeStyleId))
+        ?? slotCache.values().next().value;
+      if (geom) {
+        const outlineGeom = outlineGeometries.get(slotId) ?? null;
+        shapeEntries.set(slotId, createShapeEntry(slotId, geom, outlineGeom, material, pickingMaterial, outlineMaterial));
+      }
+    }
+
+    // Picking scene: mirrors the visible geometry with ID-encoded colors for hit detection
+    const pickingScene = new Scene();
+    const pickingOriginGroup = new Group();
+    pickingScene.add(pickingOriginGroup);
+    // Use RenderTarget (not WebGLRenderTarget) so the WebGPU renderer registers the texture
+    const pickingTarget = new RenderTarget(1, 1, {
+      type: UnsignedByteType,
+      format: RGBAFormat,
+    });
+
+    group.gpu = { material, pickingMaterial, outlineMaterial, shapeEntries, cachedGeometries, outlineGeometries, pickingScene, pickingOriginGroup, pickingTarget };
+  }
+
+  // Attaches an outline mesh to a shape entry that was created before its outline geometry
+  // was registered (registerOutline() arriving after registerShape() for the same slot).
+  function attachOutlineMeshToEntry(group, entry, slotId) {
+    const outlineGeom = group.gpu.outlineGeometries.get(slotId);
+    if (!outlineGeom) return;
+    const outlineMesh = makeOutlineMesh(
+      outlineGeom, group.gpu.outlineMaterial, entry.capacity,
+      entry.orientBuffer, entry.translationBuffer, entry.highlightBuffer, entry.pickingIdBuffer
+    );
+    outlineMesh.count = entry.mesh.count;
+    entry.outlineMesh = outlineMesh;
+    if (entry.mesh.parent === originGroup) {
+      originGroup.add(outlineMesh);
+    }
+  }
+
+  function addGroupMeshesToScene(group) {
+    if (!group.gpu) {
+      return;
+    }
+    for (const entry of group.gpu.shapeEntries.values()) {
+      if (entry.mesh.parent !== originGroup) {
+        originGroup.add(entry.mesh);
+      }
+      if (entry.outlineMesh && entry.outlineMesh.parent !== originGroup) {
+        originGroup.add(entry.outlineMesh);
+      }
+      if (entry.pickingMesh && entry.pickingMesh.parent !== group.gpu.pickingOriginGroup) {
+        group.gpu.pickingOriginGroup.add(entry.pickingMesh);
+      }
+    }
+  }
+
+  function setGroupMeshesCount(group, count) {
+    if (!group || !group.gpu) {
+      return;
+    }
+    for (const entry of group.gpu.shapeEntries.values()) {
+      entry.mesh.count = count;
+      if (entry.pickingMesh) {
+        entry.pickingMesh.count = count;
+      }
+      if (entry.outlineMesh) {
+        entry.outlineMesh.count = count;
+      }
+    }
+  }
+
+  function clearGroupInstances(group) {
+    if (!group) {
+      return;
+    }
+    group.instancesByShape.clear();
+  }
+
+  function syncShapeInstances(group, slotId) {
+    if (!group.gpu) {
+      return;
+    }
+    const entry = group.gpu.shapeEntries.get(slotId);
+    if (!entry) {
+      throw new Error(`Shape slot '${slotId}' is not registered for active group '${group.id}'.`);
+    }
+
+    const shapeMap = group.instancesByShape.get(slotId);
+    const instances = shapeMap ? Array.from(shapeMap.entries()) : [];
+    ensureShapeCapacity(group, slotId, instances.length);
+
+    const currentEntry = group.gpu.shapeEntries.get(slotId);
+    currentEntry.mesh.count = instances.length;
+    if (currentEntry.pickingMesh) {
+      currentEntry.pickingMesh.count = instances.length;
+    }
+    if (currentEntry.outlineMesh) {
+      currentEntry.outlineMesh.count = instances.length;
+    }
+    for (let i = 0; i < instances.length; i += 1) {
+      const [instanceId, { position, orientationIndex, colorIndex, highlight = 0 }] = instances[i];
+      currentEntry.orientBuffer[i] = orientationIndex;
+      const base = i * 3;
+      currentEntry.translationBuffer[base] = position.x;
+      currentEntry.translationBuffer[base + 1] = position.y;
+      currentEntry.translationBuffer[base + 2] = position.z;
+      currentEntry.colorIndexBuffer[i] = colorIndex;
+      currentEntry.highlightBuffer[i] = highlight;
+      currentEntry.pickingIdBuffer[i] = instanceId;
+    }
+
+    const geom = currentEntry.mesh.geometry;
+    geom.getAttribute("orientationIndex").needsUpdate = true;
+    geom.getAttribute("instanceTranslation").needsUpdate = true;
+    geom.getAttribute("colorIndex").needsUpdate = true;
+    geom.getAttribute("highlightIntensity").needsUpdate = true;
+    geom.getAttribute("pickingId").needsUpdate = true;
+
+    // outlineMesh's geometry is a *different* BufferGeometry (see makeOutlineMesh) that
+    // wraps the same underlying typed arrays via its own InstancedBufferAttribute
+    // instances, so the data above is already current -- but needsUpdate must still be
+    // flagged separately, once per GPU buffer.
+    if (currentEntry.outlineMesh) {
+      const outlineGeom = currentEntry.outlineMesh.geometry;
+      outlineGeom.getAttribute("orientationIndex").needsUpdate = true;
+      outlineGeom.getAttribute("instanceTranslation").needsUpdate = true;
+      outlineGeom.getAttribute("highlightIntensity").needsUpdate = true;
+      outlineGeom.getAttribute("pickingId").needsUpdate = true;
+    }
+  }
+
+  function ensureShapeCapacity(group, key, needed) {
+    const entry = group.gpu.shapeEntries.get(key);
+    if (needed <= entry.capacity) {
+      return;
+    }
+
+    const expandedCapacity = Math.max(needed, entry.capacity * 2);
+    const nextOrient = new Float32Array(expandedCapacity);
+    const nextTranslation = new Float32Array(expandedCapacity * 3);
+    const nextColor = new Float32Array(expandedCapacity);
+    const nextHighlight = new Float32Array(expandedCapacity);
+    const nextPickingId = new Float32Array(expandedCapacity);
+    nextOrient.set(entry.orientBuffer);
+    nextTranslation.set(entry.translationBuffer);
+    nextColor.set(entry.colorIndexBuffer);
+    nextHighlight.set(entry.highlightBuffer);
+    nextPickingId.set(entry.pickingIdBuffer);
+
+    const previousMesh = entry.mesh;
+    const previousGeometry = previousMesh.geometry;
+
+    // Clone from the source geometry so the new cached geom has clean base vertex data
+    const activeStyle = group.styles.get(group.activeStyleId);
+    const sourceGeom = activeStyle ? activeStyle.geometries.get(entry.slotId) : null;
+    const nextGeometry = sourceGeom ? sourceGeom.clone() : previousGeometry.clone();
+    attachAttributes(nextGeometry, nextOrient, nextTranslation, nextColor, nextHighlight, nextPickingId);
+
+    // Update the geometry cache: replace the active style's entry with the new geometry
+    const slotCache = group.gpu.cachedGeometries.get(entry.slotId);
+    if (slotCache && group.activeStyleId) {
+      slotCache.set(group.activeStyleId, nextGeometry);
+    }
+
+    const nextMesh = new InstancedMesh(nextGeometry, group.gpu.material, expandedCapacity);
+    initializeIdentityMatrices(nextMesh, expandedCapacity);
+    nextMesh.count = previousMesh.count;
+    // See the matching comment in createShapeEntry: bounding-sphere-based frustum culling
+    // doesn't account for per-instance translation, so it's disabled on every mesh here too
+    // (this replacement mesh doesn't inherit frustumCulled from previousMesh automatically).
+    nextMesh.frustumCulled = false;
+
+    if (previousMesh.parent === originGroup) {
+      originGroup.remove(previousMesh);
+      originGroup.add(nextMesh);
+    }
+
+    const nextPickingMesh = new InstancedMesh(nextGeometry, group.gpu.pickingMaterial, expandedCapacity);
+    initializeIdentityMatrices(nextPickingMesh, expandedCapacity);
+    nextPickingMesh.count = previousMesh.count;
+    nextPickingMesh.frustumCulled = false;
+
+    const previousPickingMesh = entry.pickingMesh;
+    if (previousPickingMesh && previousPickingMesh.parent === group.gpu.pickingOriginGroup) {
+      group.gpu.pickingOriginGroup.remove(previousPickingMesh);
+      group.gpu.pickingOriginGroup.add(nextPickingMesh);
+    }
+
+    // Outline mesh, if this shape has one, needs its own geometry (different vertex/index
+    // topology than nextGeometry) but reuses the same expanded buffers -- see makeOutlineMesh.
+    let nextOutlineMesh = null;
+    const previousOutlineMesh = entry.outlineMesh;
+    if (previousOutlineMesh) {
+      const sourceOutlineGeom = group.gpu.outlineGeometries.get(entry.slotId);
+      const nextOutlineGeometry = sourceOutlineGeom ? sourceOutlineGeom.clone() : previousOutlineMesh.geometry.clone();
+      nextOutlineMesh = makeOutlineMesh(
+        nextOutlineGeometry, group.gpu.outlineMaterial, expandedCapacity,
+        nextOrient, nextTranslation, nextHighlight, nextPickingId
+      );
+      nextOutlineMesh.count = previousOutlineMesh.count;
+      nextOutlineMesh.visible = previousOutlineMesh.visible;
+      if (previousOutlineMesh.parent === originGroup) {
+        originGroup.remove(previousOutlineMesh);
+        originGroup.add(nextOutlineMesh);
+      }
+      const previousOutlineGeometry = previousOutlineMesh.geometry;
+      requestAnimationFrame(() => previousOutlineGeometry.dispose());
+    }
+
+    // The old geometry is no longer in the cache; defer disposal to avoid destroying
+    // buffers that the current frame's command buffer may still reference
+    requestAnimationFrame(() => previousGeometry.dispose());
+
+    group.gpu.shapeEntries.set(key, {
+      ...entry,
+      capacity: expandedCapacity,
+      mesh: nextMesh,
+      pickingMesh: nextPickingMesh,
+      outlineMesh: nextOutlineMesh,
+      orientBuffer: nextOrient,
+      translationBuffer: nextTranslation,
+      colorIndexBuffer: nextColor,
+      highlightBuffer: nextHighlight,
+      pickingIdBuffer: nextPickingId,
+    });
+  }
+
+  function attachAttributes(geometry, orientBuffer, translationBuffer, colorIndexBuffer, highlightBuffer, pickingIdBuffer) {
+    geometry.setAttribute("orientationIndex", new InstancedBufferAttribute(orientBuffer, 1));
+    geometry.setAttribute("instanceTranslation", new InstancedBufferAttribute(translationBuffer, 3));
+    geometry.setAttribute("colorIndex", new InstancedBufferAttribute(colorIndexBuffer, 1));
+    geometry.setAttribute("highlightIntensity", new InstancedBufferAttribute(highlightBuffer, 1));
+    geometry.setAttribute("pickingId", new InstancedBufferAttribute(pickingIdBuffer, 1));
+  }
+
+  function initializeIdentityMatrices(mesh, capacity) {
+    const identity = new Matrix4();
+    for (let i = 0; i < capacity; i += 1) {
+      mesh.setMatrixAt(i, identity);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  }
+
+  function disposeGroupGpu(group) {
+    if (!group.gpu) {
+      return;
+    }
+
+    for (const entry of group.gpu.shapeEntries.values()) {
+      if (entry.mesh.parent === originGroup) {
+        originGroup.remove(entry.mesh);
+      }
+      if (entry.pickingMesh && entry.pickingMesh.parent === group.gpu.pickingOriginGroup) {
+        group.gpu.pickingOriginGroup.remove(entry.pickingMesh);
+      }
+      if (entry.outlineMesh) {
+        if (entry.outlineMesh.parent === originGroup) {
+          originGroup.remove(entry.outlineMesh);
+        }
+        // Unlike the fill/picking geometry, the outline mesh's geometry is not shared with
+        // anything else and isn't kept in cachedGeometries, so it must be disposed here.
+        entry.outlineMesh.geometry.dispose();
+      }
+      // Fill/picking geometry is owned by cachedGeometries; disposed below
+    }
+    for (const slotCache of group.gpu.cachedGeometries.values()) {
+      for (const geom of slotCache.values()) {
+        geom.dispose();
+      }
+    }
+    group.gpu.material.dispose();
+    group.gpu.pickingMaterial.dispose();
+    group.gpu.outlineMaterial.dispose();
+    group.gpu.pickingTarget.dispose();
+    group.gpu = null;
+  }
+
+  function syncAllInstancesForGroup(group) {
+    for (const slotId of group.instancesByShape.keys()) {
+      syncShapeInstances(group, slotId);
+    }
+  }
+
+  function getSymmetryGroup(groupId) {
+    const group = symmetryGroups.get(groupId);
+    if (!group) {
+      throw new Error(`Unknown symmetry group '${groupId}'.`);
+    }
+    return group;
+  }
+
+  function getStyle(group, styleId) {
+    const style = group.styles.get(styleId);
+    if (!style) {
+      throw new Error(`Unknown style '${styleId}' in group '${group.id}'.`);
+    }
+    return style;
+  }
+
+  function getGroupIds() {
+    return [...symmetryGroups.keys()];
+  }
+
+  function getActiveGroupId() {
+    return activeGroupId;
+  }
+
+  function getActiveGroup() {
+    if (activeGroupId === null) {
+      throw new Error("No active symmetry group. Call switchSymmetryGroup() first.");
+    }
+    return getSymmetryGroup(activeGroupId);
+  }
+
+  function getOrCreateShapeInstanceMap(group, key) {
+    let shapeMap = group.instancesByShape.get(key);
+    if (!shapeMap) {
+      shapeMap = new Map();
+      group.instancesByShape.set(key, shapeMap);
+    }
+    return shapeMap;
+  }
+
+  function normalizeOrientationIndex(group, orientationIndex) {
+    if (orientationIndex === undefined || orientationIndex === null) {
+      return Math.floor(Math.random() * group.orientations.length);
+    }
+    if (!Number.isInteger(orientationIndex)) {
+      throw new Error("orientationIndex must be an integer.");
+    }
+    if (orientationIndex < 0 || orientationIndex >= group.orientations.length) {
+      throw new Error(`orientationIndex out of range for group '${group.id}'.`);
+    }
+    return orientationIndex;
+  }
+
+  function normalizeColorIndex(colorIndex) {
+    if (colorIndex === undefined || colorIndex === null) {
+      return Math.floor(Math.random() * colorMatrices.length);
+    }
+    if (!Number.isInteger(colorIndex)) {
+      throw new Error("colorIndex must be an integer.");
+    }
+    if (colorIndex < 0 || colorIndex >= colorMatrices.length) {
+      throw new Error("colorIndex out of range.");
+    }
+    return colorIndex;
+  }
+
+  function normalizeColorInput(colorInput) {
+    if (colorInput instanceof Vector3) {
+      return colorInput.clone();
+    }
+    if (colorInput instanceof Color) {
+      return new Vector3(colorInput.r, colorInput.g, colorInput.b);
+    }
+    if (Array.isArray(colorInput) && colorInput.length === 3) {
+      return new Vector3(colorInput[0], colorInput[1], colorInput[2]);
+    }
+    if (typeof colorInput === "object" && colorInput !== null && "r" in colorInput && "g" in colorInput && "b" in colorInput) {
+      return new Vector3(colorInput.r, colorInput.g, colorInput.b);
+    }
+    if (typeof colorInput === "number" || typeof colorInput === "string") {
+      const color = new Color(colorInput);
+      return new Vector3(color.r, color.g, color.b);
+    }
+    throw new Error("registerColor expects a Color, Vector3, [r,g,b], {r,g,b}, number, or CSS color string.");
+  }
+
+  function ensureGroupHasActiveStyle(group) {
+    if (group.activeStyleId !== null) {
+      return;
+    }
+    const firstStyle = group.styles.keys().next();
+    group.activeStyleId = firstStyle.done ? null : firstStyle.value;
+  }
+
+  function ensureStyleIsActiveForInstances(group, styleId) {
+    if (group.activeStyleId === null) {
+      group.activeStyleId = styleId;
+      return;
+    }
+    if (group.activeStyleId === styleId) {
+      return;
+    }
+    group.activeStyleId = styleId;
+    if (group.gpu) {
+      swapGeometriesForStyle(group, styleId);
+    }
+  }
+
+  function setInstanceHighlight(shapeId, instanceId, intensity = 1) {
+    const group = getActiveGroup();
+    const shapeMap = group.instancesByShape.get(shapeId);
+    if (!shapeMap || !shapeMap.has(instanceId)) {
+      return false;
+    }
+    shapeMap.get(instanceId).highlight = intensity;
+    syncShapeInstances(group, shapeId);
+    return true;
+  }
+
+  function clearHighlights(shapeId) {
+    const group = getActiveGroup();
+    if (shapeId !== undefined) {
+      const shapeMap = group.instancesByShape.get(shapeId);
+      if (shapeMap) {
+        for (const inst of shapeMap.values()) {
+          inst.highlight = 0;
+        }
+        syncShapeInstances(group, shapeId);
+      }
+    } else {
+      for (const [sid, shapeMap] of group.instancesByShape) {
+        for (const inst of shapeMap.values()) {
+          inst.highlight = 0;
+        }
+        syncShapeInstances(group, sid);
+      }
+    }
+  }
+
+  function listShapeKeys(group, styleId) {
+    const keys = [];
+    for (const slotId of group.slots) {
+      keys.push({ styleId, shapeId: slotId });
+    }
+    return keys;
+  }
+
+  // GPU picking: render an offscreen pass with per-instance ID colors, read back the pixel under
+  // the cursor, and return the hit { shapeId, instanceId } or null for background.
+  // Instance IDs are encoded as 24-bit values across RGB (up to ~16.7M unique instances).
+  async function pickAt(clientX, clientY, renderer, camera) {
+    if (activeGroupId === null) return null;
+    const group = symmetryGroups.get(activeGroupId);
+    if (!group || !group.gpu) return null;
+
+    const { pickingScene, pickingOriginGroup: pickGroup, pickingTarget } = group.gpu;
+
+    // Sync picking group transform with the visible origin group
+    pickGroup.position.copy(originGroup.position);
+    pickGroup.quaternion.copy(originGroup.quaternion);
+    pickGroup.scale.copy(originGroup.scale);
+    pickGroup.updateMatrixWorld(true);
+
+    // Resize render target to match canvas if needed
+    const canvas = renderer.domElement;
+    const w = canvas.width;
+    const h = canvas.height;
+    if (pickingTarget.width !== w || pickingTarget.height !== h) {
+      pickingTarget.setSize(w, h);
+    }
+
+    // Render picking pass with transparent clear so background pixels have alpha=0
+    const prevClearColor = new Color();
+    const prevClearAlpha = renderer.getClearAlpha();
+    renderer.getClearColor(prevClearColor);
+    renderer.setClearColor(0x000000, 0);
+    renderer.setRenderTarget(pickingTarget);
+    renderer.render(pickingScene, camera);
+    renderer.setRenderTarget(null);
+    renderer.setClearColor(prevClearColor, prevClearAlpha);
+
+    // Convert CSS client coordinates to render target pixel coordinates
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = w / rect.width;
+    const scaleY = h / rect.height;
+    const pixelX = Math.floor((clientX - rect.left) * scaleX);
+    const pixelY = Math.floor((clientY - rect.top) * scaleY);
+    const readY = h - pixelY - 1; // WebGL origin is bottom-left
+
+    // Read back the single pixel under the cursor
+    // readRenderTargetPixelsAsync returns a typed array (WebGPU renderer API)
+    const pixelBuffer = await renderer.readRenderTargetPixelsAsync(pickingTarget, pixelX, readY, 1, 1);
+
+    if (pixelBuffer[3] === 0) return null; // transparent = background
+
+    // Decode 24-bit instance ID from RGB channels
+    const instanceId = pixelBuffer[0] + pixelBuffer[1] * 256 + pixelBuffer[2] * 65536;
+    if (instanceId === 0) return null;
+
+    // Find which shape owns this instanceId
+    for (const [shapeId, shapeMap] of group.instancesByShape) {
+      if (shapeMap.has(instanceId)) {
+        return { shapeId, instanceId };
+      }
+    }
+    return null;
+  }
+
+  // Expose a setOrigin method to set the group's position
+  function setOrigin(vec3) {
+    originGroup.position.copy(vec3);
+  }
+
+  return {
+    registerSymmetryGroup,
+    registerStyle,
+    registerShape,
+    registerOutline,
+    registerColor,
+    switchSymmetryGroup,
+    switchStyle,
+    setOutlinesVisible,
+    setDiscardInactiveShaders,
+    addInstance,
+    removeInstance,
+    removeAllInstances,
+    clearActiveInstances,
+    setInstanceHighlight,
+    clearHighlights,
+    getGroupIds,
+    getActiveGroupId,
+    getActiveGroup,
+    listShapeKeys,
+    pickAt,
+    setOrigin,
+    originGroup,
+  };
+}

--- a/online/src/viewer/context/webxr.jsx
+++ b/online/src/viewer/context/webxr.jsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, Show, createResource, createContext, useContext, } from "solid-js";
+import { lazy, Suspense, Show, createContext, useContext, } from "solid-js";
 
 import { createT } from 'solid-three';
 import { Group } from "three";
@@ -42,7 +42,7 @@ export const WebXRSupport = (props) =>
       </T.Group>
       {/* Having this Suspense inside the T.Group was causing a weird scaling issue when XR is supported */}
       <Suspense>
-        <Show when={xrSupported()}>
+        <Show when={props.xrSupported && props.xrSupported()}>
           <StartXRButton getRootGroup={() => originGroup} trackball={trackball} />
         </Show>
       </Suspense>

--- a/online/src/viewer/context/webxr.jsx
+++ b/online/src/viewer/context/webxr.jsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, Show, createContext, useContext, } from "solid-js";
+import { lazy, Suspense, Show, createContext, createSignal, useContext, } from "solid-js";
 
 import { createT } from 'solid-three';
 import { Group } from "three";
@@ -8,18 +8,33 @@ import { useCamera } from "./camera.jsx";
 export const WebXRSupport = (props) =>
 {
   const { globalScale } = useCamera();
+  // originGroup needs to be BOTH a real JSX-nested <T.Group> (so children declared here --
+  // the camera, TrackballControls, Labels, ShapedGeometry -- compose into it the normal
+  // solid-three way) AND imperatively reachable by code that isn't part of that JSX tree
+  // (XRGripToMove/XRScaling in src/xr/, and SymmetryGeometry, which builds its own Three.js
+  // objects outside solid-three's reconciler). Those two requirements are in tension:
+  // solid-three constructs a <T.*> element's underlying instance lazily, behind an internal
+  // memo forced only when something reads it (inside a createRenderEffect) -- so there is no
+  // point at which "the group exists" is synchronously true relative to a sibling or
+  // descendant component's own setup code. `originGroupReady`, a signal set from the group's
+  // ref callback, is the correct way to bridge that: consumers that need the group at their
+  // own setup time (SymmetryGeometry) gate on the signal; consumers that only need it lazily,
+  // well after mount (XRGripToMove etc., inside onViewerStart/frame callbacks -- see
+  // getRootGroup below) can keep reading the plain `originGroup` variable directly.
   let originGroup = null;
   let trackball = null;
 
-  const setTrackball = (tb) => { 
+  const [ originGroupReady, setOriginGroupReady ] = createSignal( null );
+  const captureOriginGroup = ( g ) => {
+    originGroup = g;
+    setOriginGroupReady( g );
+  };
+
+  const setTrackball = (tb) => {
     trackball = tb;
   };
 
   const StartXRButton = lazy(() => import( "../../xr/index.jsx" ));
-
-  const checkXRSupport = async () => typeof navigator.xr === "object" && navigator.xr && "isSessionSupported" in navigator.xr && await navigator.xr.isSessionSupported( 'immersive-ar' );
-
-  const [xrSupported] = createResource( checkXRSupport );
 
   const setRootScene = ( scene ) =>
   {
@@ -35,8 +50,8 @@ export const WebXRSupport = (props) =>
 
   return (
     <>
-      <T.Group ref={originGroup} scale={globalScale} >
-        <WebXRContext.Provider value={ { setRootScene, setTrackball, } }>
+      <T.Group ref={captureOriginGroup} scale={globalScale} >
+        <WebXRContext.Provider value={ { setRootScene, setTrackball, originGroupReady, } }>
           {props.children}
         </WebXRContext.Provider>
       </T.Group>

--- a/online/src/viewer/geometry.jsx
+++ b/online/src/viewer/geometry.jsx
@@ -116,6 +116,66 @@ const centroid = vertices =>
   return { x: sx/num, y: sy/num, z: sz/num };
 }
 
+// Builds a triangulated (or polygon-fan) BufferGeometry for a shape, decoupled from
+// SolidJS so it can be reused outside a reactive/component context (e.g. by a
+// symmetry renderer that owns its geometries imperatively).
+export const buildShapeGeometry = ( shape, polygons ) =>
+{
+  // TODO: use indexed vertices, if I can understand how to do normals
+  const { vertices, faces } = shape;
+  const computeNormal = ( [ v0, v1, v2 ] ) => {
+    const e1 = new Vector3().subVectors( v1, v0 )
+    const e2 = new Vector3().subVectors( v2, v0 )
+    return new Vector3().crossVectors( e1, e2 ).normalize()
+  }
+  let positions = [];
+  let normals = [];
+  faces.forEach( face => {
+    const corners = face.vertices.map( i => vertices[ i ] )
+    const { x:nx, y:ny, z:nz } = computeNormal( corners )
+    const addVertex = ( { x, y, z } ) =>
+    {
+      positions.push( x, y, z );
+      normals.push( nx, ny, nz )
+    }
+    if ( polygons ) {
+      for (let index = 0; index < corners.length-2; index++) {
+        addVertex( corners[ 0 ] );
+        addVertex( corners[ (index+1) % corners.length ] );
+        addVertex( corners[ (index+2) % corners.length ] );
+      }
+    } else {
+      corners.forEach( addVertex );
+    }
+  } );
+  const geometry = new BufferGeometry();
+  geometry.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
+  geometry.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+  geometry.computeBoundingSphere();
+  geometry.shapeCentroid = centroid( vertices );
+  return geometry;
+}
+
+// Builds a wireframe (edge) BufferGeometry for a shape's outline, decoupled from SolidJS.
+export const buildOutlineGeometry = ( shape ) =>
+{
+  const { vertices, faces } = shape;
+  let positions = [];
+  vertices .map( ( { x, y, z } ) => positions.push( x, y, z ) );
+  let indices = [];
+  faces.forEach( face => {
+    for (let i = 0; i < face.vertices.length; i++) {
+      indices .push( face.vertices[ i ] );
+      indices .push( face.vertices[ (i+1) % face.vertices.length ] );
+    }
+  } );
+  const geometry = new BufferGeometry();
+  geometry .setIndex( indices );
+  geometry .setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
+  geometry .computeBoundingSphere();
+  return geometry;
+}
+
 const InstancedShape = ( props ) =>
 {
   const { scene } = useScene();
@@ -123,62 +183,18 @@ const InstancedShape = ( props ) =>
 
   const geometry = createMemo( () =>
   {
-    // TODO: use indexed vertices, if I can understand how to do normals
-    const { vertices, faces } = props.shape;
-    const computeNormal = ( [ v0, v1, v2 ] ) => {
-      const e1 = new Vector3().subVectors( v1, v0 )
-      const e2 = new Vector3().subVectors( v2, v0 )
-      return new Vector3().crossVectors( e1, e2 ).normalize()
-    }
-    let positions = [];
-    let normals = [];
-    faces.forEach( face => {
-      const corners = face.vertices.map( i => vertices[ i ] )
-      const { x:nx, y:ny, z:nz } = computeNormal( corners )
-      const addVertex = ( { x, y, z } ) =>
-      {
-        positions.push( x, y, z );
-        normals.push( nx, ny, nz )
-      }
-      if ( scene.polygons ) {
-        for (let index = 0; index < corners.length-2; index++) {
-          addVertex( corners[ 0 ] );
-          addVertex( corners[ (index+1) % corners.length ] );
-          addVertex( corners[ (index+2) % corners.length ] );
-        }  
-      } else {
-        corners.forEach( addVertex );
-      }
-    } );
-    const geometry = new BufferGeometry();
-    geometry.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
-    geometry.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-    geometry.computeBoundingSphere();
-    geometry.shapeCentroid = centroid( vertices );
+    const geometry = buildShapeGeometry( props.shape, scene.polygons );
     onCleanup( () => geometry.dispose() );
     return geometry;
   } );
 
   const outlineGeometry = createMemo( () =>
   {
-    const { vertices, faces } = props.shape;
-    let positions = [];
-    vertices .map( ( { x, y, z } ) => positions.push( x, y, z ) );
-    let indices = [];
-    faces.forEach( face => {
-      for (let i = 0; i < face.vertices.length; i++) {
-        indices .push( face.vertices[ i ] );
-        indices .push( face.vertices[ (i+1) % face.vertices.length ] );
-      }
-    } );
-    const geometry = new BufferGeometry();
-    geometry .setIndex( indices );
-    geometry .setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
-    geometry .computeBoundingSphere();
+    const geometry = buildOutlineGeometry( props.shape );
     onCleanup( () => geometry.dispose() );
     return geometry;
   } );
-  
+
   return (
     <>
       <For each={props.shape.instances}>{ instance =>

--- a/online/src/viewer/index.jsx
+++ b/online/src/viewer/index.jsx
@@ -73,7 +73,7 @@ const SceneViewer = ( props ) =>
             TODO: refactor more for use in VRML and glTF, where there is no scene context.
           */}
           <Show when={scene} fallback={props.children}>
-            <SceneCanvas id='scene-canvas' height={props.height} width={props.width} >
+            <SceneCanvas symmetryRenderer={false} id='scene-canvas' height={props.height} width={props.width} >
               {props.children3d}
             </SceneCanvas>
           </Show>

--- a/online/src/viewer/labels.jsx
+++ b/online/src/viewer/labels.jsx
@@ -1,11 +1,25 @@
 
-import { createEffect, onMount } from "solid-js";
+import { createEffect, onCleanup, onMount } from "solid-js";
 import { useFrame, useThree } from 'solid-three';
 import { CSS2DObject, CSS2DRenderer } from "three-stdlib";
 
 export const Labels = (props) =>
 {
-  const { scene, camera, canvas } = useThree();
+  // useThree() is called once here, but .scene/.camera are live getters on the returned
+  // object (cameraStack.peek() ?? camera() -- see solid-three's source) -- destructuring
+  // captures whatever they return at THIS instant, not a live reference. ControlledCamera
+  // (perspectivecamera.jsx/orthographiccamera.jsx) registers the real camera via
+  // setCamera(cam) sometime after mount; if that happens after this destructure runs,
+  // a destructured `camera` binding here would be permanently stuck on solid-three's
+  // fallback default camera (which sits at the origin), even though the actual WebGL
+  // render -- which re-reads the getter fresh every frame internally -- uses the correct,
+  // repositioned one. Symptom (found the hard way): the 3D scene renders correctly, but
+  // CSS2DRenderer.render(scene, camera) with a stale camera projects labels against a
+  // camera sitting at/near the geometry itself -- degenerate projection math, labels
+  // silently get display:none (fail the [-1,1] clip-space z check) with no error anywhere.
+  // Fixed by reading three.camera fresh inside useFrame instead of destructuring it above.
+  const three = useThree();
+  const { scene, canvas } = three;
 
   let labelRenderer;
   onMount( () => {
@@ -27,7 +41,7 @@ export const Labels = (props) =>
   } );
 
   useFrame( () => {
-    labelRenderer .render( scene, camera );
+    labelRenderer .render( scene, three.camera );
   })
 
   return null;
@@ -35,7 +49,7 @@ export const Labels = (props) =>
 
 export const Label = (props) =>
 {
-  let label;  
+  let label;
   onMount( () => {
     const elem = document .createElement( 'div' );
     elem.className = 'vzome-label';
@@ -44,6 +58,23 @@ export const Label = (props) =>
     label = new CSS2DObject( elem );
     props.parent .add( label );
   });
+
+  // props.parent is a <T.Mesh> managed by solid-three's own scene-graph reconciler
+  // (see Instance in geometry.jsx), which automatically detaches meshes it created from
+  // their own parent on unmount -- but `label` was added to that mesh *imperatively*
+  // (props.parent.add(label) above), outside solid-three's JSX-child tracking, so that
+  // automatic cleanup has no knowledge of it. Without this, switching away from a scene
+  // that had a labeled instance unmounts <Instance> (and detaches its mesh from the scene
+  // graph), but `label` -- still a child of that now-orphaned, detached mesh -- keeps
+  // existing with a matrixWorld that's simply never recomputed or traversed again.
+  // Symptom (found the hard way): the label doesn't disappear, it freezes in place on
+  // screen at wherever it last was, because CSS2DRenderer.render()'s traversal starts
+  // from the live scene and can no longer reach it, so it never touches (or hides) that
+  // DOM element again. Removing it here (rather than leaving it to hang off an orphaned
+  // mesh) also fires CSS2DObject's own "removed" event listener, which detaches the DOM
+  // element automatically (see three-stdlib's CSS2DRenderer.js) -- no manual DOM cleanup
+  // needed, matching the pattern already used for this in SymmetryGeometry's own labels.
+  onCleanup( () => label?.parent?.remove( label ) );
 
   createEffect( () => {
     const { x, y, z } = props.position;

--- a/online/src/viewer/ltcanvas.jsx
+++ b/online/src/viewer/ltcanvas.jsx
@@ -1,5 +1,6 @@
 
-import { Color, Scene, WebGLRenderer, Group, Mesh, AmbientLight, DirectionalLight } from "three";
+import { Color, Scene, Group, Mesh, AmbientLight, DirectionalLight } from "three";
+import { WebGPURenderer } from 'three/webgpu';
 import { createRenderEffect, onMount, For, Show } from "solid-js";
 import { createElementSize } from "@solid-primitives/resize-observer";
 
@@ -113,7 +114,7 @@ export const LightedTrackballCanvas = ( props ) =>
 
   const makeCustomRenderer = ( canvas ) =>
   {
-    const renderer = new WebGLRenderer({
+    const renderer = new WebGPURenderer({
       powerPreference: "high-performance",
       canvas,
       antialias: true,

--- a/online/src/viewer/ltcanvas.jsx
+++ b/online/src/viewer/ltcanvas.jsx
@@ -1,10 +1,10 @@
 
 import { Color, Scene, Group, Mesh, AmbientLight, DirectionalLight } from "three";
 import { WebGPURenderer } from 'three/webgpu';
-import { createRenderEffect, onMount, For, Show } from "solid-js";
+import { createRenderEffect, createResource, createSignal, onMount, For, Show, Suspense } from "solid-js";
 import { createElementSize } from "@solid-primitives/resize-observer";
 
-import { Canvas, createT, useFrame } from 'solid-three';
+import { Canvas, createT, createXR, useFrame } from 'solid-three';
 const T = createT({ Group, Mesh, AmbientLight, DirectionalLight });
 
 import { TrackballControls } from "./trackballcontrols.jsx";
@@ -72,6 +72,19 @@ export const LightedTrackballCanvas = ( props ) =>
   const canvasSize = () => size;
   const { labels } = useViewer();
 
+  const xr = createXR();
+  const [xrSupported] = createResource( () => xr.isSupported( 'immersive-ar' ) );
+
+  // connectRef captures the canvas DOM element (via ctx.gl.domElement) and wires createXR.
+  // Canvas must be rendered inside <xr.Provider> (not pre-assigned) so that useXR() in
+  // Canvas children can find the provider context.
+  const [canvasEl, setCanvasEl] = createSignal( null );
+  size = createElementSize( canvasEl );
+  const connectRef = ( ctx ) => {
+    setCanvasEl( ctx.gl.domElement );
+    return xr.connect( ctx );
+  };
+
   const [ tool ] = useInteractionTool();
 
   const handlePointerMove = ( e ) =>
@@ -120,48 +133,69 @@ export const LightedTrackballCanvas = ( props ) =>
       antialias: true,
       alpha: true,
       preserveDrawingBuffer: true,
+      forceWebGL: true,
     });
     // renderer.xr.enabled = true;
     return renderer;
   }
 
-  const canvas =
-    <Canvas class='canvas3d' dpr={ window.devicePixelRatio } gl={makeCustomRenderer}
-        style={{
-          height: props.height ?? "100%",
-          width: props.width ?? "100%",
-          display: 'flex',
-        }}
-        frameloop="always" onClickMissed={handlePointerMissed} >
-      <WebXRSupport>
-
-        { /* This should add the camera to the scene so that the lights move with the camera,
-              but it apparently does not. */ }
-        <ControlledCamera aspect={aspect()} >
-          <Lighting />
-        </ControlledCamera>
-
-        <TrackballControls rotationOnly={props.rotationOnly}
-          rotateSpeed={props.rotateSpeed} zoomSpeed={props.zoomSpeed} panSpeed={props.panSpeed} />
-
-        {props.children}
-
-        {labels && labels() && <Labels size={canvasSize()} />}
-
-      </WebXRSupport>
-    </Canvas>;
-  
-  size = createElementSize( canvas );
-
   createRenderEffect( () => {
-    canvas.style.cursor = (tool ?.cursor()) || 'auto';
-  });
-  
-  onMount( () => {
-    // canvas .addEventListener( 'pointermove', handlePointerMove );
-    canvas .addEventListener( 'pointerup', handlePointerUp );
-    canvas .addEventListener( 'wheel', handleWheel );
+    const el = canvasEl();
+    if ( el ) el.style.cursor = (tool ?.cursor()) || 'auto';
   });
 
-  return canvas;
+  onMount( () => {
+    const el = canvasEl();
+    if ( el ) {
+      // el.addEventListener( 'pointermove', handlePointerMove );
+      el.addEventListener( 'pointerup', handlePointerUp );
+      el.addEventListener( 'wheel', handleWheel );
+    }
+  });
+
+  return (
+    <xr.Provider>
+      <div style={{ position: 'relative', height: props.height ?? "100%", width: props.width ?? "100%" }}>
+        <Canvas ref={connectRef} class='canvas3d' dpr={ window.devicePixelRatio } gl={makeCustomRenderer}
+            style={{
+              height: "100%",
+              width: "100%",
+              display: 'flex',
+            }}
+            frameloop="always" onClickMissed={handlePointerMissed} >
+          <WebXRSupport xrSupported={xrSupported}>
+
+            { /* This should add the camera to the scene so that the lights move with the camera,
+                  but it apparently does not. */ }
+            <ControlledCamera aspect={aspect()} >
+              <Lighting />
+            </ControlledCamera>
+
+            <TrackballControls rotationOnly={props.rotationOnly}
+              rotateSpeed={props.rotateSpeed} zoomSpeed={props.zoomSpeed} panSpeed={props.panSpeed} />
+
+            {props.children}
+
+            {labels && labels() && <Labels size={canvasSize()} />}
+
+          </WebXRSupport>
+        </Canvas>
+        <Suspense>
+          <Show when={xrSupported()}>
+            <button
+              style={{
+                position: 'absolute', bottom: '20px', left: '50%', transform: 'translateX(-50%)',
+                padding: '12px 24px', 'border-radius': '4px', border: 'none',
+                background: 'rgba(0,0,0,0.7)', color: 'white', cursor: 'pointer',
+                'font-size': '13px', 'font-family': 'sans-serif',
+              }}
+              onClick={() => xr.enter( 'immersive-ar', { optionalFeatures: ['local-floor', 'hand-tracking'] } )}
+            >
+              START AR
+            </button>
+          </Show>
+        </Suspense>
+      </div>
+    </xr.Provider>
+  );
 }

--- a/online/src/viewer/scenecanvas.jsx
+++ b/online/src/viewer/scenecanvas.jsx
@@ -1,6 +1,7 @@
 
 import { LightedTrackballCanvas } from './ltcanvas.jsx';
 import { ShapedGeometry } from './geometry.jsx';
+import { SymmetryGeometry } from './symmetry-geometry.jsx';
 import { mergeProps } from 'solid-js';
 import { useScene } from './context/scene.jsx';
 
@@ -15,7 +16,10 @@ const SceneCanvas = ( props ) =>
         height={props.height} width={props.width} rotationOnly={props.rotationOnly}
         rotateSpeed={props.rotateSpeed} zoomSpeed={props.zoomSpeed} panSpeed={props.panSpeed} >
       <Show when={ () => props.scene?.shapes }>
-        <ShapedGeometry embedding={scene?.embedding} shapes={scene?.shapes} />
+        { props.symmetryRenderer
+          ? <SymmetryGeometry embedding={scene?.embedding} shapes={scene?.shapes} orientations={scene?.orientations} polygons={scene?.polygons} />
+          : <ShapedGeometry embedding={scene?.embedding} shapes={scene?.shapes} />
+        }
       </Show>
       {props.children}
     </LightedTrackballCanvas>

--- a/online/src/viewer/symmetry-geometry.jsx
+++ b/online/src/viewer/symmetry-geometry.jsx
@@ -1,0 +1,298 @@
+
+import { createEffect, createSignal, Show } from "solid-js";
+import { Matrix4, Vector3 } from "three";
+import { CSS2DObject } from "three-stdlib";
+
+import { createSymmetryRenderer } from "./context/symmetry-renderer.js";
+import { buildShapeGeometry, buildOutlineGeometry } from "./geometry.jsx";
+import { useCamera } from "./context/camera.jsx";
+import { useWebXRClient } from "./context/webxr.jsx";
+
+const GROUP_ID = "default";
+const STYLE_ID = "default";
+
+// ShapedGeometry's InstancedShape (geometry.jsx) shows selection as a binary emissive
+// swap -- "#c8c8c8" or "black" -- not a graded intensity. symmetry-renderer.js's
+// highlightIntensity attribute feeds emissiveNode = white * highlightIntensity (see
+// createMaterialForGroup), so 0xc8/0xff match the same visual result; 1.0 would be pure
+// white, brighter than ShapedGeometry's highlight.
+const SELECTED_HIGHLIGHT = 0xc8 / 0xff;
+
+// The worker sends each orientation as a flat 16-element array (see
+// vzome-worker-static.js), but registerSymmetryGroup wants THREE.Matrix4 instances.
+// Use .set(...) -- not .fromArray() -- to match how geometry.jsx's Instance interprets
+// the very same rotation arrays: m.set(...props.rotation), no transpose.
+const toMatrix4 = flat => new Matrix4().set( ...flat );
+
+// Instance positions arrive as [x, y, z] arrays (that's what T.Group position={...}
+// accepts directly in geometry.jsx's Instance), but the renderer reads position.x/y/z.
+const toVector3 = ( [ x, y, z ] ) => new Vector3( x, y, z );
+
+// Rendering-only replacement for ShapedGeometry, built on createSymmetryRenderer's
+// GPU-instanced meshes instead of one Three.js object per ball/strut. Selection highlight
+// (Phase 6) and labels (Phase 7) are implemented; no picking/interaction (Phase 5) --
+// deliberately deferred, this component is meant for viewer-only (non-editing) use cases
+// for now, see symmetry-renderer-plan.md and symmetry-renderer-status.md.
+export const SymmetryGeometry = ( props ) =>
+{
+  const { originGroupReady } = useWebXRClient();
+
+  // SymmetryGeometry builds its Three.js objects imperatively (createSymmetryRenderer),
+  // outside solid-three's reconciler, but still needs to parent under WebXRSupport's
+  // originGroup (webxr.jsx) -- that's the group XRGripToMove/XRScaling reposition and
+  // rescale during an XR session, so content attached under it moves/resizes correctly with
+  // the viewer; content attached elsewhere (e.g. straight to the scene) does not, and sits
+  // stranded at whatever transform it had before entering XR. originGroup only exists as a
+  // signal, not a synchronously-readable value, because solid-three constructs a <T.*>
+  // element's instance lazily; wait for it here before creating anything that needs it.
+  return (
+    <Show when={ originGroupReady() }>
+      { parent => <SymmetryGeometryImpl { ...props } parent={ parent() } /> }
+    </Show>
+  );
+};
+
+// Split out from SymmetryGeometry purely so the group-dependent setup below (creating the
+// renderer, registering effects) only ever runs once parent is a real Object3D.
+const SymmetryGeometryImpl = ( props ) =>
+{
+  const { state: cameraState } = useCamera();
+
+  const renderer = createSymmetryRenderer( props.parent );
+
+  const [ groupReady, setGroupReady ] = createSignal( false );
+  const registeredShapeIds = new Set();
+  const colorIndexByCss = new Map();
+
+  // Phase 6 (selection highlight): keyed by vZome instance id (props.id on each entry in
+  // shape.instances), not by renderer instanceId directly, because the instance-registration
+  // effect below fully tears down and re-adds every instance (removeAllInstances + re-add)
+  // on any props.shapes change -- including a pure SELECTION_TOGGLED, since scene.jsx
+  // replaces the whole shapes tree with new object/array identities rather than mutating a
+  // fine-grained per-instance store (see symmetry-renderer-status.md's Phase 6 section for
+  // why this wasn't also fixed here). So the renderer's own instanceId is NOT stable across
+  // a selection change and can't be cached long-term; what IS stable is the vZome instance's
+  // own id, which this map is keyed by, refreshed every time the registration effect runs.
+  let instanceRefById = new Map(); // vZome instance id -> { shapeId, instanceId }
+  let lastSelectedById = new Map(); // vZome instance id -> boolean, to diff against
+
+  // Phase 7 (labels): retained from the group-registration effect below so the label-
+  // positioning math (see the instance-registration effect) can replicate the GPU vertex
+  // shader's rotatedPositionNode transform (orientation * localVertex + instanceTranslation,
+  // see createMaterialForGroup in symmetry-renderer.js) once per label in JS, instead of
+  // per-vertex on the GPU -- there is no per-instance mesh for a <Label> to be parented to
+  // and inherit that transform from "for free" the way ShapedGeometry's Instance gets it.
+  let orientationMatrices = [];
+  // Shape centroids (local-space, one per shape, NOT per instance) are attached to the
+  // BufferGeometry returned by buildShapeGeometry as .shapeCentroid (see geometry.jsx) but
+  // only at registration time; retained here since registerShape doesn't hand it back.
+  const shapeCentroidById = new Map(); // shapeId -> {x,y,z} (local space, from buildShapeGeometry)
+  let labelById = new Map(); // vZome instance id -> CSS2DObject, currently attached to originGroup
+
+  const colorIndexFor = ( cssColor ) =>
+  {
+    let index = colorIndexByCss.get( cssColor );
+    if ( index === undefined ) {
+      index = renderer.registerColor( cssColor );
+      colorIndexByCss.set( cssColor, index );
+    }
+    return index;
+  }
+
+  // renderer.originGroup is now a child of WebXRSupport's own originGroup (props.parent
+  // above), which already supplies globalScale -- and, during an XR session,
+  // position/quaternion/scale for viewer-relative placement, grip-drag, and two-handed
+  // resize -- via its own default (auto-updating) matrix. So this group's .matrix only
+  // needs to encode the embedding transform, nothing more.
+  //
+  // originGroup.matrixAutoUpdate is false (see symmetry-renderer.js), so .matrix must be
+  // built explicitly here -- setting .position/.quaternion/.scale alone does NOT work,
+  // silently: with matrixAutoUpdate off, nothing ever recomputes .matrix from those
+  // properties. (An earlier version of this effect had to premultiply a manual globalScale
+  // in here too, back when originGroup was parented directly to the raw scene instead of to
+  // WebXRSupport's group -- see git history/symmetry-renderer-status.md if that context is
+  // needed again; it does not apply with the current parenting.)
+  createEffect( () => {
+    const m = new Matrix4();
+    if ( props.embedding ) {
+      m.set( ...props.embedding );
+      m.transpose();
+    }
+    renderer.originGroup.matrix.copy( m );
+  } );
+
+  createEffect( () => {
+    const shapes = props.shapes || {};
+    const hasInstances = Object.values( shapes ) .some( shape => shape.instances.length > 0 );
+
+    if ( groupReady() || ! props.orientations || props.orientations.length === 0 || ! hasInstances )
+      return;
+
+    // The renderer's material/shader is built when the group becomes active, and it
+    // indexes into the color palette unconditionally -- so at least one color must be
+    // registered before switchSymmetryGroup(), or that lookup dereferences a null palette.
+    for ( const shape of Object.values( shapes ) ) {
+      for ( const instance of shape.instances ) {
+        colorIndexFor( instance.color );
+      }
+    }
+
+    orientationMatrices = props.orientations.map( toMatrix4 );
+    renderer.registerSymmetryGroup( GROUP_ID, orientationMatrices );
+    renderer.registerStyle( GROUP_ID, STYLE_ID );
+    renderer.switchSymmetryGroup( GROUP_ID );
+    setGroupReady( true );
+  } );
+
+  createEffect( () => {
+    if ( ! groupReady() )
+      return;
+    const shapes = props.shapes || {};
+
+    for ( const [ shapeId, shape ] of Object.entries( shapes ) ) {
+      if ( ! registeredShapeIds.has( shapeId ) ) {
+        // Phase 4 (polygon mode) note: there is only ever ONE fill geometry per shape, always
+        // built with polygons=true (the fan triangulation). buildShapeGeometry's polygons=false
+        // path is NOT a valid alternate "style" -- for any face with more than 3 vertices
+        // (pentagons, hexagons, ...) it pushes that face's raw corner list straight into a
+        // TRIANGLES draw call with no triangulation at all, producing garbage: wrong vertex
+        // groupings, wrong winding, geometry that has nothing to do with the actual face.
+        // ShapedGeometry (geometry.jsx's InstancedShape) never hits this because it builds
+        // exactly one geometry, always from the *live* scene.polygons value, so it only takes
+        // the false branch when the whole scene is actually in non-polygon mode. A first
+        // attempt here pre-built both branches as two switchable "styles" so toggling would
+        // need no lazy rebuild -- that produced exactly this scattered-triangle corruption the
+        // moment any shape had a non-triangular face. The fan triangulation (polygons=true) is
+        // geometrically identical to the non-fan path for already-triangular faces and correct
+        // for everything else, so using it unconditionally is always safe. scene.polygons still
+        // matters, just not here -- see the outline-visibility effect below.
+        const geometry = buildShapeGeometry( shape, true );
+        renderer.registerShape( GROUP_ID, STYLE_ID, shapeId, geometry );
+        renderer.registerOutline( GROUP_ID, shapeId, buildOutlineGeometry( shape ) );
+        shapeCentroidById.set( shapeId, geometry.shapeCentroid );
+        registeredShapeIds.add( shapeId );
+      }
+    }
+
+    for ( const shapeId of registeredShapeIds ) {
+      renderer.removeAllInstances( STYLE_ID, shapeId );
+    }
+
+    // Every removeAllInstances above invalidates all previously-returned renderer
+    // instanceIds for this group, so instanceRefById (and lastSelectedById, so removed
+    // instances' ids don't linger forever) are rebuilt from scratch here rather than
+    // updated incrementally -- see the comment where they're declared.
+    const nextInstanceRefById = new Map();
+    const nextSelectedById = new Map();
+    // Phase 7: labels are rebuilt in lockstep with instances for the same reason -- there is
+    // no cheaper "just this one instance changed" path today (see the Phase 6 comment on
+    // instanceRefById), so every registration cycle recomputes every label from scratch.
+    // Existing CSS2DObjects are reused where the vZome instance id is unchanged (skip DOM
+    // element churn on every keystroke-triggered rebuild); ones for ids no longer present are
+    // removed from originGroup, which -- per CSS2DObject's own "removed" listener -- also
+    // detaches its DOM element (see three-stdlib's CSS2DRenderer.js).
+    const nextLabelById = new Map();
+
+    for ( const [ shapeId, shape ] of Object.entries( shapes ) ) {
+      const centroid = shapeCentroidById.get( shapeId );
+      for ( const instance of shape.instances ) {
+        const selected = !! instance.selected;
+        const instanceId = renderer.addInstance( STYLE_ID, shapeId, {
+          position: toVector3( instance.position ),
+          // scene.jsx uses orientation === -1 to mean "no orientation, use identity"
+          // (see its own `(orientation < 0) ? 0 : orientation` guard), but
+          // normalizeOrientationIndex() in symmetry-renderer.js throws on negative
+          // indices instead of tolerating them, so clamp here to match.
+          orientationIndex: instance.orientation < 0 ? 0 : instance.orientation,
+          colorIndex: colorIndexFor( instance.color ),
+          // Set the initial highlight directly (rather than relying on the separate
+          // Phase 6 diff effect below to catch up) so a selected instance never flashes
+          // unhighlighted for a frame right after a rebuild.
+          highlight: selected ? SELECTED_HIGHLIGHT : 0,
+        } );
+        nextInstanceRefById.set( instance.id, { shapeId, instanceId } );
+        nextSelectedById.set( instance.id, selected );
+
+        if ( instance.label ) {
+          // Same transform the GPU vertex shader applies per-vertex (rotatedPositionNode in
+          // symmetry-renderer.js's createMaterialForGroup): orientation * localVertex +
+          // instanceTranslation. Here localVertex is the shape's centroid (not a real
+          // vertex, but the same math applies) and the result is expressed in originGroup's
+          // own local space, matching where instance positions are already expressed --
+          // exactly the space CSS2DObjects parented directly to originGroup need.
+          const orientationIndex = instance.orientation < 0 ? 0 : instance.orientation;
+          const worldPos = new Vector3( centroid.x, centroid.y, centroid.z )
+            .applyMatrix4( orientationMatrices[ orientationIndex ] )
+            .add( toVector3( instance.position ) );
+
+          let label = labelById.get( instance.id );
+          if ( ! label ) {
+            const elem = document.createElement( 'div' );
+            elem.className = 'vzome-label';
+            elem.id = `vzome-label-${instance.label}`;
+            elem.textContent = instance.label;
+            label = new CSS2DObject( elem );
+            renderer.originGroup.add( label );
+          }
+          label.position.copy( worldPos );
+          nextLabelById.set( instance.id, label );
+          labelById.delete( instance.id );
+        }
+      }
+    }
+
+    // Whatever's left in labelById belonged to instances not seen in this pass (removed, or
+    // lost their label) -- detach them; CSS2DObject's "removed" listener cleans up the DOM.
+    for ( const staleLabel of labelById.values() ) {
+      renderer.originGroup.remove( staleLabel );
+    }
+
+    instanceRefById = nextInstanceRefById;
+    lastSelectedById = nextSelectedById;
+    labelById = nextLabelById;
+  } );
+
+  // Phase 6: selection highlight. Diffs instance.selected against the last-seen value per
+  // vZome instance id and only calls setInstanceHighlight for instances whose selection
+  // actually changed, so toggling a selection stays cheap regardless of model size -- unlike
+  // the instance-registration effect above, which necessarily rebuilds everything on any
+  // props.shapes change (see the comment on instanceRefById). This effect still depends on
+  // (and therefore re-runs whenever) props.shapes changes identity, same as that one, but
+  // its own body only touches the GPU buffers for instances that actually flipped.
+  createEffect( () => {
+    if ( ! groupReady() )
+      return;
+    const shapes = props.shapes || {};
+
+    for ( const shape of Object.values( shapes ) ) {
+      for ( const instance of shape.instances ) {
+        const selected = !! instance.selected;
+        if ( lastSelectedById.get( instance.id ) === selected )
+          continue;
+        const ref = instanceRefById.get( instance.id );
+        if ( ! ref )
+          continue; // shouldn't happen: registration effect above always runs first
+        renderer.setInstanceHighlight( ref.shapeId, ref.instanceId, selected ? SELECTED_HIGHLIGHT : 0 );
+        lastSelectedById.set( instance.id, selected );
+      }
+    }
+  } );
+
+  // Phase 4: outline visibility depends on two independent things, both required:
+  // - props.polygons: whether this scene's faces are real polygon data at all (a format
+  //   capability -- older/triangles-only files have no true face edges to outline; see the
+  //   long comment above on why the fill geometry itself doesn't depend on this).
+  // - cameraState.outlines: the end user's own show/hide preference (Settings dialog's
+  //   "Outlines" switch, toggleOutlines() in context/camera.jsx), independent of and
+  //   defaulting false regardless of what the scene data supports.
+  // ShapedGeometry's InstancedShape (geometry.jsx) does not currently wire the second one up
+  // -- its showOutlines is scene.polygons alone -- so this is a real behavior improvement
+  // over it, not just parity, per explicit direction.
+  createEffect( () => {
+    if ( ! groupReady() )
+      return;
+    renderer.setOutlinesVisible( !! props.polygons && !! cameraState.outlines );
+  } );
+
+  return null;
+};

--- a/online/src/worker/vzome-worker-static.js
+++ b/online/src/worker/vzome-worker-static.js
@@ -19,7 +19,8 @@ export const DEFAULT_SNAPSHOT = -1;
 
 // Take a normalized scene and prepare it to send to the client, by
 //   resolving the shapes and snapshot
-// TODO: change the client contract to avoid sending shapes and rotation matrices all the time!
+// TODO: once SymmetryGeometry replaces ShapedGeometry, stop sending rotation
+//   matrices per-instance and have the client resolve them from orientations.
 const prepareSceneResponse = ( design, snapshot ) =>
 {
   const { embedding, polygons, snapshots, orientations, instances } = design.rendered;
@@ -33,7 +34,7 @@ const prepareSceneResponse = ( design, snapshot ) =>
     shapes[ instance.shapeId ].instances.push( { ...instance, rotation } );
   }
   const parts = createPartsList( shapes, design.wrapper?.controller?.symmController );
-  return { shapes, embedding, polygons, parts };
+  return { shapes, embedding, polygons, parts, orientations };
 }
 
 const prepareEditSceneResponse = ( design, edit, before ) =>
@@ -56,7 +57,7 @@ const prepareEditSceneResponse = ( design, edit, before ) =>
     }
     shapes[ instance.shapeId ].instances.push( { ...instance, rotation } );
   }
-  return { scene: { shapes, polygons }, edit };
+  return { scene: { shapes, polygons, orientations }, edit };
 }
 
 const fetchUrlText = async ( url ) =>

--- a/online/src/xr/grip2move.jsx
+++ b/online/src/xr/grip2move.jsx
@@ -2,7 +2,7 @@
 import { Vector3, } from "three";
 import { useThree, } from "solid-three";
 
-import { useXR, useXRControllers, xrViewerPose, } from "./manager.jsx";
+import { useXRSession, useXRControllers, xrViewerPose, } from "./manager.jsx";
 
 // ──────────────────────────────────────────────────────────────────────────────
 // XRGripToMove — contribution that lets the user grip and drag the model.
@@ -10,7 +10,7 @@ import { useXR, useXRControllers, xrViewerPose, } from "./manager.jsx";
 
 export const XRGripToMove = () =>
 {
-  const { onViewerStart, onViewerEnd, getRootGroup } = useXR();
+  const { onViewerStart, onViewerEnd, getRootGroup } = useXRSession();
   const { onGripStart, onGripEnd } = useXRControllers();
   const store = useThree();
 

--- a/online/src/xr/help.jsx
+++ b/online/src/xr/help.jsx
@@ -2,7 +2,7 @@
 import { useThree, } from "solid-three";
 import { createText } from "three-stdlib";
 
-import { useXR, useXRControllers, xrViewerPose, } from "./manager.jsx";
+import { useXRSession, useXRControllers, xrViewerPose, } from "./manager.jsx";
 
 // ──────────────────────────────────────────────────────────────────────────────
 // XRInstructionText — contribution that displays a floating text label when a
@@ -10,7 +10,7 @@ import { useXR, useXRControllers, xrViewerPose, } from "./manager.jsx";
 
 export const XRInstructionText = ( props ) =>
 {
-  const { onViewerStart, onViewerEnd } = useXR();
+  const { onViewerStart, onViewerEnd } = useXRSession();
   const { onControllerConnected, onGripStart } = useXRControllers();
   const store = useThree();
 

--- a/online/src/xr/manager.jsx
+++ b/online/src/xr/manager.jsx
@@ -1,8 +1,8 @@
 
-import { createContext, useContext, } from "solid-js";
+import { createContext, useContext, createEffect, on, } from "solid-js";
 import { Vector3, Quaternion, } from "three";
-import { ARButton, createText, XRControllerModelFactory, XRHandModelFactory, } from "three-stdlib";
-import { useThree, useFrame, } from "solid-three";
+import { createText, XRControllerModelFactory, XRHandModelFactory, } from "three-stdlib";
+import { useThree, useFrame, useXR, } from "solid-three";
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Reads the current XR viewer pose from the GL context.  Only valid to call
@@ -18,8 +18,8 @@ export const xrViewerPose = ( store ) => {
 // ──────────────────────────────────────────────────────────────────────────────
 // Context shared between XRSessionManager and its contribution subcomponents
 
-const XRContext = createContext();
-export const useXR = () => useContext(XRContext);
+const XRSessionContext = createContext();
+export const useXRSession = () => useContext(XRSessionContext);
 
 const XRControllerContext = createContext();
 export const useXRControllers = () => useContext(XRControllerContext);
@@ -44,10 +44,10 @@ export const XRSessionManager = ( props ) =>
   let _origCameraPos, _origCameraQuat;
   let _origControlsTarget;
   let needsCameraRestore = false;
-  let sessionStarted = false;
+  let sessionActivated = false;
+  let sessionInProgress = false;
+  let endSessionPending = false;
 
-  store.canvas.parentElement.appendChild( ARButton.createButton(store.gl, { optionalFeatures: ['local-floor', 'hand-tracking'] }));
-  
   const startSession = () =>
   {
     // Toggle scene background/fog and orbit trackball for AR passthrough
@@ -71,8 +71,7 @@ export const XRSessionManager = ( props ) =>
     store.camera.near = 0.01;
     store.camera.far  = 100;
     store.camera.updateProjectionMatrix();
-
-    sessionStarted = true; // useFrame will dispatch onViewerStart once xr.isPresenting is confirmed
+    sessionInProgress = true;
   };
 
   const endSession = () =>
@@ -91,15 +90,30 @@ export const XRSessionManager = ( props ) =>
     props.trackball.target.copy(_origControlsTarget);
     props.trackball.enabled = true;
 
-    sessionStarted = false;
+    sessionInProgress = false;
     for (const fn of viewerEndHandlers) fn();
     needsCameraRestore = true;
   };
 
-  store.gl.xr.addEventListener( 'sessionstart', startSession );
-  store.gl.xr.addEventListener( 'sessionend',   endSession   );
+  const { isPresenting } = useXR();
+
+  createEffect( on( isPresenting, ( presenting ) => {
+    if ( presenting ) {
+      endSessionPending = false;       // cancel any deferred end — brief interruption, session resumed
+      if ( !sessionInProgress ) {      // only start if not already in a session
+        startSession();
+        sessionActivated = true;
+      }
+    } else {
+      endSessionPending = true;        // defer to next frame; if presenting resumes, it will be cancelled
+    }
+  }, { defer: true } ) );
 
   useFrame( () => {
+    if (endSessionPending) {
+      endSessionPending = false;
+      endSession();
+    }
     if (needsCameraRestore) {
       needsCameraRestore = false;
       store.camera.updateProjectionMatrix();
@@ -107,18 +121,18 @@ export const XRSessionManager = ( props ) =>
       props.trackball.update();              // re-derives its internal state from camera
       store.gl.render( store.scene, store.camera ); // render a frame to ensure the restored camera state is visible immediately
     }
-    if ( sessionStarted && store?.gl?.xr?.isPresenting ) {
-      sessionStarted = false;
+    if ( sessionActivated ) {
+      sessionActivated = false;
       for (const fn of viewerStartHandlers) fn(); // xr camera pose is now available
     }
   });
 
   return (
-    <XRContext.Provider value={{ onViewerStart, onViewerEnd, getRootGroup: props.getRootGroup }}>
+    <XRSessionContext.Provider value={{ onViewerStart, onViewerEnd, getRootGroup: props.getRootGroup }}>
       <XRControllerManager>
         {props.children}
       </XRControllerManager>
-    </XRContext.Provider>
+    </XRSessionContext.Provider>
   );
 };
 
@@ -129,7 +143,7 @@ export const XRSessionManager = ( props ) =>
 
 export const XRControllerManager = ( props ) =>
 {
-  const { onViewerStart, onViewerEnd } = useXR();
+  const { onViewerStart, onViewerEnd } = useXRSession();
   const store = useThree();
 
   const controllerConnectedHandlers = [];

--- a/online/src/xr/scaling.jsx
+++ b/online/src/xr/scaling.jsx
@@ -1,6 +1,6 @@
 import { useThree, useFrame, } from "solid-three";
 
-import { useXR, useXRControllers, } from "./manager.jsx";
+import { useXRSession, useXRControllers, } from "./manager.jsx";
 
 // ──────────────────────────────────────────────────────────────────────────────
 // XRScaling — contribution that scales the model while both grips are squeezed.
@@ -8,7 +8,7 @@ import { useXR, useXRControllers, } from "./manager.jsx";
 
 export const XRScaling = () =>
 {
-  const { onViewerStart, onViewerEnd, getRootGroup } = useXR();
+  const { onViewerStart, onViewerEnd, getRootGroup } = useXRSession();
   const { onScaleStart, onScaleEnd, getControllerSeparation } = useXRControllers();
   const store = useThree();
 

--- a/online/src/xr/solid-three-xr.md
+++ b/online/src/xr/solid-three-xr.md
@@ -1,0 +1,104 @@
+
+Reworks solid-three's WebXR integration so the consumer owns the session
+and core stays out of the frame loop while a session presents. Continues
+#58 on top of a cleaned-up next branch.
+
+## Summary
+
+Previously core drove the WebXR loop itself: on the renderer's
+`sessionstart` it toggled `setAnimationLoop(...)` and set `xr.enabled`.
+That breaks `WebGPURenderer` — three's WebGPU `XRManager` snapshots the
+renderer's animation loop at `setSession` time, before `sessionstart`
+fires, so toggling on `sessionstart` is too late and clobbers the
+manager's own frame driver. On a Quest this surfaced as
+`gl.getContextAttributes is not a function` on the WebGPU backend, and a
+hung headset with endless "Not all layers submitted" warnings under
+`forceWebGL`. The same internal driver also caused a latent
+`frameloop="always"` + XR double-render.
+
+Core now depends only on the stable, cross-renderer contract — the
+consumer installs `setAnimationLoop(render)` before `setSession`, and
+core reads the read-only `renderer.xr.isPresenting` to yield its window
+loop while presenting, resuming via a single `sessionend` listener. No
+WebGL-vs-WebGPU branching. The session wiring then lives behind one
+small primitive so consumers can't trip the sharp edges.
+
+## What changed
+
+### `createXR()` — consumer-owned XR entry
+
+A Solid primitive called in a component body (it owns one reactive
+effect), built only on `context.gl`, `context.render`, and the
+renderer's standard `xr` event target — no core internals, no
+renderer-family branching. Members: `connect` (a cleanup-returning
+`Ref<XRContext>` for `<Canvas ref={xr.connect}>`), `enter(mode, init?)`
+/ `enter(session)`, `exit()`, `isSupported(mode)`, `isPresenting()`,
+`session()`, and `Provider`. It absorbs the three edges of the contract
+so the consumer never has to: snapshot order (`setAnimationLoop(render)`
+before `setSession`), post-exit double-drive (`setAnimationLoop(null)`
+on `sessionend`), and transient activation (`requestSession` first,
+nothing awaited before it).
+
+### `useXR()` + `createXR().Provider` — in-scene state
+
+Wrap the subtree (Canvas + its button) in `<xr.Provider>`; scene
+components read `{ isPresenting, session, exit }` with `useXR()` (which
+throws outside a provider). This serves in-world UI — e.g. a mesh whose
+`onClick` calls `exit()`, since the DOM exit button is not rendered
+while an immersive session presents. `useXR` is deliberately not the
+entry API: `use*` hooks read a provider from inside Canvas, whereas
+`createXR()` is created outside it.
+
+### Cleanup-returning refs
+
+`useRef` now runs a callback ref's returned cleanup via `onCleanup` (the
+React-19 cleanup-ref shape), and `<Canvas>`'s `ref` type is widened to
+allow it (`RefWithCleanup<T>`). This is what makes `xr.connect` a
+one-liner that returns its own disconnect.
+
+### API surface
+
+New exports: `createXR`, `useXR`, and types `XRContext` (`Pick<Context,
+"gl" | "render">`) and `XRState`. `connect` is typed `XRContext`, not
+the full `Context`, so its real dependency is explicit and any `{ gl,
+render }` works — it is tied to neither `<Canvas>` nor its ref.
+
+### Docs
+
+New API pages `create-xr.mdx` and `use-xr.mdx`; `use-three.mdx`
+documents the manual escape hatch and points at `createXR` as the
+recommended path; `canvas.mdx` documents the cleanup-returning `ref`.
+README gains `createXR`/`useXR` sections, a feature bullet, and TOC
+entries. Design specs and TDD plans live under `docs/superpowers/`.
+
+## Breaking
+
+- Removed `Context.xr` (`{ connect, disconnect }`) — XR is now
+consumer-wired (via `createXR`, or `gl.xr` directly).
+- `Context.render` signature changed (`delta` → `timestamp`, added
+`frame`) so the `XRFrame` flows through to `useFrame`.
+
+## Manual escape hatch
+
+`createXR` is the recommended path, but the raw contract is small enough
+to wire by hand for both renderers: `gl.setAnimationLoop(render)` before
+`gl.xr.setSession(session)` (with `gl.xr.enabled = true`), and
+`gl.setAnimationLoop(null); gl.xr.enabled = false` to exit. For XR with
+`WebGPURenderer` on three ≤ r184, construct it with `{ forceWebGL: true
+}` (WebGPU-backend XR is unreleased upstream).
+
+## Test plan
+
+- `pnpm test` — 175 passed, 2 todo (12 files): core yields the window
+loop while presenting and resumes on `sessionend`; core leaves
+`gl.xr.enabled` alone; `XRFrame` forwarded to `useFrame`; `createXR`
+state & wiring (snapshot order, post-exit loop-null, renderer-swap
+re-attach, no-crash on an `xr` lacking `addEventListener`,
+connect/disconnect); `enter` (request-first, provided-session overload,
+error paths); `exit`/`isSupported`; `useXR` throws outside provider;
+`Provider` bridges state across the Canvas boundary; cleanup-returning
+`useRef`.
+- `pnpm lint:types` — clean
+- `pnpm lint:code` — clean
+- Pending: on-device `WebGPURenderer({ forceWebGL: true })` + WebXR on
+Quest 3 (the original report).

--- a/online/yarn.lock
+++ b/online/yarn.lock
@@ -2944,9 +2944,9 @@ solid-prevent-scroll@^0.1.4:
   dependencies:
     "@corvu/utils" "~0.3.1"
 
-"solid-three@https://pkg.pr.new/solid-three@4fe9e16":
+"solid-three@https://pkg.pr.new/solid-three@8348eb8":
   version "0.3.0-next.12"
-  resolved "https://pkg.pr.new/solid-three@4fe9e16#2ecfc9fbfab1409a2527a7dca4d972bda43ec581"
+  resolved "https://pkg.pr.new/solid-three@8348eb8#860a5017d7877ea127654484449cfbee48f8efae"
   dependencies:
     "@bigmistqke/solid-whenever" "^0.1.0"
     "@solid-primitives/resize-observer" "^2.0.25"

--- a/online/yarn.lock
+++ b/online/yarn.lock
@@ -2944,9 +2944,9 @@ solid-prevent-scroll@^0.1.4:
   dependencies:
     "@corvu/utils" "~0.3.1"
 
-"solid-three@https://pkg.pr.new/solid-three@8348eb8":
+"solid-three@https://pkg.pr.new/solid-three@824aea9":
   version "0.3.0-next.12"
-  resolved "https://pkg.pr.new/solid-three@8348eb8#860a5017d7877ea127654484449cfbee48f8efae"
+  resolved "https://pkg.pr.new/solid-three@824aea9#210b3c8f0df88658b45c036afa4f7dabf7ccab31"
   dependencies:
     "@bigmistqke/solid-whenever" "^0.1.0"
     "@solid-primitives/resize-observer" "^2.0.25"


### PR DESCRIPTION
I believe we are still forcing the WebGL fallback, however, to enable Quest 3.

The editing scenarios are still using the old shader.