### PR TITLE
Fix perspective color speckling in instanced renderer

### DIFF
--- a/online/developer-docs/symmetry-renderer-status.md
+++ b/online/developer-docs/symmetry-renderer-status.md
@@ -863,6 +863,26 @@ time, rather than continuing to reason abstractly about solid-three's internals.
 projected-position numbers were what finally made the real cause legible — everything before
 that was consistent with several different explanations.
 
+## Perspective-only color speckling from interpolated discrete attributes
+
+**Status: fixed and reproduced with an instrumented live viewer.** Some GPUs rendered balls
+and struts with dense, incorrect-color speckles in perspective mode, while orthographic mode
+was clear. The artifact was unchanged when outlines, multisampling, or depth testing were
+disabled. A WebGL draw trace also showed one fill draw and one fill material per shape, ruling
+out duplicate geometry or simultaneous visible/picking materials.
+
+The generated fragment shader received the instanced `colorIndex` float as a normal varying
+and used `int(colorIndex)` to index the palette. Perspective-correct interpolation can turn an
+exact integer into `N - epsilon`; GLSL integer conversion truncates that to `N - 1`. This
+explains both the projection and GPU dependence, as well as the specific colors: white balls
+intermittently sampled the preceding red palette entry, while palette index zero stayed
+stable. Orthographic interpolation preserved the constant index exactly on the affected GPU.
+
+`createMaterialForGroup()` now rounds `colorIndex` with `floor(value + 0.5)` before the
+palette lookup. It applies the same protection to `pickingId`, which is also a discrete
+instanced float consumed in a fragment shader. Replacing only the palette conversion in the
+live generated shader removed the perspective artifact completely.
+
 ## Debugging technique notes for whoever continues this
 
 The Phase 3 debugging session (item 6 above especially) went through a long sequence of

--- a/online/src/viewer/context/symmetry-renderer.js
+++ b/online/src/viewer/context/symmetry-renderer.js
@@ -386,7 +386,10 @@ export function createSymmetryRenderer(parent)
       const orientationMat = orientationUniform.element(orientationIndexNode.toInt());
       return orientationMat.mul(vec4(positionLocal, 1.0)).xyz.add(instanceTranslationNode);
     })();
-    const indexedColorNode = colorPalette.element(colorIndexNode.toInt());
+    // Fragment attributes are perspective-interpolated. An exact integer can arrive as
+    // N-epsilon, so truncating it would intermittently select the preceding palette color.
+    const roundedColorIndexNode = floor(colorIndexNode.add(float(0.5)));
+    const indexedColorNode = colorPalette.element(roundedColorIndexNode.toInt());
 
     // MeshLambertNodeMaterial (diffuse only, no specular term) to match ShapedGeometry's
     // MeshLambertMaterial exactly -- see geometry.jsx's InstancedShape. The original
@@ -403,7 +406,10 @@ export function createSymmetryRenderer(parent)
     material.emissiveNode = vec4(1.0, 1.0, 1.0, 1.0).xyz.mul(highlightIntensityNode);
 
     // Picking material: encodes per-instance ID into RGB, shares the same vertex transform
-    const pickingIdNode = attribute("pickingId", "float");
+    // Apply the same interpolation protection before encoding the discrete ID.
+    const pickingIdNode = floor(
+      attribute("pickingId", "float").add(float(0.5))
+    );
     // R = id % 256, G = floor(id/256) % 256, B = floor(id/65536)
     const pickingColorNode = vec3(
       mod(pickingIdNode, float(256.0)).div(255.0),


### PR DESCRIPTION
## Summary

- Round the fragment-interpolated `colorIndex` before using it as a palette index.
- Apply the same protection to the fragment-interpolated `pickingId`.
- Document the root cause and the cross-machine investigation.

## Why

The instanced renderer sends `colorIndex` to the fragment shader as a normal
floating-point varying, then converts it with `int()` for the palette lookup.
Perspective-correct interpolation can produce `N - epsilon` even though every
vertex of the instance receives the same integer-valued attribute. GLSL integer
conversion truncates that to `N - 1`, so individual fragments select the
preceding palette entry. This produces the fuzzy, incorrect-color pattern seen
on balls and struts.

The effect is GPU/driver-dependent. Orthographic projection keeps clip-space
`w` constant and did not trigger the error in any test. This was not duplicate
visible/picking materials, outlines, or depth-buffer precision: an instrumented
live viewer showed one fill draw per shape, and disabling outlines,
multisampling, depth testing, or derivative normals did not remove the artifact.

Rounding with `floor(value + 0.5)` restores the intended nonnegative integer
before either palette indexing or picking-ID encoding.

## Browser/GPU evidence

A standalone WebGL2 probe rendered one instanced triangle whose three vertices
all received `discreteIndex = 1`. It compared direct `int()` conversion with
the rounded conversion used by this change. Each run covered 105,800 pixels.

| Machine | Browser | WebGL renderer | Orthographic wrong | Perspective wrong | Rounded perspective wrong |
|---|---|---|---:|---:|---:|
| nanma-hp | Chrome | ANGLE, NVIDIA T1000 8GB, Direct3D 11 | 0 | 53,875 (50.92%) | 0 |
| nanma-hp | Edge | ANGLE, NVIDIA T1000 8GB, Direct3D 11 | 0 | 53,875 (50.92%) | 0 |
| Laptop | Chrome | ANGLE, Intel Iris Xe Graphics, Direct3D 11 | 0 | 0 | 0 |
| Laptop | Edge | ANGLE, Intel Iris Xe Graphics, Direct3D 11 | 0 | 0 | 0 |
| Devbox over RDP | Edge | ANGLE, Microsoft Basic Render Driver, Direct3D 11 | 0 | 13,075 (12.36%) | 0 |

The same runtime rounding substitution removed the artifact completely from
the reported model on the affected NVIDIA machine:

https://bubsir.github.io/vzome-sharing/2026/08/10/09-23-02-Tetras-Red-Blue-floating-small/

## Checks performed

- Reproduced the live perspective artifact with outlines both enabled and
  disabled.
- Captured the generated GLSL and confirmed the palette lookup used a
  perspective-interpolated float followed by truncating `int()`.
- Verified a runtime substitution of the proposed rounding produced a clear
  perspective rendering.
- Ran the standalone probe across the five browser/machine combinations above.
- Ran `node --check online/src/viewer/context/symmetry-renderer.js`.
- Ran `git diff --check`.

A full local production build was not completed because this machine had no
installed frontend dependencies and both Yarn restore attempts were blocked by
TLS handshake failures from the package registry. CI should provide the clean
Node 22 production build.

## How to test

1. Use Node 22, run `yarn install` in `online`, then run `yarn dev`.
2. Open `http://localhost:8532/app/test/cases/github-share/`.
3. In the browser console, load the reported model:

   ```js
   document.querySelector("vzome-viewer").src =
     "https://bubsir.github.io/vzome-sharing/2026/08/10/09-23-02-Tetras-Red-Blue-floating-small/Tetras-Red-Blue-floating-small.vZome";
   ```

4. With Perspective enabled, verify that balls and struts remain solid and
   clear. Toggle Outlines both on and off, then toggle Orthographic and back to
   Perspective.
5. Repeat on an affected NVIDIA or Microsoft Basic Render Driver machine and
   an unaffected Intel machine in both Chrome and Edge.
6. In the classic editor, load a small model and click several balls and
   struts in both projections to confirm that rounded picking IDs still select
   the intended instances.
