### PR TITLE
Add automatic WebGLRenderer fallback for machines where WebGPURenderer fails

### DIFF
--- a/online/src/viewer/ltcanvas.jsx
+++ b/online/src/viewer/ltcanvas.jsx
@@ -1,5 +1,5 @@
 
-import { Color, Scene, Group, Mesh, AmbientLight, DirectionalLight } from "three";
+import { Color, Scene, Group, Mesh, AmbientLight, DirectionalLight, WebGLRenderer } from "three";
 import { WebGPURenderer } from 'three/webgpu';
 import { createRenderEffect, createResource, createSignal, onMount, For, Show, Suspense } from "solid-js";
 import { createElementSize } from "@solid-primitives/resize-observer";
@@ -149,6 +149,22 @@ export const LightedTrackballCanvas = ( props ) =>
 
   const makeCustomRenderer = ( canvas ) =>
   {
+    // props.useWebGL is resolved by the capability probe upstream (see SceneCanvas and
+    // renderer-support.js). On machines where WebGPURenderer fails to initialize -- notably
+    // Intel Macs on Safari/Sequoia, where the viewer otherwise renders solid white -- we fall
+    // back to the classic WebGLRenderer here. That path also forces symmetryRenderer off (see
+    // SceneCanvas), since the classic renderer can't consume the symmetry renderer's TSL node
+    // materials; the combined fallback is WebGLRenderer + ShapedGeometry.
+    if ( props.useWebGL ) {
+      const renderer = new WebGLRenderer({
+        powerPreference: "high-performance",
+        canvas,
+        antialias: true,
+        alpha: true,
+        preserveDrawingBuffer: true,
+      });
+      return renderer;
+    }
     const renderer = new WebGPURenderer({
       powerPreference: "high-performance",
       canvas,

--- a/online/src/viewer/renderer-support.js
+++ b/online/src/viewer/renderer-support.js
@@ -1,0 +1,80 @@
+
+import { WebGPURenderer } from 'three/webgpu';
+
+// When true, we skip the WebGPURenderer entirely and use the classic WebGLRenderer
+// with ShapedGeometry (non-instanced) -- see makeCustomRenderer in ltcanvas.jsx and the
+// symmetryRenderer gating in scenecanvas.jsx. This is the fallback path for machines where
+// WebGPURenderer (even with forceWebGL:true) fails to initialize -- notably observed on
+// Intel Macs running Safari on macOS Sequoia, where the viewer renders solid white.
+
+const STORAGE_KEY = 'vzome.forceWebGLFallback';
+const URL_PARAM = 'forceWebGL';
+
+const readStorage = () => {
+  // localStorage access can throw in sandboxed/partitioned embedded iframes.
+  try { return globalThis.localStorage ?.getItem( STORAGE_KEY ) === 'true'; }
+  catch { return false; }
+};
+
+const writeStorage = () => {
+  try { globalThis.localStorage ?.setItem( STORAGE_KEY, 'true' ); }
+  catch { /* non-fatal: URL param still forces fallback for this page load */ }
+};
+
+// The URL param (?forceWebGL=1) is a convenience so a link can be handed to an affected
+// user instead of console instructions. Because the flag is per-origin (localStorage), and
+// each domain embedding the web component is its own origin, honoring the param also
+// persists it to localStorage so the user only needs the link once per domain.
+const readUrlParam = () => {
+  try {
+    const value = new URLSearchParams( globalThis.location ?.search ) .get( URL_PARAM );
+    // Present with no value (?forceWebGL), or an affirmative value, both count.
+    return value === '' || value === '1' || value === 'true';
+  } catch { return false; }
+};
+
+// Support/user escape hatch to force the WebGL + ShapedGeometry fallback regardless of the
+// capability probe below. Set via console -- localStorage.setItem('vzome.forceWebGLFallback',
+// 'true') -- or via a ?forceWebGL=1 link, which also persists it to localStorage.
+export const isFallbackForced = () => {
+  if ( readUrlParam() ) {
+    writeStorage();
+    return true;
+  }
+  return readStorage();
+};
+
+let probePromise = null;
+
+// Resolves true if a WebGPURenderer configured the way ltcanvas.jsx configures it
+// (forceWebGL:true) can actually initialize on this machine, false if it fails the way it
+// does on the affected Intel Sequoia Safari. Probed at most once per page load and cached.
+//
+// This deliberately runs the same `await renderer.init()` that solid-three runs internally
+// (see getPendingInit / rendererReady in solid-three's Canvas) -- but solid-three has no
+// .catch on that init, so an async rejection there just leaves the canvas white with nothing
+// surfaced. Running it ourselves first lets us both catch the rejection (console diagnostic)
+// and choose the renderer up front.
+export const canUseWebGPURenderer = () => {
+  if ( probePromise )
+    return probePromise;
+  probePromise = (async () => {
+    if ( isFallbackForced() ) {
+      console.info( '[vZome] WebGL fallback forced (localStorage/URL); using classic WebGLRenderer.' );
+      return false;
+    }
+    let renderer;
+    try {
+      const canvas = document.createElement( 'canvas' ); // never inserted into the DOM
+      renderer = new WebGPURenderer( { canvas, antialias: true, alpha: true, forceWebGL: true } );
+      await renderer.init();
+      return true;
+    } catch ( e ) {
+      console.warn( '[vZome] WebGPURenderer init failed; using classic WebGLRenderer fallback.', e );
+      return false;
+    } finally {
+      try { renderer ?.dispose ?.(); } catch { /* ignore dispose errors on a failed renderer */ }
+    }
+  })();
+  return probePromise;
+};

--- a/online/src/viewer/scenecanvas.jsx
+++ b/online/src/viewer/scenecanvas.jsx
@@ -2,8 +2,9 @@
 import { LightedTrackballCanvas } from './ltcanvas.jsx';
 import { ShapedGeometry } from './geometry.jsx';
 import { SymmetryGeometry } from './symmetry-geometry.jsx';
-import { mergeProps } from 'solid-js';
+import { mergeProps, createResource, Show } from 'solid-js';
 import { useScene } from './context/scene.jsx';
+import { canUseWebGPURenderer } from './renderer-support.js';
 
 const SceneCanvas = ( props ) =>
 {
@@ -11,19 +12,30 @@ const SceneCanvas = ( props ) =>
 
   const { scene } = useScene();
 
+  // Probe (once, cached) whether WebGPURenderer can initialize on this machine. Until it
+  // resolves, webgpuOk() is undefined; we treat that as "not yet WebGL" so we don't force the
+  // fallback prematurely, and gate the actual Canvas mount on it having resolved below.
+  const [ webgpuOk ] = createResource( canUseWebGPURenderer );
+  const useWebGL = () => webgpuOk() === false;
+  // The classic WebGLRenderer can't consume the symmetry renderer's TSL node materials, so the
+  // fallback rides a combined toggle: WebGLRenderer + ShapedGeometry (symmetryRenderer off).
+  const useSymmetry = () => props.symmetryRenderer && ! useWebGL();
+
   return (
-    <LightedTrackballCanvas
-        height={props.height} width={props.width} rotationOnly={props.rotationOnly}
-        rotateSpeed={props.rotateSpeed} zoomSpeed={props.zoomSpeed} panSpeed={props.panSpeed}
-        symmetryRenderer={props.symmetryRenderer} >
-      <Show when={ () => props.scene?.shapes }>
-        { props.symmetryRenderer
-          ? <SymmetryGeometry embedding={scene?.embedding} shapes={scene?.shapes} orientations={scene?.orientations} polygons={scene?.polygons} />
-          : <ShapedGeometry embedding={scene?.embedding} shapes={scene?.shapes} />
-        }
-      </Show>
-      {props.children}
-    </LightedTrackballCanvas>
+    <Show when={ webgpuOk() !== undefined }>
+      <LightedTrackballCanvas
+          height={props.height} width={props.width} rotationOnly={props.rotationOnly}
+          rotateSpeed={props.rotateSpeed} zoomSpeed={props.zoomSpeed} panSpeed={props.panSpeed}
+          useWebGL={useWebGL()} symmetryRenderer={useSymmetry()} >
+        <Show when={ () => props.scene?.shapes }>
+          { useSymmetry()
+            ? <SymmetryGeometry embedding={scene?.embedding} shapes={scene?.shapes} orientations={scene?.orientations} polygons={scene?.polygons} />
+            : <ShapedGeometry embedding={scene?.embedding} shapes={scene?.shapes} />
+          }
+        </Show>
+        {props.children}
+      </LightedTrackballCanvas>
+    </Show>
   );
 }
 


### PR DESCRIPTION
Since the switch to WebGPURenderer (even with forceWebGL:true), the viewer
renders solid white on some machines -- notably Intel Macs running Safari on
macOS Sequoia, where the WebGPURenderer's async init() rejects. solid-three
awaits that init() with no .catch, so the failure is silent and the canvas
just stays blank.

This adds a capability probe that runs the same init() ourselves, in a
try/catch, before mounting the real Canvas:

- renderer-support.js: canUseWebGPURenderer() constructs a throwaway
  WebGPURenderer and awaits init(), caching a boolean and logging a warning
  on failure (the diagnostic solid-three swallows). Also exposes a force flag
  via localStorage 'vzome.forceWebGLFallback' or a ?forceWebGL=1 URL param
  (the param persists itself to localStorage, since the flag is per-origin).

- ltcanvas.jsx: makeCustomRenderer picks the classic WebGLRenderer (from
  "three") when the new useWebGL prop is set, else WebGPURenderer as before.

- scenecanvas.jsx: resolves the probe via createResource, gates the Canvas
  mount on it, and drives a combined toggle -- the fallback forces
  symmetryRenderer off (WebGLRenderer + ShapedGeometry), since the classic
  renderer can't consume the symmetry renderer's TSL node materials.

No worker protocol change. The picking WebGPURenderer in symmetry-renderer.js
needs no change: it only exists when SymmetryGeometry is mounted, which never
happens on the fallback path.

Known limitation: the fallback's ShapedGeometry path is validated for the
read-only viewer, not live editing in the classic editor; picking/strut-drag
there hit pre-existing worker-interaction issues and are out of scope here.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
