### PR TITLE
Reuse the trackball worker across symmetry/field switches

### DIFF
--- a/online/src/app/classic/components/camera.jsx
+++ b/online/src/app/classic/components/camera.jsx
@@ -1,5 +1,5 @@
 
-import { Show } from 'solid-js';
+import { createEffect, createMemo } from 'solid-js';
 
 import Stack from "@suid/material/Stack"
 import Switch from "@suid/material/Switch";
@@ -8,7 +8,7 @@ import FormControlLabel from "@suid/material/FormControlLabel";
 import { controllerProperty } from '../../framework/context/editor.jsx';
 import { useSymmetry } from "../context/symmetry.jsx";
 import { WorkerProvider } from '../../../viewer/context/worker.jsx';
-import { ViewerProvider } from '../../../viewer/context/viewer.jsx';
+import { ViewerProvider, useViewer } from '../../../viewer/context/viewer.jsx';
 import { CameraProvider, useCamera } from '../../../viewer/context/camera.jsx';
 import { InteractionToolProvider } from '../../../viewer/context/interaction.jsx';
 import { SceneCanvas } from '../../../viewer/scenecanvas.jsx';
@@ -29,56 +29,113 @@ import { resourceUrl } from './length.jsx';
 // makes it always self-consistent in its own field, with zero trackball-specific worker code.
 //
 // The `url` is the current symmetry's model resource path (was wrapper.getTrackballUrl on the
-// worker; now read client-side from the symmetry controller's modelResourcePath property). The
-// whole stack is remounted per url via <Show keyed> so a symmetry change loads a fresh worker with
-// the new trackball design -- matching how 59icosahedra's ModelWorker isolates one worker per
-// fixed model (WorkerProvider now terminates its Worker on unmount, so remounting doesn't leak).
-// Fixed `distance` + `context`-driven rotation/background sync make the trackball mirror the main
-// view. config.camera:false tells this ViewerProvider NOT to drive the camera or background from
-// the trackball design (loadDesign emits SCENES_DISCOVERED with the trackball .vZome's own camera
-// + lighting, which would otherwise clobber the main-view mirror); see ViewerProvider.
+// worker; now read client-side from the symmetry controller's modelResourcePath property).
+//
+// WORKER REUSE (was: remount per url): the whole provider stack -- worker, viewer, scene, canvas --
+// is mounted ONCE and kept alive for the life of the camera panel. A symmetry/field switch no
+// longer remounts anything; instead TrackballLoader (below) reloads a new trackball design into the
+// SAME worker via requestDesign. The worker's expensive one-time init (fetch+parse all symmetry/
+// shape VEFs, build the FieldApplications) is memoized and reused across loads, so a switch is just
+// a parse+render of the new fixed .vZome, not a fresh worker cold-start. Hoisting WorkerProvider
+// above any url gating also lets the worker begin that init immediately at panel mount, overlapping
+// with the symmetry controller becoming ready -- so the first trackball appears sooner.
+//
+// No <Show> gate: loading is guarded solely by TrackballLoader's `if (!url) return`, and SceneCanvas
+// already renders an empty canvas until the first SCENE_RENDERED arrives (it gates geometry on
+// scene.shapes), which is also the steady state between reloads. So an un-gated mount is safe.
+//
+// config.camera:false tells ViewerProvider NOT to drive the camera or background from the trackball
+// design (loadDesign emits SCENES_DISCOVERED with the trackball .vZome's own camera + lighting,
+// which would otherwise clobber the main-view mirror). Fixed `distance` + `context`-driven rotation/
+// background sync (via the MAIN camera context) make the trackball mirror the main view.
 //
 // preview:false because the trackball .vZome files have no .shapes.json preview export, so the
-// worker interprets the XML directly. SceneChangeListener (mounted below) consumes the resulting
-// SCENE_RENDERED to populate this isolated SceneProvider's shapes/orientations.
+// worker interprets the XML directly. SceneChangeListener consumes each SCENE_RENDERED to populate
+// this isolated SceneProvider's shapes/orientations.
 const TrackballViewer = () =>
 {
   const context = useCamera(); // the MAIN camera context, to mirror its rotation
   const { symmetryController } = useSymmetry();
-  // modelResourcePath is reactive: it re-requests on symmetry change (controllerProperty), so
-  // trackballUrl() tracks the current symmetry. undefined until the symmetry controller is ready.
-  const trackballUrl = () => {
+
+  // Compute the trackball url HERE, in TrackballViewer's body -- crucially OUTSIDE the trackball's
+  // own <WorkerProvider> below. controllerProperty() reads useWorkerClient() to send its initial
+  // property request, resolving to the NEAREST WorkerProvider ancestor. Here that is the MAIN editor
+  // worker (which owns the symmetry controller and modelResourcePath); if this ran inside the
+  // trackball WorkerProvider, controllerProperty would target the trackball worker instead, which
+  // has no such controller, so modelResourcePath would never arrive and nothing would ever load.
+  // (The old <Show when={trackballUrl()}> worked for the same reason: it evaluated above the
+  // trackball WorkerProvider.) modelResourcePath is reactive -- re-requested on symmetry change --
+  // so this memo tracks the current symmetry/field; undefined until the symmetry controller is ready.
+  const trackballUrl = createMemo( () => {
     const symm = symmetryController();
     const path = symm && controllerProperty( symm, 'modelResourcePath' );
     // Must be a FULLY-QUALIFIED url: the worker runs from a blob: origin and fetches this string
     // directly (fetchUrlText), so a root-relative "/app/classic/resources/..." would resolve
     // against the blob origin and 403. Resolve against window.location here (the client has it;
     // the worker doesn't, which is why the old trackball path passed baseURL to `new URL`).
-    // resourceUrl() gives the root-relative path; new URL(..., window.location) makes it absolute
-    // -- same construction as 59icosahedra's getModelURL.
-    const url = path ? new URL( resourceUrl( path ), window.location ) .toString() : undefined;
-    return url;
-  };
+    // resourceUrl() gives the root-relative path; new URL(..., window.location) makes it absolute.
+    const path2 = path ? new URL( resourceUrl( path ), window.location ) .toString() : undefined;
+    return path2;
+  } );
 
   return (
     <CameraProvider name='trackball' outlines={false} context={context}>
-      <Show when={ trackballUrl() } keyed>
-        { url => (
-          <WorkerProvider>
-            <ViewerProvider config={ { url, preview: false, debug: false, camera: false } }>
-              <SceneProvider>
-                <SceneChangeListener />
-                <InteractionToolProvider>
-                  <SnapCameraTool />
-                  <TrackballCanvas />
-                </InteractionToolProvider>
-              </SceneProvider>
-            </ViewerProvider>
-          </WorkerProvider>
-        ) }
-      </Show>
+      <WorkerProvider>
+        {/* No `url` in this config: ViewerProvider's on-create auto-load is guarded on url (see
+            `url && postMessage(...)` there), so omitting it leaves the provider in its generic
+            "no design loaded yet" state. TrackballLoader then owns every load, uniformly. The one
+            config the trackball still needs -- camera:false -- is a pre-existing generic prop. */}
+        <ViewerProvider config={ { preview: false, debug: false, camera: false } }>
+          <SceneProvider>
+            <SceneChangeListener />
+            <TrackballLoader url={ trackballUrl } />
+            <InteractionToolProvider>
+              <SnapCameraTool />
+              <TrackballCanvas />
+            </InteractionToolProvider>
+          </SceneProvider>
+        </ViewerProvider>
+      </WorkerProvider>
     </CameraProvider>
   );
+};
+
+// Owns ALL trackball design loads (first and subsequent), reactively, into the reused trackball
+// worker/scene. Receives the url accessor from TrackballViewer (computed against the MAIN editor
+// worker -- see the memo comment above); here we are inside the trackball WorkerProvider, so
+// requestDesign/resetScene act on the trackball's own worker and scene, which is what we want.
+const TrackballLoader = ( props ) =>
+{
+  const { requestDesign } = useViewer();
+  const { resetScene } = useScene();
+
+  // The url last actually loaded into the trackball worker. Opening/creating a document rebuilds
+  // the editor's controller store, so symmetryController() yields a NEW controller object and
+  // modelResourcePath momentarily reads undefined before being re-requested -- so props.url()
+  // transitions url -> undefined -> url even when the new document uses the SAME symmetry/field,
+  // and thus the same trackball. Without this guard that round-trip would trigger a needless
+  // resetScene()+reload, blanking and re-fetching an identical trackball. By remembering what we
+  // last loaded and skipping when the (defined) url is unchanged, we keep the existing trackball
+  // rendered until we KNOW a different one is needed.
+  let loadedUrl;
+
+  createEffect( () => {
+    const url = props.url();
+    if ( ! url )
+      return; // symmetry controller not ready yet (or transiently undefined during a doc rebuild)
+    if ( url === loadedUrl )
+      return; // same trackball as currently loaded -- leave it rendered, no reload
+    loadedUrl = url;
+    // Clear the previous design's shapes/orientations/symmetryId before loading the next, so a
+    // field switch starts from a truly empty store (see SceneProvider.resetScene). requestDesign
+    // posts URL_PROVIDED to the same worker, which reuses the memoized field/shape init. Only
+    // preview/debug are read from this per-request config by the worker; the camera:false that
+    // protects the main-view mirror is a ViewerProvider-level prop (driveViewFromDesign), set above.
+    resetScene();
+    requestDesign( url, { preview: false, debug: false } );
+  } );
+
+  return null;
 };
 
 // Renders the trackball scene, reading the isolated SceneProvider that SceneChangeListener above

--- a/online/src/viewer/context/scene.jsx
+++ b/online/src/viewer/context/scene.jsx
@@ -51,6 +51,18 @@ const SceneProvider = ( props ) =>
     }
   }
 
+  // Clear all design-derived scene state, for a component that loads a SUCCESSION of designs into
+  // ONE reused SceneProvider (the classic editor's trackball, which now keeps one long-lived
+  // worker/scene and reloads a new trackball design on every symmetry/field switch, instead of
+  // remounting). updateShapes only empties the INSTANCES of shapes absent from the next scene; it
+  // leaves stale shape ENTRIES, and never touches orientations/symmetryId. That's fine within one
+  // design, but across a field switch the shape set, orientation set, and symmetryId all differ,
+  // so the next design must start from a truly empty store: otherwise SymmetryGeometry would keep
+  // the previous field's shapes, and -- because its group-switch effect early-returns when the key
+  // is unchanged -- could fail to switch groups. reconcile('') replaces the whole store; clearing
+  // symmetryId here guarantees the next design's symmetryId reads as a change.
+  const resetScene = () => setScene( reconcile( {} ) );
+
   // Optional imperative selection-highlight hook. SymmetryGeometry registers a callback here
   // (id, selected) so the SELECTION_TOGGLED handler can update the one flipped instance's GPU
   // highlight in O(1) -- an id-keyed lookup inside the renderer -- instead of the previous
@@ -65,7 +77,7 @@ const SceneProvider = ( props ) =>
   const setSelectionHighlighter = fn => { selectionHighlighter = fn; };
   const highlightSelection = ( shapeId, id, selected ) => selectionHighlighter?.( shapeId, id, selected );
 
-  const apiObject = { scene, setScene, labels, updateShapes, addShape, useViewer, setSelectionHighlighter, highlightSelection, }
+  const apiObject = { scene, setScene, labels, updateShapes, addShape, resetScene, useViewer, setSelectionHighlighter, highlightSelection, }
 
   return (
     <SceneContext.Provider value={ apiObject }>


### PR DESCRIPTION
The classic editor's camera trackball previously wrapped its whole worker
stack in <Show keyed> on the trackball url, so every symmetry/field switch
tore down and rebuilt the WorkerProvider -- terminating the Web Worker and
cold-starting a fresh one that re-ran the full field/shape/symmetry init
just to render a trivial fixed trackball design.

Now the provider stack (worker, viewer, scene, canvas) mounts ONCE and is
reused. A new TrackballLoader behavioral component (renders null; owns only
the load lifecycle) reloads a new trackball design into the same long-lived
worker via requestDesign on each symmetry/field change, reusing the worker's
memoized field/shape init. Hoisting WorkerProvider above any url gating also
lets the worker begin init at panel mount, overlapping with the symmetry
controller becoming ready.

- ViewerProvider stays generic: constructed with no `url` (its on-create
  auto-load is already url-guarded, so it stays dormant) and no new config
  props; all trackball load logic lives in TrackballLoader.
- SceneProvider gains a generic resetScene(), called before each reload so a
  field switch starts from a truly empty store (different shape/orientation
  sets and symmetryId).
- trackballUrl is computed in TrackballViewer's body, ABOVE the trackball
  WorkerProvider: controllerProperty() binds to the nearest WorkerProvider
  ancestor, so modelResourcePath must be read against the MAIN editor worker,
  then passed down to TrackballLoader as an accessor. (Computing it inside the
  trackball worker's context targeted the wrong worker and loaded nothing.)
- No <Show> gate: SceneCanvas already renders an empty canvas until the first
  SCENE_RENDERED (it gates geometry on scene.shapes), the same state as
  between reloads, so an un-gated mount is safe.
- TrackballLoader remembers the last-loaded url and skips reloading when it is
  unchanged. Opening/creating a document rebuilds the controller store, so the
  url transitions url -> undefined -> url even for the same symmetry/field;
  without the guard that blanked and re-fetched an identical trackball. Now the
  existing trackball stays rendered until a genuinely different one is needed.

No worker, Java, or JSweet changes. Deferred: load-time latency and a
remaining warning observed during switching.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
