### PR TITLE
Content-derived shape ids for cross-worker/design sharing

### DIFF
--- a/core/src/main/java/com/vzome/core/exporters/POVRayExporter.java
+++ b/core/src/main/java/com/vzome/core/exporters/POVRayExporter.java
@@ -125,7 +125,10 @@ public class POVRayExporter extends DocumentExporter
 		Map<AlgebraicMatrix, String> transforms = new HashMap<>();
 		Map<Color, String> colors = new HashMap<>();
         for (RenderedManifestation rm : mModel) {
-            String shapeName = "S" + rm .getShapeId() .toString() .replaceAll( "-", "" );
+            // Content-derived shape key (see Polyhedron.shapeKey); strip characters not valid in
+            // a POV-Ray identifier. Was getShapeId() (per-object UUID); the key dedups content-
+            // identical shapes and is stable, and the sanitizer keeps the declared-name legal.
+            String shapeName = "S" + rm .getShapeKey() .replaceAll( "[^A-Za-z0-9_]", "_" );
             if ( ! shapes .contains( shapeName ) ) {
                 shapes .add( shapeName );
                 exportShape( shapeName, rm .getShape() );

--- a/core/src/main/java/com/vzome/core/math/Polyhedron.java
+++ b/core/src/main/java/com/vzome/core/math/Polyhedron.java
@@ -44,6 +44,36 @@ public class Polyhedron implements Cloneable
 
     private UUID guid = UUID .randomUUID();
 
+    // A stable, content-derived identifier for this shape, used as the shape key when a scene
+    // is serialized to a client (see JsonMapper, unity.Renderer, POVRayExporter) and, on the
+    // web, as the key under which the client caches and instances a shape's geometry.
+    //
+    // WHY THIS EXISTS SEPARATELY FROM guid:
+    //   guid is per-OBJECT identity (a fresh randomUUID per Polyhedron instance). On the desktop
+    //   that doubles as shape identity, because same-symmetry designs share ONE cached Polyhedron
+    //   object (see AbstractShapes), so its random guid is stable "by reference". On the web,
+    //   each design runs in its own worker with its own object graph, so that reference-sharing
+    //   is gone and the random guid degrades to per-worker noise -- two workers realizing the
+    //   IDENTICAL shape get different guids, so neither the design worker / shapes worker split
+    //   nor cross-design dedup can key on it. shapeKey fixes that by being a function of the
+    //   shape's DEFINITION, so any worker computes the same key for the same shape.
+    //
+    // TWO DERIVATION STRATEGIES, by shape kind:
+    //   - Catalog shapes (struts / connectors): a READABLE key derived from the same identifying
+    //     inputs AbstractShapes already caches by -- "<symmetry>:<orbit>:<length>" for struts,
+    //     "<symmetry>:<pkg>:ball" for connectors. Deliberately human-readable, because these are
+    //     the ids we debug by eye (in scene.shapes keys, the DOM, worker logs). Set by the
+    //     AbstractShapes factory methods.
+    //   - Content-hashed shapes (panels today; user-defined shapes in future): no short readable
+    //     vocabulary exists, so hash the geometry. See deriveGeometricKey(). NOTE: user-defined
+    //     shapes (a future feature: select panels -> define one shape, scoped to that design) are
+    //     the reason this lives on Polyhedron rather than only in AbstractShapes -- they are
+    //     realized outside the catalog cache, but still need the same content-derived-key contract.
+    //
+    // Defaults to the random guid's string, so any Polyhedron that never gets an explicit key
+    // (ad-hoc shapes that never reach a client) still has a unique, if unreadable, key.
+    private String shapeKey = this .guid .toString();
+
     public Polyhedron( AlgebraicField field )
     {
         this.field = field;
@@ -68,7 +98,11 @@ public class Polyhedron implements Cloneable
             }
             this .evilTwin .isEvil = true;
             this .evilTwin .guid = UUID .randomUUID();
-            
+            // clone() copied our shapeKey; the twin is a DISTINCT shape (isEvil is part of
+            // equals/hashCode), so it must get a distinct key -- but still deterministically,
+            // derived from ours, so any worker computes the same twin key. Suffix, don't randomize.
+            this .evilTwin .shapeKey = this .shapeKey + ":evil";
+
             this .evilTwin .m_vertexList = new ArrayList<>();
             // this loop should preserve the order, and thus indices for the faces below
             for ( AlgebraicVector vertex : m_vertexList ) {
@@ -404,6 +438,76 @@ public class Polyhedron implements Cloneable
     public UUID getGuid()
     {
         return this .guid;
+    }
+
+    /**
+     * The stable, content-derived shape key used as the shape identity when serializing a scene
+     * to a client, and (on the web) as the geometry cache/instancing key. See the shapeKey field
+     * comment for why this is distinct from getGuid(). Defaults to the guid string until a factory
+     * (AbstractShapes) or a future user-shape realization path sets a content-derived key.
+     */
+    @JsonIgnore
+    public String getShapeKey()
+    {
+        return this .shapeKey;
+    }
+
+    /**
+     * Set a readable, content-derived shape key. Used by AbstractShapes for catalog shapes, e.g.
+     * "<symmetry>:<orbit>:<length>" (strut) or "<symmetry>:<pkg>:ball" (connector). Must be a pure
+     * function of the shape's DEFINITION so that any worker realizing the same shape computes the
+     * same key; do NOT fold in design/session/instance identity.
+     */
+    public void setShapeKey( String shapeKey )
+    {
+        this .shapeKey = shapeKey;
+    }
+
+    /**
+     * Content hash of this shape's geometry, for shapes with no short readable key (panels; and,
+     * in future, user-defined shapes assembled from a selected panel collection -- a per-design
+     * feature not yet implemented). Deterministic across workers because it depends only on the
+     * canonicalized vertex/face definition, matching the fields equals()/hashCode() already use.
+     *
+     * NOTE: intentionally NOT wired in yet for the future user-shape path -- that path also needs
+     * a per-design shape registry (to give the shape a home and round-trip through the design XML),
+     * which is separate work. This method is provided so that, when that feature lands, its
+     * realization code has a ready, worker-agnostic way to derive the same key everywhere. Panels
+     * MAY adopt it now (see AbstractShapes.getPanelShape); struts/connectors deliberately do not,
+     * to keep their readable keys.
+     */
+    @JsonIgnore
+    public String deriveGeometricKey()
+    {
+        StringBuilder buf = new StringBuilder();
+        buf .append( isEvil ? "e:" : "s:" );
+        // Vertices in list order: getEvilTwin and the VEF/geometry builders preserve a stable
+        // order, and equals() compares m_vertexList (a List) order-sensitively, so list order is
+        // a legitimate part of identity here.
+        for ( AlgebraicVector v : m_vertexList )
+            buf .append( v .toString() ) .append( ';' );
+        buf .append( '|' );
+        // Faces are a Set (unordered); sort their string forms so the hash is order-independent,
+        // matching equals() comparing m_faces as a Set.
+        List<String> faceStrings = new ArrayList<>();
+        for ( Face face : m_faces )
+            faceStrings .add( face .toString() );
+        Collections .sort( faceStrings );
+        for ( String f : faceStrings )
+            buf .append( f ) .append( ';' );
+        // FNV-1a 64-bit hash over the characters. We only need a deterministic string, not a real
+        // UUID; UUID.nameUUIDFromBytes is not available in the JSweet shim, and this computes
+        // identically in Java and the transpiled web (pure long arithmetic, no library calls), so
+        // any worker derives the same key for the same geometry.
+        final long FNV_OFFSET = 0xcbf29ce484222325L;
+        final long FNV_PRIME  = 0x100000001b3L;
+        String s = buf .toString();
+        long hash = FNV_OFFSET;
+        for ( int i = 0; i < s .length(); i++ ) {
+            hash ^= s .charAt( i );
+            hash *= FNV_PRIME;
+        }
+        return "u" + Long .toHexString( hash );
     }
 
     @JsonProperty( "faces" )

--- a/core/src/main/java/com/vzome/core/render/JsonMapper.java
+++ b/core/src/main/java/com/vzome/core/render/JsonMapper.java
@@ -67,7 +67,10 @@ public class JsonMapper
     
     public ObjectNode getShapeNode( Polyhedron shape )
     {
-        String shapeId = shape .getGuid() .toString();
+        // Content-derived shape key (see Polyhedron.shapeKey): dedups content-identical shapes to
+        // one definition even when realized as separate objects (e.g. across web workers), which
+        // the old per-object guid could not.
+        String shapeId = shape .getShapeKey();
         if ( ! this .shapeIds .contains( shapeId ) )
         {
             this .shapeIds .add( shapeId );
@@ -79,7 +82,7 @@ public class JsonMapper
                 return node;                
             } else {
                 ObjectNode node = this .objectMapper .createObjectNode();
-                node .put( "id", shape .getGuid() .toString() );
+                node .put( "id", shape .getShapeKey() );
                 String name = shape .getName();
                 if ( name == "ball" )
                     node .put( "name", name );
@@ -135,7 +138,9 @@ public class JsonMapper
         try {
             Manifestation man = rm .getManifestation();
             Polyhedron shape = rm .getShape();
-            String shapeId = shape .getGuid() .toString();
+            // Must match the "id" written in getShapeNode above -- both are the content-derived
+            // shape key now, so an instance's "shape" reference resolves to its shape definition.
+            String shapeId = shape .getShapeKey();
             if ( man instanceof Strut )
             {
 

--- a/core/src/main/java/com/vzome/core/render/RenderedManifestation.java
+++ b/core/src/main/java/com/vzome/core/render/RenderedManifestation.java
@@ -130,6 +130,15 @@ public class RenderedManifestation implements RenderedObject
     {
         return this .mShape .getGuid();
     }
+
+    // The stable, content-derived shape key (see Polyhedron.shapeKey), which is what scene
+    // serialization and the web client key shapes by -- distinct from getShapeId()/getGuid(),
+    // which is per-object identity that only doubles as shape identity on the desktop via
+    // object reuse. Callers that dedup/reference shapes should use this.
+    public String getShapeKey()
+    {
+        return this .mShape .getShapeKey();
+    }
     
     @JsonIgnore
     public Polyhedron getShape()

--- a/core/src/main/java/com/vzome/core/viewing/AbstractShapes.java
+++ b/core/src/main/java/com/vzome/core/viewing/AbstractShapes.java
@@ -12,6 +12,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.vzome.core.algebra.AlgebraicField;
 import com.vzome.core.algebra.AlgebraicMatrix;
 import com.vzome.core.algebra.AlgebraicNumber;
 import com.vzome.core.algebra.AlgebraicVector;
@@ -125,6 +126,9 @@ public abstract class AbstractShapes implements Shapes
         if ( mConnectorGeometry == null ) {
             mConnectorGeometry = buildConnectorShape( mPkgName );
             mConnectorGeometry .setName( "ball" );
+            // Readable, content-derived shape key (see Polyhedron.shapeKey). Same identifying
+            // inputs that make this the one cached connector for this symmetry+package.
+            mConnectorGeometry .setShapeKey( mSymmetry .getName() + ":" + mPkgName + ":ball" );
         }
         return mConnectorGeometry;
     }
@@ -175,8 +179,17 @@ public abstract class AbstractShapes implements Shapes
             if ( lengthShape != null ) {
                 lengthShape .setName( orbit .getName() + strutShapesByLength .size() );
                 lengthShape .setOrbit( orbit );
-                // reproduce the calculation in LengthModel .setActualLength()                
+                // reproduce the calculation in LengthModel .setActualLength()
                 lengthShape .setLength( orbit .getLengthInUnits( length ) );
+                // Readable, content-derived shape key (see Polyhedron.shapeKey), built from the
+                // same (symmetry, orbit, length) that key this strut shape in the cache above.
+                // Call toString(int) explicitly, not the no-arg toString(): AlgebraicNumber
+                // overloads toString, and JSweet's overload resolution binds the no-arg form to
+                // toString(int) and fails to transpile. DEFAULT_FORMAT reproduces exactly what the
+                // no-arg toString() returns (it just delegates to toString(DEFAULT_FORMAT)), so the
+                // key is identical on desktop and web.
+                lengthShape .setShapeKey( mSymmetry .getName() + ":" + orbit .getName() + ":"
+                        + length .toString( AlgebraicField .DEFAULT_FORMAT ) );
             }
         }
         return lengthShape;
@@ -249,6 +262,11 @@ public abstract class AbstractShapes implements Shapes
         Polyhedron shape = map3 .get( canonicalVertices );
         if ( shape == null ) {
             shape = makePanelPolyhedron( canonicalVertices, oneSidedPanels );
+            // Panels have no short readable vocabulary (they're keyed by canonical vertices), so
+            // use the geometry content hash rather than a readable key -- panel ids aren't the
+            // ones debugged by eye. Still content-derived, so it's stable across workers.
+            if ( shape != null )
+                shape .setShapeKey( shape .deriveGeometricKey() );
             map3 .put( canonicalVertices, shape );
         }
         return shape;

--- a/core/src/main/java/com/vzome/unity/Renderer.java
+++ b/core/src/main/java/com/vzome/unity/Renderer.java
@@ -44,7 +44,9 @@ class Renderer implements RenderingChanges
             ObjectNode shapeNode = this .mapper .getShapeNode( shape );
             if ( shapeNode != null )
             {
-                shapeNode .put( "id", shape .getGuid() .toString() );
+                // Content-derived shape key (see Polyhedron.shapeKey); matches the "shape"
+                // reference JsonMapper writes on each instance, so DefineMesh ids line up.
+                shapeNode .put( "id", shape .getShapeKey() );
                 sendJson( "DefineMesh", shapeNode );
             }
             node .put( "id", rm .getGuid() .toString() );

--- a/online/src/worker/legacy/core-java.js
+++ b/online/src/worker/legacy/core-java.js
@@ -2547,6 +2547,9 @@ export var com;
                     getShapeId() {
                         return this.mShape.getGuid();
                     }
+                    getShapeKey() {
+                        return this.mShape.getShapeKey();
+                    }
                     getShape() {
                         return this.mShape;
                     }
@@ -3328,6 +3331,10 @@ export var com;
                             this.orbits = new com.vzome.core.math.symmetry.OrbitSet(symmetry);
                         }
                         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                        getOrientations$() {
+                            return this.getOrientations(false);
+                        }
+                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                         getEmbedding() {
                             const symmetry = this.getSymmetry();
                             const field = symmetry.getField();
@@ -3349,14 +3356,6 @@ export var com;
                             embedding[14] = 0.0;
                             embedding[15] = 1.0;
                             return embedding;
-                        }
-                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                        getOrientations$() {
-                            return this.getOrientations(false);
-                        }
-                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                        getZone(orbit, orientation) {
-                            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
                         }
                         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                         getOrientations(rowMajor) {
@@ -3411,6 +3410,10 @@ export var com;
                             }
                             else
                                 throw new Error('invalid overload');
+                        }
+                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                        getZone(orbit, orientation) {
+                            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
                         }
                         /**
                          *
@@ -3817,6 +3820,7 @@ export var com;
                         if (this.mConnectorGeometry == null) {
                             this.mConnectorGeometry = this.buildConnectorShape(this.mPkgName);
                             this.mConnectorGeometry.setName("ball");
+                            this.mConnectorGeometry.setShapeKey(this.mSymmetry.getName() + ":" + this.mPkgName + ":ball");
                         }
                         return this.mConnectorGeometry;
                     }
@@ -3841,6 +3845,7 @@ export var com;
                                 lengthShape.setName(orbit.getName() + strutShapesByLength.size());
                                 lengthShape.setOrbit(orbit);
                                 lengthShape.setLength(orbit.getLengthInUnits(length));
+                                lengthShape.setShapeKey(this.mSymmetry.getName() + ":" + orbit.getName() + ":" + length.toString(com.vzome.core.algebra.AlgebraicField.DEFAULT_FORMAT));
                             }
                         }
                         return lengthShape;
@@ -3920,6 +3925,8 @@ export var com;
                         let shape = map3.get(canonicalVertices);
                         if (shape == null) {
                             shape = this.makePanelPolyhedron(canonicalVertices, oneSidedPanels);
+                            if (shape != null)
+                                shape.setShapeKey(shape.deriveGeometricKey());
                             map3.put(canonicalVertices, shape);
                         }
                         return shape;
@@ -5289,6 +5296,7 @@ export var com;
                         this.isEvil = false;
                         this.__isPanel = false;
                         this.guid = java.util.UUID.randomUUID();
+                        this.shapeKey = this.guid.toString();
                         if (this.name === undefined) {
                             this.name = null;
                         }
@@ -5333,6 +5341,7 @@ export var com;
                             }
                             this.evilTwin.isEvil = true;
                             this.evilTwin.guid = java.util.UUID.randomUUID();
+                            this.evilTwin.shapeKey = this.shapeKey + ":evil";
                             this.evilTwin.m_vertexList = (new java.util.ArrayList());
                             for (let index = this.m_vertexList.iterator(); index.hasNext();) {
                                 let vertex = index.next();
@@ -5521,6 +5530,71 @@ export var com;
                     }
                     getGuid() {
                         return this.guid;
+                    }
+                    /**
+                     * The stable, content-derived shape key used as the shape identity when serializing a scene
+                     * to a client, and (on the web) as the geometry cache/instancing key. See the shapeKey field
+                     * comment for why this is distinct from getGuid(). Defaults to the guid string until a factory
+                     * (AbstractShapes) or a future user-shape realization path sets a content-derived key.
+                     * @return {string}
+                     */
+                    getShapeKey() {
+                        return this.shapeKey;
+                    }
+                    /**
+                     * Set a readable, content-derived shape key. Used by AbstractShapes for catalog shapes, e.g.
+                     * "<symmetry>:<orbit>:<length>" (strut) or "<symmetry>:<pkg>:ball" (connector). Must be a pure
+                     * function of the shape's DEFINITION so that any worker realizing the same shape computes the
+                     * same key; do NOT fold in design/session/instance identity.
+                     * @param {string} shapeKey
+                     */
+                    setShapeKey(shapeKey) {
+                        this.shapeKey = shapeKey;
+                    }
+                    /**
+                     * Content hash of this shape's geometry, for shapes with no short readable key (panels; and,
+                     * in future, user-defined shapes assembled from a selected panel collection -- a per-design
+                     * feature not yet implemented). Deterministic across workers because it depends only on the
+                     * canonicalized vertex/face definition, matching the fields equals()/hashCode() already use.
+                     *
+                     * NOTE: intentionally NOT wired in yet for the future user-shape path -- that path also needs
+                     * a per-design shape registry (to give the shape a home and round-trip through the design XML),
+                     * which is separate work. This method is provided so that, when that feature lands, its
+                     * realization code has a ready, worker-agnostic way to derive the same key everywhere. Panels
+                     * MAY adopt it now (see AbstractShapes.getPanelShape); struts/connectors deliberately do not,
+                     * to keep their readable keys.
+                     * @return {string}
+                     */
+                    deriveGeometricKey() {
+                        const buf = new java.lang.StringBuilder();
+                        buf.append(this.isEvil ? "e:" : "s:");
+                        for (let index = this.m_vertexList.iterator(); index.hasNext();) {
+                            let v = index.next();
+                            buf.append(v.toString()).append(';');
+                        }
+                        buf.append('|');
+                        const faceStrings = (new java.util.ArrayList());
+                        for (let index = this.m_faces.iterator(); index.hasNext();) {
+                            let face = index.next();
+                            faceStrings.add(face.toString());
+                        }
+                        java.util.Collections.sort(faceStrings);
+                        for (let index = faceStrings.iterator(); index.hasNext();) {
+                            let f = index.next();
+                            buf.append(f).append(';');
+                        }
+                        const FNV_OFFSET = -3750763034362895579;
+                        const FNV_PRIME = 1099511628211;
+                        const s = buf.toString();
+                        let hash = FNV_OFFSET;
+                        for (let i = 0; i < s.length; i++) {
+                            {
+                                hash ^= (s.charAt(i)).charCodeAt(0);
+                                hash *= FNV_PRIME;
+                            }
+                            ;
+                        }
+                        return "u" + javaemul.internal.LongHelper.toHexString(hash);
                     }
                     getTriangleFaces() {
                         const result = (new java.util.ArrayList());
@@ -16167,6 +16241,10 @@ export var com;
                         this.setStyle(styleName);
                     }
                     /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                    getOrientations$() {
+                        return this.getOrientations(false);
+                    }
+                    /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                     getEmbedding() {
                         const symmetry = this.getSymmetry();
                         const field = symmetry.getField();
@@ -16188,14 +16266,6 @@ export var com;
                         embedding[14] = 0.0;
                         embedding[15] = 1.0;
                         return embedding;
-                    }
-                    /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                    getOrientations$() {
-                        return this.getOrientations(false);
-                    }
-                    /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                    getZone(orbit, orientation) {
-                        return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
                     }
                     /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                     getOrientations(rowMajor) {
@@ -16271,6 +16341,10 @@ export var com;
                         }
                         else
                             throw new Error('invalid overload');
+                    }
+                    /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                    getZone(orbit, orientation) {
+                        return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
                     }
                     static LOGGER_$LI$() { if (SymmetrySystem.LOGGER == null) {
                         SymmetrySystem.LOGGER = java.util.logging.Logger.getLogger("com.vzome.core.editor");
@@ -36431,7 +36505,7 @@ export var com;
                         for (let index = this.mModel.iterator(); index.hasNext();) {
                             let rm = index.next();
                             {
-                                const shapeName = "S" + /* replaceAll */ rm.getShapeId().toString().replace(new RegExp("-", 'g'), "");
+                                const shapeName = "S" + /* replaceAll */ rm.getShapeKey().replace(new RegExp("[^A-Za-z0-9_]", 'g'), "_");
                                 if (!shapes.contains(shapeName)) {
                                     shapes.add(shapeName);
                                     this.exportShape(shapeName, rm.getShape());
@@ -47745,6 +47819,10 @@ export var com;
                             this.__parent = __parent;
                         }
                         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                        getOrientations$() {
+                            return this.getOrientations(false);
+                        }
+                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                         getEmbedding() {
                             const symmetry = this.getSymmetry();
                             const field = symmetry.getField();
@@ -47766,14 +47844,6 @@ export var com;
                             embedding[14] = 0.0;
                             embedding[15] = 1.0;
                             return embedding;
-                        }
-                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                        getOrientations$() {
-                            return this.getOrientations(false);
-                        }
-                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-                        getZone(orbit, orientation) {
-                            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
                         }
                         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
                         getOrientations(rowMajor) {
@@ -47822,6 +47892,10 @@ export var com;
                             }
                             else
                                 throw new Error('invalid overload');
+                        }
+                        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+                        getZone(orbit, orientation) {
+                            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
                         }
                         /**
                          *

--- a/online/src/worker/legacy/ts/com/vzome/core/exporters/POVRayExporter.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/exporters/POVRayExporter.ts
@@ -98,7 +98,7 @@ namespace com.vzome.core.exporters {
             for(let index=this.mModel.iterator();index.hasNext();) {
                 let rm = index.next();
                 {
-                    const shapeName: string = "S" + /* replaceAll */rm.getShapeId().toString().replace(new RegExp("-", 'g'),"");
+                    const shapeName: string = "S" + /* replaceAll */rm.getShapeKey().replace(new RegExp("[^A-Za-z0-9_]", 'g'),"_");
                     if (!shapes.contains(shapeName)){
                         shapes.add(shapeName);
                         this.exportShape(shapeName, rm.getShape());

--- a/online/src/worker/legacy/ts/com/vzome/core/math/Polyhedron.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/math/Polyhedron.ts
@@ -21,6 +21,8 @@ namespace com.vzome.core.math {
 
         /*private*/ guid: java.util.UUID;
 
+        /*private*/ shapeKey: string;
+
         public constructor(field: com.vzome.core.algebra.AlgebraicField) {
             this.numVertices = 0;
             this.m_vertices = <any>(new java.util.HashMap<any, any>());
@@ -31,6 +33,7 @@ namespace com.vzome.core.math {
             this.isEvil = false;
             this.__isPanel = false;
             this.guid = java.util.UUID.randomUUID();
+            this.shapeKey = this.guid.toString();
             if (this.name === undefined) { this.name = null; }
             if (this.orbit === undefined) { this.orbit = null; }
             if (this.length === undefined) { this.length = null; }
@@ -56,6 +59,7 @@ namespace com.vzome.core.math {
                 }
                 this.evilTwin.isEvil = true;
                 this.evilTwin.guid = java.util.UUID.randomUUID();
+                this.evilTwin.shapeKey = this.shapeKey + ":evil";
                 this.evilTwin.m_vertexList = <any>(new java.util.ArrayList<any>());
                 for(let index=this.m_vertexList.iterator();index.hasNext();) {
                     let vertex = index.next();
@@ -229,6 +233,71 @@ namespace com.vzome.core.math {
 
         public getGuid(): java.util.UUID {
             return this.guid;
+        }
+
+        /**
+         * The stable, content-derived shape key used as the shape identity when serializing a scene
+         * to a client, and (on the web) as the geometry cache/instancing key. See the shapeKey field
+         * comment for why this is distinct from getGuid(). Defaults to the guid string until a factory
+         * (AbstractShapes) or a future user-shape realization path sets a content-derived key.
+         * @return {string}
+         */
+        public getShapeKey(): string {
+            return this.shapeKey;
+        }
+
+        /**
+         * Set a readable, content-derived shape key. Used by AbstractShapes for catalog shapes, e.g.
+         * "<symmetry>:<orbit>:<length>" (strut) or "<symmetry>:<pkg>:ball" (connector). Must be a pure
+         * function of the shape's DEFINITION so that any worker realizing the same shape computes the
+         * same key; do NOT fold in design/session/instance identity.
+         * @param {string} shapeKey
+         */
+        public setShapeKey(shapeKey: string) {
+            this.shapeKey = shapeKey;
+        }
+
+        /**
+         * Content hash of this shape's geometry, for shapes with no short readable key (panels; and,
+         * in future, user-defined shapes assembled from a selected panel collection -- a per-design
+         * feature not yet implemented). Deterministic across workers because it depends only on the
+         * canonicalized vertex/face definition, matching the fields equals()/hashCode() already use.
+         * 
+         * NOTE: intentionally NOT wired in yet for the future user-shape path -- that path also needs
+         * a per-design shape registry (to give the shape a home and round-trip through the design XML),
+         * which is separate work. This method is provided so that, when that feature lands, its
+         * realization code has a ready, worker-agnostic way to derive the same key everywhere. Panels
+         * MAY adopt it now (see AbstractShapes.getPanelShape); struts/connectors deliberately do not,
+         * to keep their readable keys.
+         * @return {string}
+         */
+        public deriveGeometricKey(): string {
+            const buf: java.lang.StringBuilder = new java.lang.StringBuilder();
+            buf.append(this.isEvil ? "e:" : "s:");
+            for(let index=this.m_vertexList.iterator();index.hasNext();) {
+                let v = index.next();
+                buf.append(v.toString()).append(';')
+            }
+            buf.append('|');
+            const faceStrings: java.util.List<string> = <any>(new java.util.ArrayList<any>());
+            for(let index=this.m_faces.iterator();index.hasNext();) {
+                let face = index.next();
+                faceStrings.add(face.toString())
+            }
+            java.util.Collections.sort<any>(faceStrings);
+            for(let index=faceStrings.iterator();index.hasNext();) {
+                let f = index.next();
+                buf.append(f).append(';')
+            }
+            const FNV_OFFSET: number = -3750763034362895579;
+            const FNV_PRIME: number = 1099511628211;
+            const s: string = buf.toString();
+            let hash: number = FNV_OFFSET;
+            for(let i: number = 0; i < s.length; i++) {{
+                hash ^= (s.charAt(i)).charCodeAt(0);
+                hash *= FNV_PRIME;
+            };}
+            return "u" + javaemul.internal.LongHelper.toHexString(hash);
         }
 
         public getTriangleFaces(): java.util.List<Polyhedron.Face.Triangle> {

--- a/online/src/worker/legacy/ts/com/vzome/core/render/RenderedManifestation.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/render/RenderedManifestation.ts
@@ -111,6 +111,10 @@ namespace com.vzome.core.render {
             return this.mShape.getGuid();
         }
 
+        public getShapeKey(): string {
+            return this.mShape.getShapeKey();
+        }
+
         public getShape(): com.vzome.core.math.Polyhedron {
             return this.mShape;
         }

--- a/online/src/worker/legacy/ts/com/vzome/core/viewing/AbstractShapes.ts
+++ b/online/src/worker/legacy/ts/com/vzome/core/viewing/AbstractShapes.ts
@@ -107,6 +107,7 @@ namespace com.vzome.core.viewing {
             if (this.mConnectorGeometry == null){
                 this.mConnectorGeometry = this.buildConnectorShape(this.mPkgName);
                 this.mConnectorGeometry.setName("ball");
+                this.mConnectorGeometry.setShapeKey(this.mSymmetry.getName() + ":" + this.mPkgName + ":ball");
             }
             return this.mConnectorGeometry;
         }
@@ -134,6 +135,7 @@ namespace com.vzome.core.viewing {
                     lengthShape.setName(orbit.getName() + strutShapesByLength.size());
                     lengthShape.setOrbit(orbit);
                     lengthShape.setLength(orbit.getLengthInUnits(length));
+                    lengthShape.setShapeKey(this.mSymmetry.getName() + ":" + orbit.getName() + ":" + length.toString(com.vzome.core.algebra.AlgebraicField.DEFAULT_FORMAT));
                 }
             }
             return lengthShape;
@@ -211,6 +213,7 @@ namespace com.vzome.core.viewing {
             let shape: com.vzome.core.math.Polyhedron = map3.get(canonicalVertices);
             if (shape == null){
                 shape = this.makePanelPolyhedron(canonicalVertices, oneSidedPanels);
+                if (shape != null)shape.setShapeKey(shape.deriveGeometricKey());
                 map3.put(canonicalVertices, shape);
             }
             return shape;

--- a/online/src/worker/legacy/ts/core-java.ts
+++ b/online/src/worker/legacy/ts/core-java.ts
@@ -2703,6 +2703,10 @@ namespace com.vzome.core.render {
             return this.mShape.getGuid();
         }
 
+        public getShapeKey(): string {
+            return this.mShape.getShapeKey();
+        }
+
         public getShape(): com.vzome.core.math.Polyhedron {
             return this.mShape;
         }
@@ -3489,6 +3493,10 @@ namespace com.vzome.core.render {
 
         export class SymmetryOrbitSource implements com.vzome.core.editor.api.OrbitSource {
             /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+            getOrientations$(): number[][] {
+                return this.getOrientations(false);
+            }
+            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
             getEmbedding(): number[] {
                 const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
                 const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
@@ -3506,14 +3514,6 @@ namespace com.vzome.core.render {
                 embedding[14] = 0.0;
                 embedding[15] = 1.0;
                 return embedding;
-            }
-            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getOrientations$(): number[][] {
-                return this.getOrientations(false);
-            }
-            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
-                return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
             }
             /* Default method injected from com.vzome.core.editor.api.OrbitSource */
             public getOrientations(rowMajor?: any): number[][] {
@@ -3553,6 +3553,10 @@ namespace com.vzome.core.render {
                 } else if (rowMajor === undefined) {
                     return <any>this.getOrientations$();
                 } else throw new Error('invalid overload');
+            }
+            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+            getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
+                return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
             }
             symmetry: com.vzome.core.math.symmetry.Symmetry;
 
@@ -3997,6 +4001,7 @@ namespace com.vzome.core.viewing {
             if (this.mConnectorGeometry == null){
                 this.mConnectorGeometry = this.buildConnectorShape(this.mPkgName);
                 this.mConnectorGeometry.setName("ball");
+                this.mConnectorGeometry.setShapeKey(this.mSymmetry.getName() + ":" + this.mPkgName + ":ball");
             }
             return this.mConnectorGeometry;
         }
@@ -4024,6 +4029,7 @@ namespace com.vzome.core.viewing {
                     lengthShape.setName(orbit.getName() + strutShapesByLength.size());
                     lengthShape.setOrbit(orbit);
                     lengthShape.setLength(orbit.getLengthInUnits(length));
+                    lengthShape.setShapeKey(this.mSymmetry.getName() + ":" + orbit.getName() + ":" + length.toString(com.vzome.core.algebra.AlgebraicField.DEFAULT_FORMAT));
                 }
             }
             return lengthShape;
@@ -4101,6 +4107,7 @@ namespace com.vzome.core.viewing {
             let shape: com.vzome.core.math.Polyhedron = map3.get(canonicalVertices);
             if (shape == null){
                 shape = this.makePanelPolyhedron(canonicalVertices, oneSidedPanels);
+                if (shape != null)shape.setShapeKey(shape.deriveGeometricKey());
                 map3.put(canonicalVertices, shape);
             }
             return shape;
@@ -5578,6 +5585,8 @@ namespace com.vzome.core.math {
 
         /*private*/ guid: java.util.UUID;
 
+        /*private*/ shapeKey: string;
+
         public constructor(field: com.vzome.core.algebra.AlgebraicField) {
             this.numVertices = 0;
             this.m_vertices = <any>(new java.util.HashMap<any, any>());
@@ -5588,6 +5597,7 @@ namespace com.vzome.core.math {
             this.isEvil = false;
             this.__isPanel = false;
             this.guid = java.util.UUID.randomUUID();
+            this.shapeKey = this.guid.toString();
             if (this.name === undefined) { this.name = null; }
             if (this.orbit === undefined) { this.orbit = null; }
             if (this.length === undefined) { this.length = null; }
@@ -5613,6 +5623,7 @@ namespace com.vzome.core.math {
                 }
                 this.evilTwin.isEvil = true;
                 this.evilTwin.guid = java.util.UUID.randomUUID();
+                this.evilTwin.shapeKey = this.shapeKey + ":evil";
                 this.evilTwin.m_vertexList = <any>(new java.util.ArrayList<any>());
                 for(let index=this.m_vertexList.iterator();index.hasNext();) {
                     let vertex = index.next();
@@ -5786,6 +5797,71 @@ namespace com.vzome.core.math {
 
         public getGuid(): java.util.UUID {
             return this.guid;
+        }
+
+        /**
+         * The stable, content-derived shape key used as the shape identity when serializing a scene
+         * to a client, and (on the web) as the geometry cache/instancing key. See the shapeKey field
+         * comment for why this is distinct from getGuid(). Defaults to the guid string until a factory
+         * (AbstractShapes) or a future user-shape realization path sets a content-derived key.
+         * @return {string}
+         */
+        public getShapeKey(): string {
+            return this.shapeKey;
+        }
+
+        /**
+         * Set a readable, content-derived shape key. Used by AbstractShapes for catalog shapes, e.g.
+         * "<symmetry>:<orbit>:<length>" (strut) or "<symmetry>:<pkg>:ball" (connector). Must be a pure
+         * function of the shape's DEFINITION so that any worker realizing the same shape computes the
+         * same key; do NOT fold in design/session/instance identity.
+         * @param {string} shapeKey
+         */
+        public setShapeKey(shapeKey: string) {
+            this.shapeKey = shapeKey;
+        }
+
+        /**
+         * Content hash of this shape's geometry, for shapes with no short readable key (panels; and,
+         * in future, user-defined shapes assembled from a selected panel collection -- a per-design
+         * feature not yet implemented). Deterministic across workers because it depends only on the
+         * canonicalized vertex/face definition, matching the fields equals()/hashCode() already use.
+         * 
+         * NOTE: intentionally NOT wired in yet for the future user-shape path -- that path also needs
+         * a per-design shape registry (to give the shape a home and round-trip through the design XML),
+         * which is separate work. This method is provided so that, when that feature lands, its
+         * realization code has a ready, worker-agnostic way to derive the same key everywhere. Panels
+         * MAY adopt it now (see AbstractShapes.getPanelShape); struts/connectors deliberately do not,
+         * to keep their readable keys.
+         * @return {string}
+         */
+        public deriveGeometricKey(): string {
+            const buf: java.lang.StringBuilder = new java.lang.StringBuilder();
+            buf.append(this.isEvil ? "e:" : "s:");
+            for(let index=this.m_vertexList.iterator();index.hasNext();) {
+                let v = index.next();
+                buf.append(v.toString()).append(';')
+            }
+            buf.append('|');
+            const faceStrings: java.util.List<string> = <any>(new java.util.ArrayList<any>());
+            for(let index=this.m_faces.iterator();index.hasNext();) {
+                let face = index.next();
+                faceStrings.add(face.toString())
+            }
+            java.util.Collections.sort<any>(faceStrings);
+            for(let index=faceStrings.iterator();index.hasNext();) {
+                let f = index.next();
+                buf.append(f).append(';')
+            }
+            const FNV_OFFSET: number = -3750763034362895579;
+            const FNV_PRIME: number = 1099511628211;
+            const s: string = buf.toString();
+            let hash: number = FNV_OFFSET;
+            for(let i: number = 0; i < s.length; i++) {{
+                hash ^= (s.charAt(i)).charCodeAt(0);
+                hash *= FNV_PRIME;
+            };}
+            return "u" + javaemul.internal.LongHelper.toHexString(hash);
         }
 
         public getTriangleFaces(): java.util.List<Polyhedron.Face.Triangle> {
@@ -16427,6 +16503,10 @@ namespace com.vzome.core.editor {
 namespace com.vzome.core.editor {
     export class SymmetrySystem implements com.vzome.core.editor.api.OrbitSource {
         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+        getOrientations$(): number[][] {
+            return this.getOrientations(false);
+        }
+        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
         getEmbedding(): number[] {
             const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
             const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
@@ -16444,14 +16524,6 @@ namespace com.vzome.core.editor {
             embedding[14] = 0.0;
             embedding[15] = 1.0;
             return embedding;
-        }
-        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-        getOrientations$(): number[][] {
-            return this.getOrientations(false);
-        }
-        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-        getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
-            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
         }
         /* Default method injected from com.vzome.core.editor.api.OrbitSource */
         public getOrientations(rowMajor?: any): number[][] {
@@ -16502,6 +16574,10 @@ namespace com.vzome.core.editor {
             } else if (rowMajor === undefined) {
                 return <any>this.getOrientations$();
             } else throw new Error('invalid overload');
+        }
+        /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+        getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
+            return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
         }
         static LOGGER: java.util.logging.Logger; public static LOGGER_$LI$(): java.util.logging.Logger { if (SymmetrySystem.LOGGER == null) { SymmetrySystem.LOGGER = java.util.logging.Logger.getLogger("com.vzome.core.editor"); }  return SymmetrySystem.LOGGER; }
 
@@ -35640,7 +35716,7 @@ namespace com.vzome.core.exporters {
             for(let index=this.mModel.iterator();index.hasNext();) {
                 let rm = index.next();
                 {
-                    const shapeName: string = "S" + /* replaceAll */rm.getShapeId().toString().replace(new RegExp("-", 'g'),"");
+                    const shapeName: string = "S" + /* replaceAll */rm.getShapeKey().replace(new RegExp("[^A-Za-z0-9_]", 'g'),"_");
                     if (!shapes.contains(shapeName)){
                         shapes.add(shapeName);
                         this.exportShape(shapeName, rm.getShape());
@@ -45728,6 +45804,10 @@ namespace com.vzome.core.edits {
         export class ReplaceWithShape$0 implements com.vzome.core.editor.api.OrbitSource {
             public __parent: any;
             /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+            getOrientations$(): number[][] {
+                return this.getOrientations(false);
+            }
+            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
             getEmbedding(): number[] {
                 const symmetry: com.vzome.core.math.symmetry.Symmetry = this.getSymmetry();
                 const field: com.vzome.core.algebra.AlgebraicField = symmetry.getField();
@@ -45745,14 +45825,6 @@ namespace com.vzome.core.edits {
                 embedding[14] = 0.0;
                 embedding[15] = 1.0;
                 return embedding;
-            }
-            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getOrientations$(): number[][] {
-                return this.getOrientations(false);
-            }
-            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
-            getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
-                return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
             }
             /* Default method injected from com.vzome.core.editor.api.OrbitSource */
             public getOrientations(rowMajor?: any): number[][] {
@@ -45790,6 +45862,10 @@ namespace com.vzome.core.edits {
                 } else if (rowMajor === undefined) {
                     return <any>this.getOrientations$();
                 } else throw new Error('invalid overload');
+            }
+            /* Default method injected from com.vzome.core.editor.api.OrbitSource */
+            getZone(orbit: string, orientation: number): com.vzome.core.math.symmetry.Axis {
+                return this.getSymmetry().getDirection(orbit).getAxis(com.vzome.core.math.symmetry.Symmetry.PLUS, orientation);
             }
             /**
              * 


### PR DESCRIPTION
Give Polyhedron a content-derived shapeKey, separate from its per-object
guid, and use it as the shape identity for scene serialization and (on the
web) geometry caching/instancing.

Motivation: the per-object random guid only doubles as shape identity on
the desktop because same-symmetry designs share one cached Polyhedron
object by reference. On the web each design runs in its own worker with its
own object graph, so that reference-sharing is gone and the random guid
degrades to per-worker noise -- two workers realizing the identical shape
get different ids. shapeKey is a function of the shape's definition, so any
worker/design computes the same key for the same shape, enabling a
design-worker/shapes-worker split and cross-design dedup.

- Catalog shapes get READABLE keys (kept for debugging): struts
  "<symmetry>:<orbit>:<length>", connectors "<symmetry>:<pkg>:ball", set in
  the AbstractShapes factories.
- Panels use a geometry content hash (deriveGeometricKey); no short
  readable vocabulary exists for them.
- Evil twin derives "<parentKey>:evil", staying deterministic and distinct
  (isEvil is part of equals).
- Consumers switched from getGuid()/getShapeId() to the shape key:
  JsonMapper, unity.Renderer, POVRayExporter (with identifier sanitizing).
  RenderedManifestation gains getShapeKey(). Instance-level guid uses
  (RenderedModel.byID, JsonClientRendering) are unchanged.

deriveGeometricKey is also the ready hook for future user-defined shapes
(select panels -> define one design-scoped shape); that feature still needs
a per-design shape registry, which is separate from identity.

Ran JSweet to regenerate the web core.
Desktop and web tested, but not extensively.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
