### PR TITLE
Fix stale embedding on symmetry switch (heptagon antiprism/octahedral)

### DIFF
--- a/online/src/viewer/context/scene.jsx
+++ b/online/src/viewer/context/scene.jsx
@@ -214,7 +214,7 @@ const SceneChangeListener = () =>
   const { scene, updateShapes, addShape, setScene, highlightSelection } = useScene();
   const { subscribeFor } = useWorkerClient();
 
-  subscribeFor( 'SYMMETRY_CHANGED', ( { orientations, fieldName, symmetryName } ) => {
+  subscribeFor( 'SYMMETRY_CHANGED', ( { orientations, fieldName, symmetryName, embedding } ) => {
     // fieldName + symmetryName (present for vZome files; see EditorController.setSymmetryController)
     // give SymmetryGeometry a STABLE renderer-group key. Keying on the orientation float matrices
     // instead collides across algebraic fields -- the symmetry rotations are the same reals in
@@ -251,6 +251,12 @@ const SceneChangeListener = () =>
       if ( nextSymmetryId )
         setScene( 'symmetryId', nextSymmetryId );
       setScene( 'orientations', orientations );
+      // The embedding is symmetry-system-specific (e.g. heptagon antiprism is skewed, its
+      // octahedral system is trivial), so update it on a switch. Without this the embedding
+      // only refreshed on SCENE_RENDERED, leaving the new symmetry rendered with the old
+      // transform. Undefined on the viewer/preview path, which never fires SYMMETRY_CHANGED.
+      if ( embedding )
+        setScene( 'embedding', reconcile( embedding ) );
     } );
   });
 

--- a/online/src/viewer/symmetry-geometry.jsx
+++ b/online/src/viewer/symmetry-geometry.jsx
@@ -161,6 +161,12 @@ const SymmetryGeometryImpl = ( props ) =>
       m.transpose();
     }
     renderer.originGroup.matrix.copy( m );
+    // originGroup.matrixAutoUpdate is false, so three.js never recomputes .matrixWorld from
+    // .matrix on its own; without flagging it, a changed embedding updates .matrix but the group
+    // keeps rendering its stale .matrixWorld. This is invisible for most switches (the group-
+    // switch churn happens to flush a world update), but switching TO an identity embedding (e.g.
+    // heptagon octahedral, coming from the skewed antiprism) left the old skew on screen.
+    renderer.originGroup.matrixWorldNeedsUpdate = true;
   } );
 
   // Group-registration / symmetry-switch effect. Re-runs whenever props.symmetryId or

--- a/online/src/worker/legacy/controllers/editor.js
+++ b/online/src/worker/legacy/controllers/editor.js
@@ -183,6 +183,12 @@ export class EditorController extends com.vzome.desktop.controller.DefaultContro
       return [ ...Array( field .getOrder() - 1 ) .keys() ] .map( i => field .getUnitTerm( i+1 ) .evaluate() );
     })( symmetry .getField() );
     const resourcePath = symmetrySystem .getModelResourcePath();
+    // The embedding transform is symmetry-system-specific, not just field-specific: e.g. in the
+    // heptagon field the antiprism system has a skewed embedding while its octahedral system is
+    // trivial. It must travel with SYMMETRY_CHANGED so the client updates it on a switch; otherwise
+    // the client keeps the embedding from the last SCENE_RENDERED and renders the new symmetry with
+    // the wrong transform.
+    const embedding = symmetrySystem .getEmbedding();
     // fieldName + symmetryName let the client key its renderer group on a STABLE identity rather
     // than hashing the orientation float matrices. The float matrices are the symmetry's real
     // rotations, which are field-INDEPENDENT for a given symmetry type (e.g. octahedral rotations
@@ -191,7 +197,7 @@ export class EditorController extends com.vzome.desktop.controller.DefaultContro
     // shapes) for another field, corrupting non-golden orientations. field:symmetry is unique.
     const fieldName = symmetry .getField() .getName();
     const symmetryName = symmetrySystem .getName();
-    this.clientEvents .symmetryChanged( { orientations, permutations, scalars, planes, resourcePath, fieldName, symmetryName } );
+    this.clientEvents .symmetryChanged( { orientations, permutations, scalars, planes, resourcePath, fieldName, symmetryName, embedding } );
     
     // TODO: test this change with buildPlane
     this.getSubController( 'buildPlane' ) .setOrbitSource( symmetrySystem );

--- a/online/src/worker/legacy/controllers/index.js
+++ b/online/src/worker/legacy/controllers/index.js
@@ -120,6 +120,7 @@ const initializeDesign = ( loading, polygons, legacyDesign, core, clientEvents )
     ...clientEvents,
     symmetryChanged: details => {
       rendered.orientations = details.orientations; // this enables future rendering to be with the right orientations
+      rendered.embedding = details.embedding; // likewise, so later SCENE_RENDERED responses don't replay the pre-switch embedding
       clientEvents .symmetryChanged( details );
     }
   }


### PR DESCRIPTION
The embedding transform is symmetry-system-specific, not just field-specific:
in the heptagon field the antiprism system has a skewed embedding while its
octahedral system is trivial. Switching between them left the wrong transform
on screen. For every other field the embedding is trivial and identical across
symmetry systems, which is why this was never noticed before.

Three things were wrong:

1. SYMMETRY_CHANGED omitted the embedding, so the client never got the new
   symmetry's transform on a switch (editor.js send, scene.jsx apply).

2. prepareSceneResponse reads embedding from design.rendered.embedding, which
   was captured once at load. The symmetryChanged wrapper refreshed
   rendered.orientations on a switch but not rendered.embedding, so every
   later SCENE_RENDERED replayed the pre-switch embedding and clobbered the
   value from fix (1). This was the dominant cause of the persistent skew.

3. originGroup.matrixAutoUpdate is false, so setting originGroup.matrix does
   not recompute matrixWorld; without flagging matrixWorldNeedsUpdate the
   render loop kept drawing the stale world matrix (visible when switching TO
   an identity embedding, e.g. octahedral from the skewed antiprism).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
