### PR TITLE
Drop stale cross-symmetry SCENE_RENDERED to fix orientationIndex crash

### DIFF
--- a/online/src/viewer/context/scene.jsx
+++ b/online/src/viewer/context/scene.jsx
@@ -214,6 +214,10 @@ const SceneChangeListener = () =>
   const { scene, updateShapes, addShape, setScene, highlightSelection } = useScene();
   const { subscribeFor } = useWorkerClient();
 
+  // Reads the store's current symmetryId; kept as a helper because the SCENE_RENDERED handler
+  // shadows the store `scene` with its payload parameter of the same name.
+  const storeSceneSymmetryId = () => scene.symmetryId;
+
   subscribeFor( 'SYMMETRY_CHANGED', ( { orientations, fieldName, symmetryName, embedding } ) => {
     // fieldName + symmetryName (present for vZome files; see EditorController.setSymmetryController)
     // give SymmetryGeometry a STABLE renderer-group key. Keying on the orientation float matrices
@@ -261,6 +265,17 @@ const SceneChangeListener = () =>
   });
 
   subscribeFor( 'SCENE_RENDERED', ( { scene } ) => {
+    // Drop a render that was computed for a different symmetry than the one now active. During
+    // rapid symmetry switches (notably the classic trackball, which reloads its whole design on
+    // every switch), a SCENE_RENDERED for the previous symmetry can arrive AFTER the switch,
+    // carrying shapes whose per-instance orientation indices belong to the old (larger) orientation
+    // set -- out of range for the new symmetry group, which throws in the renderer
+    // (normalizeOrientationIndex). The worker stamps each render with its symmetryId
+    // (prepareSceneResponse); drop any whose id != the current one. Only guard when both ids are
+    // known: edit/legacy render paths omit symmetryId, and the store id is unset before the first
+    // SYMMETRY_CHANGED.
+    if ( scene.symmetryId && storeSceneSymmetryId() && scene.symmetryId !== storeSceneSymmetryId() )
+      return;
     setScene( 'embedding', reconcile( scene.embedding ) );
     setScene( 'polygons', scene.polygons );
     // Needed by SymmetryGeometry. SYMMETRY_CHANGED (above) is the usual source of

--- a/online/src/worker/vzome-worker-static.js
+++ b/online/src/worker/vzome-worker-static.js
@@ -33,8 +33,17 @@ const prepareSceneResponse = ( design, snapshot ) =>
     }
     shapes[ instance.shapeId ].instances.push( { ...instance, rotation } );
   }
-  const parts = createPartsList( shapes, design.wrapper?.controller?.symmController );
-  return { shapes, embedding, polygons, parts, orientations };
+  const symmController = design.wrapper?.controller?.symmController;
+  const parts = createPartsList( shapes, symmController );
+  // Stamp the render with the symmetry system it was built for. During rapid symmetry switches
+  // (e.g. the classic trackball reloading a design on each switch) a SCENE_RENDERED computed for
+  // the previous symmetry can arrive AFTER the switch, carrying shapes whose per-instance
+  // orientation indices belong to the old (larger) orientation set. The client drops any render
+  // whose symmetryId != the current one, so those stale shapes never reach the new symmetry group
+  // (where out-of-range indices throw in the renderer).
+  const orbitSource = symmController?.getOrbitSource?.();
+  const symmetryId = orbitSource ? `${orbitSource.getSymmetry().getField().getName()}:${orbitSource.getName()}` : undefined;
+  return { shapes, embedding, polygons, parts, orientations, symmetryId };
 }
 
 const prepareEditSceneResponse = ( design, edit, before ) =>


### PR DESCRIPTION
Reproducer: new golden design, switch to octahedral, start dragging a strut
the instant the origin ball changes shape -> "orientationIndex out of range
for group 'id:golden:octahedral'".

Root cause: two independent scene viewers (the main editor and the classic
trackball) run on separate workers, and the trackball reloads its whole
design on every symmetry switch. During the rapid icosahedral->octahedral
churn, a SCENE_RENDERED computed for the previous symmetry (icosahedral, 60
orientations) can arrive AFTER the switch to octahedral (24-orientation
group). Its shapes carry per-instance orientation indices up to 59, which are
out of range for the new group, so SymmetryGeometry's registration throws in
normalizeOrientationIndex. It surfaced on the trackball, not the editor.

Fix: the worker stamps each SCENE_RENDERED with the symmetryId (field:symmetry)
it was built for (prepareSceneResponse), and the client drops any render whose
id != the currently active symmetryId. Guarded so it only acts when both ids
are known -- edit/legacy render paths omit symmetryId, and the store id is
unset before the first SYMMETRY_CHANGED. Confirmed via logs: the stale
icosahedral render is dropped, the correct octahedral render applied, no throw.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
